### PR TITLE
fix(memory): seed the blob scan at the brace that encloses it

### DIFF
--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -576,23 +576,44 @@ const ALT_STARTS: &[&[u8]] = &[
 
 /// Where a stitched buffer's blob begins: `(marker_at, seed_at)`.
 ///
-/// `marker_at` is the first known inventory key in the buffer; `seed_at` is the
-/// brace enclosing it, which is where the scan is seeded. See
-/// `enclosing_object_start` for why the two are rarely the same offset.
+/// `marker_at` is the marker occurrence the seed is anchored to; `seed_at` is
+/// the brace enclosing it, or the marker itself when no occurrence has a
+/// brace that reads as an object head. See `enclosing_object_start` for why
+/// marker and brace are rarely the same offset.
 ///
-/// With no marker anywhere, `marker_at` becomes the buffer's last byte so the
-/// caller's slice stays in bounds, and the backward match still runs from
-/// there, so an unbalanced `{` earlier in the buffer would be seeded from.
-/// Either way the seed is junk and fails to parse, which is what the walk
-/// already does with a bad start.
+/// With no primary marker anywhere the fallbacks keep both offsets in bounds,
+/// down to the buffer's last byte when nothing matches at all. Such a seed is
+/// junk and fails to parse, which is what the walk already does with a bad
+/// start.
 fn blob_seed_offsets(combined: &[u8]) -> (usize, usize) {
-    let marker_at = combined
+    // The heap can hold a stale copy of the blob ahead of the live one: its
+    // marker survives but its opening brace was overwritten, so brace-matching
+    // backward from it lands on a stray `{` in binary garbage. A live seed is
+    // a JSON object head, so only accept a brace followed by a quote, and keep
+    // trying later marker occurrences until one qualifies.
+    let mut first_marker = None;
+    let mut search_from = 0;
+    while let Some(found) = combined[search_from..]
         .windows(START_MARKER.len())
         .position(|w| w == START_MARKER)
+    {
+        let marker_at = search_from + found;
+        first_marker.get_or_insert(marker_at);
+        if let Some(open) = enclosing_object_start(combined, marker_at) {
+            if combined.get(open + 1) == Some(&b'"') {
+                return (marker_at, open);
+            }
+        }
+        search_from = marker_at + 1;
+    }
+    // Without a plausible brace anywhere, seed at the first marker: the
+    // parser can rebuild the object head from a marker-anchored seed.
+    let marker_at = first_marker
         .or_else(|| ALT_STARTS.iter().find_map(|a|
             combined.windows(a.len()).position(|w| w == *a)))
         .unwrap_or(combined.len().saturating_sub(1));
-    (marker_at, enclosing_object_start(combined, marker_at).unwrap_or(marker_at))
+    (marker_at, first_marker.unwrap_or_else(||
+        enclosing_object_start(combined, marker_at).unwrap_or(marker_at)))
 }
 
 /// Parse a FULL_ACCOUNT blob from raw memory bytes into structured inventory data.
@@ -1595,5 +1616,36 @@ mod seed_tests {
         let data = b"no json here at all";
         let (marker_at, seed_at) = blob_seed_offsets(data);
         assert!(marker_at < data.len() && seed_at < data.len());
+    }
+
+    /// A freed copy of the blob can sit ahead of the live one with its marker
+    /// intact but its opening brace overwritten. Brace-matching backward from
+    /// that copy lands on a stray `{` in binary garbage ("key must be a string
+    /// at line 1 column 2"), so the stale occurrence has to be skipped in
+    /// favour of the live one.
+    #[test]
+    fn a_stale_headless_copy_is_skipped_for_the_live_blob() {
+        let mut combined = b"\x00{J>\x01\x02 garbage ".to_vec();
+        combined.extend_from_slice(br#""SubscribedToEmails":0,"RegularCredits":1,"#);
+        combined.extend_from_slice(b"\x03\x04 more garbage ");
+        let live_at = combined.len();
+        combined.extend_from_slice(br#"{"SubscribedToEmails":0,"RegularCredits":42}"#);
+
+        let (marker_at, seed_at) = blob_seed_offsets(&combined);
+        assert_eq!(seed_at, live_at, "seed is the live copy's opening brace");
+        assert!(marker_at > live_at, "the marker used is the live copy's");
+    }
+
+    /// With only the headless copy in the buffer, seeding at the marker lets
+    /// the parser rebuild the object head instead of parsing garbage.
+    #[test]
+    fn a_lone_headless_copy_seeds_at_its_marker() {
+        let mut combined = b"\x00{J>\x01\x02 garbage ".to_vec();
+        let marker = combined.len();
+        combined.extend_from_slice(br#""SubscribedToEmails":0,"RegularCredits":42,"#);
+
+        let (marker_at, seed_at) = blob_seed_offsets(&combined);
+        assert_eq!(marker_at, marker);
+        assert_eq!(seed_at, marker, "seed skips the garbage brace");
     }
 }

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -535,6 +535,66 @@ fn find_blob_end(raw: &[u8]) -> Option<usize> {
     Some(after + brace + 1)
 }
 
+/// Offset of the `{` that encloses `marker_at`, matching braces backward.
+///
+/// The blob's opening brace is not the first `{"` in the buffer. The walk
+/// stitches whole mappings together, so other allocations and their own JSON
+/// are in there too, and seeding at the earliest `{"` produces a document that
+/// fails to parse on its first value.
+///
+/// `None` means no enclosing brace is in the buffer, so the opening lives in a
+/// mapping the walk could not stitch.
+///
+/// A `{` or `}` inside a JSON string value would skew the count. The blob is
+/// item paths and numbers, so this has not been observed; a seed it did skew
+/// would fail to parse and be dropped like any other bad seed.
+fn enclosing_object_start(data: &[u8], marker_at: usize) -> Option<usize> {
+    let mut depth = 0usize;
+    // Clamped so any offset is safe to pass, not only the in-bounds one the
+    // scan's own marker search produces.
+    for offset in (0..marker_at.min(data.len())).rev() {
+        match data[offset] {
+            b'}' => depth += 1,
+            b'{' if depth == 0 => return Some(offset),
+            b'{' => depth -= 1,
+            _ => {}
+        }
+    }
+    None
+}
+
+/// First key of the FULL_ACCOUNT blob's own object, plus the fallbacks for the
+/// accounts and builds where it is absent or lands in a mapping the walk
+/// skipped. Both are unambiguous inventory fields, so combined with the
+/// mission-delta exclusion they are safe to seed from on their own.
+const START_MARKER: &[u8] = b"\"SubscribedToEmails\"";
+const ALT_STARTS: &[&[u8]] = &[
+    b"\"MiscItems\":[{\"ItemType\":\"/Lotus/",  // resources array with real items
+    b"\"Suits\":[{\"ItemType\":\"/Lotus/",       // warframes array with real items
+    b"\"RegularCredits\":",                       // present in every blob
+];
+
+/// Where a stitched buffer's blob begins: `(marker_at, seed_at)`.
+///
+/// `marker_at` is the first known inventory key in the buffer; `seed_at` is the
+/// brace enclosing it, which is where the scan is seeded. See
+/// `enclosing_object_start` for why the two are rarely the same offset.
+///
+/// With no marker anywhere, `marker_at` becomes the buffer's last byte so the
+/// caller's slice stays in bounds, and the backward match still runs from
+/// there, so an unbalanced `{` earlier in the buffer would be seeded from.
+/// Either way the seed is junk and fails to parse, which is what the walk
+/// already does with a bad start.
+fn blob_seed_offsets(combined: &[u8]) -> (usize, usize) {
+    let marker_at = combined
+        .windows(START_MARKER.len())
+        .position(|w| w == START_MARKER)
+        .or_else(|| ALT_STARTS.iter().find_map(|a|
+            combined.windows(a.len()).position(|w| w == *a)))
+        .unwrap_or(combined.len().saturating_sub(1));
+    (marker_at, enclosing_object_start(combined, marker_at).unwrap_or(marker_at))
+}
+
 /// Parse a FULL_ACCOUNT blob from raw memory bytes into structured inventory data.
 ///
 /// Compute the deterministic riven mod name from its buff stats.
@@ -620,7 +680,16 @@ pub fn parse_full_account_blob(raw: &[u8]) -> Option<BlobInventory> {
     };
 
     let json: serde_json::Value = serde_json::from_slice(&json_bytes)
-        .map_err(|e| eprintln!("[blob-parse] JSON error: {}", e))
+        .map_err(|e| {
+            // A column number alone cannot distinguish a seed that starts in the
+            // wrong place from a blob that was cut short, and those want opposite
+            // fixes, so show what the document actually begins with.
+            let head: String = json_bytes.iter().take(48)
+                .map(|&b| if (0x20..0x7f).contains(&b) { b as char } else { '.' })
+                .collect();
+            eprintln!("[blob-parse] JSON error: {} ({} B starting \"{}\")",
+                e, json_bytes.len(), head);
+        })
         .ok()?;
 
     // Scalars
@@ -916,7 +985,6 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
     const PAGE_EXECUTE_WC:   u32 = 0x80;
     const EXEC_MASK: u32 = PAGE_EXECUTE | PAGE_EXECUTE_READ | PAGE_EXECUTE_RW | PAGE_EXECUTE_WC;
 
-    const START_MARKER:  &[u8] = b"\"SubscribedToEmails\"";
     const MISSION_DELTA: &[u8] = b"\"InventoryChanges\":";
     const LOTUS_KEY:     &[u8] = b"/Lotus/";
     const ANCHORS: &[&[u8]] = &[
@@ -926,14 +994,6 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
         b"\"LongGuns\":[",
         b"\"Melee\":[",
         b"\"Pistols\":[",
-    ];
-    // Secondary start triggers: unambiguous inventory fields that are present in every
-    // account's FULL_ACCOUNT blob even when SubscribedToEmails is absent or in a
-    // skipped memory region. Combined with !is_mission these are safe to use alone.
-    const ALT_STARTS: &[&[u8]] = &[
-        b"\"MiscItems\":[{\"ItemType\":\"/Lotus/",  // resources array with real items
-        b"\"Suits\":[{\"ItemType\":\"/Lotus/",       // warframes array with real items
-        b"\"RegularCredits\":",                       // credit balance — in every blob
     ];
 
     // ── Fast path: try the cached region from last successful scan ─────────────
@@ -1179,17 +1239,7 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
             }
             combined.extend_from_slice(chunk);
 
-            // Find any known start marker within combined, then search backward for
-            // the first {"  — that is the outermost JSON object open.
-            let start_off = combined.windows(START_MARKER.len())
-                .position(|w| w == START_MARKER)
-                .or_else(|| ALT_STARTS.iter().find_map(|a|
-                    combined.windows(a.len()).position(|w| w == *a)))
-                .unwrap_or(combined.len().saturating_sub(1));
-            let json_open = combined[..start_off + 1]
-                .windows(2)
-                .position(|w| w == b"{\"")
-                .unwrap_or(start_off);
+            let (start_off, json_open) = blob_seed_offsets(&combined);
 
             // Absolute memory address of the seed start (for LAST_BLOB_REGION cache).
             let seed_addr = blob_start_addr + json_open;
@@ -1481,3 +1531,69 @@ fn find_warframe_pid() -> Option<u32> {
     }
 }
 
+
+// ─── Blob seed placement ─────────────────────────────────────────────────────
+//
+// The walk needs a live game process, but the buffer it hands to
+// `blob_seed_offsets` is just bytes, so the seed decision can be driven from a
+// synthetic stitch.
+#[cfg(test)]
+mod seed_tests {
+    use super::*;
+
+    /// A stitched buffer that reproduces the reported failure: a mapping ahead
+    /// of the blob carries a Lotus path, so it joins the prefix chain, and its
+    /// own `{"` is the earliest one in the buffer. Seeding there produced a
+    /// document that died on its first value ("expected value at line 1 column
+    /// 9") and lost the whole inventory.
+    #[test]
+    fn seed_lands_on_the_blob_not_on_earlier_json() {
+        let prefix = br#"{"Mods":garbage /Lotus/Weapons/Tenno/Rifle "#;
+        // Padded past the parser's 50 KB floor with whitespace, which is legal
+        // between JSON tokens and keeps the fixture readable.
+        let mut blob =
+            br#"{"SubscribedToEmails":true,"RegularCredits":42,"MiscItems":[{"ItemType":"/Lotus/Types/Items/x"}],"#
+                .to_vec();
+        blob.resize(60_000, b' ');
+        blob.extend_from_slice(br#""DeathSquadable":false}"#);
+
+        let mut combined = prefix.to_vec();
+        combined.extend_from_slice(&blob);
+
+        let (marker_at, seed_at) = blob_seed_offsets(&combined);
+        assert_eq!(seed_at, prefix.len(), "seed is the brace enclosing the marker");
+        assert!(marker_at > seed_at, "the marker sits inside the object that was seeded");
+
+        let inventory = parse_full_account_blob(&combined[seed_at..]);
+        assert_eq!(inventory.expect("blob parses from the seed").credits, 42);
+    }
+
+    #[test]
+    fn the_enclosing_brace_is_found_past_nested_objects() {
+        let data = br#"xx{"Suits":[{"a":{"b":1}},{"c":2}],"SubscribedToEmails""#;
+        let marker = data.windows(20)
+            .position(|w| w == b"\"SubscribedToEmails\"")
+            .expect("the marker is in the fixture");
+        assert_eq!(enclosing_object_start(data, marker), Some(2));
+    }
+
+    /// Every brace ahead of the marker closes again, so picking the first `{`
+    /// it passes would seed outside the blob.
+    #[test]
+    fn no_enclosing_brace_reports_none() {
+        let data = br#"{"a":{"b":1}} "SubscribedToEmails""#;
+        let marker = data.windows(20)
+            .position(|w| w == b"\"SubscribedToEmails\"")
+            .expect("the marker is in the fixture");
+        assert_eq!(enclosing_object_start(data, marker), None);
+    }
+
+    /// The caller slices with the offset, so it has to stay in bounds even when
+    /// there is nothing to seed from.
+    #[test]
+    fn a_buffer_without_any_marker_yields_an_in_bounds_seed() {
+        let data = b"no json here at all";
+        let (marker_at, seed_at) = blob_seed_offsets(data);
+        assert!(marker_at < data.len() && seed_at < data.len());
+    }
+}


### PR DESCRIPTION
`capture_all_blobs` seeded the FULL_ACCOUNT scan at the first `{"` in the stitched buffer.
That brace belongs to an unrelated allocation whenever a mapping ahead of the blob joins the prefix chain, so the scan parsed junk and dropped the whole inventory. `enclosing_object_start` now matches braces backward from a key known to be inside the blob instead.

Matching backward has _a failure mode of its own_ though:
The heap can hold a freed copy of the blob ahead of the live one with the marker intact but opening brace overwritten, and the backward match then walks into binary garbage and stops at a stray `{`.
A candidate brace only counts when
  - a quote follows it
  - it has the the shape of a real object head
  - and the search moves on to later marker occurrences until one qualifies
When none does, the seed falls back to the marker itself, so a lone headless copy still yields its inventory.
