### PR TITLE
fix(ocr): stop crediting reward cards to items that were not on screen

### DIFF
--- a/src-tauri/src/ocr.rs
+++ b/src-tauri/src/ocr.rs
@@ -717,7 +717,20 @@ fn word_found_in_set(
         if ocr_words.iter().any(|w| w.find(suffix).map_or(false, |p| p != 1)) { return true; }
     }
 
-    let max_dist = if catalog_word.len() >= 8 { 2 } else { 1 };
+    // Edit budget by word length. 4 chars is the shortest word this fuzzy-matches
+    // at all; below that the guard above has already returned. One edit in a 4-char
+    // word is a quarter of it, enough to land on a different real catalog word
+    // instead of a damaged read of this one: "limb" reaches "limbo", "gara" reaches
+    // "galatine", "khra" reaches "khora", "star" reaches "stars". Those short words
+    // are usually the only part of a reward name that identifies it, so a wrong hit
+    // scores a full catalog entry for an item that was never on screen.
+    let max_dist = if catalog_word.len() >= 8 {
+        2
+    } else if catalog_word.len() >= 5 {
+        1
+    } else {
+        0
+    };
     let wb = catalog_word.as_bytes();
     for ocr_w in ocr_words {
         // Full-word Levenshtein — reject pure prefix/suffix insertions (len_diff == dist && >= 2)
@@ -1884,6 +1897,37 @@ pub fn extract_reward_items_twophase(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn ocr_words(words: &[&str]) -> std::collections::HashSet<String> {
+        words.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// Both words in each pair are ones the catalog really contains, so a match
+    /// between them is always wrong: it credits a card to an item whose name was
+    /// never on screen.
+    #[test]
+    fn four_character_words_must_be_read_exactly() {
+        for (catalog_word, on_screen) in [
+            ("limb", "limbo"),
+            ("gara", "galatine"),
+            ("khra", "khora"),
+            ("star", "stars"),
+        ] {
+            assert!(
+                !word_found_in_set(catalog_word, &ocr_words(&[on_screen])),
+                "{catalog_word:?} must not match {on_screen:?}"
+            );
+        }
+    }
+
+    /// Only 4-char words are affected. Five and up keep their single edit, and a
+    /// truncated read still matches at any length through the prefix rule.
+    #[test]
+    fn longer_words_keep_their_edit_tolerance() {
+        assert!(word_found_in_set("blueprint", &ocr_words(&["bluepnnt"])));
+        assert!(word_found_in_set("tenora", &ocr_words(&["tenova"])));
+        assert!(word_found_in_set("limb", &ocr_words(&["lim"])));
+    }
 
     /// A bar set whose outermost pair spans the right distance can still be junk.
     /// Accepting one is worse than detecting no bars at all, because the fallback

--- a/src-tauri/src/ocr.rs
+++ b/src-tauri/src/ocr.rs
@@ -1184,6 +1184,20 @@ fn bar_centers_are_valid(centers: &[f32]) -> bool {
     for pair in centers.windows(2) {
         if pair[1] - pair[0] < 0.08 { return false; }
     }
+    // Cards sit on a fixed pitch, so the gaps between real bars are equal to within
+    // a pixel or two. The span check below only looks at the outermost pair, so a
+    // lopsided set gets through whenever its two ends happen to land the right
+    // distance apart. [0.204, 0.316, 0.655] spans 0.451 against the 0.46 expected
+    // of three cards, but its gaps differ threefold. The columns built from it put
+    // two cards' text into a single column and cross their component names.
+    if n >= 3 {
+        let gaps: Vec<f32> = centers.windows(2).map(|p| p[1] - p[0]).collect();
+        let mean = gaps.iter().sum::<f32>() / gaps.len() as f32;
+        // A third of the ~0.13 card pitch. Wide enough for the jitter of locating
+        // the small rarity arrows, and well under a card's width.
+        if gaps.iter().any(|g| (g - mean).abs() > 0.04) { return false; }
+    }
+
     let span = centers[n - 1] - centers[0];
     // Expected spans per card count (measured from real captures)
     let expected = match n {
@@ -1865,4 +1879,22 @@ pub fn extract_reward_items_twophase(
     _hint_squad_size: Option<usize>, _player_names: &[String],
 ) -> (bool, bool, Vec<String>, Vec<f32>, String) {
     (false, false, vec![], vec![], String::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A bar set whose outermost pair spans the right distance can still be junk.
+    /// Accepting one is worse than detecting no bars at all, because the fallback
+    /// layout at least puts each card's text in its own column.
+    #[test]
+    fn bar_centers_must_be_evenly_spaced() {
+        // Real detection from a three-card capture: spans 0.451 against the 0.46
+        // expected, but with gaps of 0.112 and 0.339.
+        assert!(!bar_centers_are_valid(&[0.204, 0.316, 0.655]));
+        // Evenly spaced sets still have to clear the span check.
+        assert!(bar_centers_are_valid(&[0.27, 0.50, 0.73]));
+        assert!(bar_centers_are_valid(&[0.24, 0.41, 0.59, 0.76]));
+    }
 }


### PR DESCRIPTION
Two independent fixes, one per commit, so either can be taken without the other.
Rationale for each is in its commit message.

`bar_centers_are_valid` checked a minimum gap and a total span, but never that the gaps are uniform.
A lopsided set passes both, and the columns derived from it put two cards' text into one column and cross their component names.

The edit budget in `word_found_set` allowed one edit on a four-character catalog word, which is loose enough to land on a different real catalog word rather than a damaged read of the intended one.
Over the 602 Void relic reward names in WFCD's `Relics.json`, this takes the four-character words that match some other catalog word from 10 down to 1.

Neither change loosens matching. Both only reject input the old code accepted, and both rejections route into fallbacks that already exist.

One caveat on the numbers: I ran the seven labelled reward screens that I captured through the pipeline with Tesseract rather than WinRT OCR, so treat those figures as indicative.
The 10 down to 1 is a pure function over the reward names and does not depend on the OCR engine.

Related to #11.
