### PR TITLE
fix: logout leaves the saved WFM credential behind

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1824,9 +1824,15 @@ fn wfm_delete_credentials() -> Result<(), String> {
 }
 
 /// Clear the stored WFM session.
+///
+/// A saved token outlives the in-memory session: the next launch restores it
+/// before the user sees anything, so a logout that only cleared memory would
+/// appear not to have happened. The delete sits here rather than at the call
+/// site so every route to a logout inherits it.
 #[tauri::command]
-fn wfm_logout(state: State<AppState>) {
+fn wfm_logout(state: State<AppState>) -> Result<(), String> {
     *state.wfm_session.lock().unwrap_or_else(|e| e.into_inner()) = None;
+    wfm_delete_credentials()
 }
 
 /// Return (username, status) for the current session, or None if not logged in.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1745,11 +1745,10 @@ async fn get_wfm_top_items(state: State<'_, AppState>) -> Result<Vec<WfmTopItem>
 }
 
 /// Save the WFM access token to Windows Credential Manager (encrypted by the OS).
-/// Stored under "FrameForge_WFM" — username field = "token", password = JWT value.
+/// Stored under "FrameForge_WFM" — username field = the email, blob = the token.
 #[tauri::command]
 #[cfg(target_os = "windows")]
-fn wfm_save_credentials(email: String, password: String) -> Result<(), String> {
-    let _ = email; // kept for API compatibility; we save the JWT passed as password
+fn wfm_save_credentials(email: String, token: String) -> Result<(), String> {
     use windows_sys::Win32::Security::Credentials::{
         CredWriteW, CREDENTIALW, CRED_TYPE_GENERIC, CRED_PERSIST_LOCAL_MACHINE,
     };
@@ -1758,7 +1757,7 @@ fn wfm_save_credentials(email: String, password: String) -> Result<(), String> {
 
     let target: Vec<u16> = OsStr::new("FrameForge_WFM").encode_wide().chain(Some(0)).collect();
     let user:   Vec<u16> = OsStr::new(&email).encode_wide().chain(Some(0)).collect();
-    let pass_bytes = password.as_bytes();
+    let token_bytes = token.as_bytes();
 
     let cred = CREDENTIALW {
         Flags: 0,
@@ -1766,8 +1765,8 @@ fn wfm_save_credentials(email: String, password: String) -> Result<(), String> {
         TargetName: target.as_ptr() as *mut _,
         Comment: std::ptr::null_mut(),
         LastWritten: unsafe { std::mem::zeroed() },
-        CredentialBlobSize: pass_bytes.len() as u32,
-        CredentialBlob: pass_bytes.as_ptr() as *mut _,
+        CredentialBlobSize: token_bytes.len() as u32,
+        CredentialBlob: token_bytes.as_ptr() as *mut _,
         Persist: CRED_PERSIST_LOCAL_MACHINE,
         AttributeCount: 0,
         Attributes: std::ptr::null_mut(),
@@ -1802,19 +1801,22 @@ fn wfm_load_credentials() -> Result<Option<(String, String)>, String> {
             String::from_utf16_lossy(slice::from_raw_parts(ptr, len))
         }
     };
-    let password = unsafe {
+    let token = unsafe {
         if cred.CredentialBlob.is_null() || cred.CredentialBlobSize == 0 { String::new() } else {
             String::from_utf8_lossy(slice::from_raw_parts(cred.CredentialBlob, cred.CredentialBlobSize as usize)).to_string()
         }
     };
     unsafe { CredFree(cred_ptr as *mut _); }
-    Ok(Some((email, password)))
+    Ok(Some((email, token)))
 }
 
 /// Delete saved WFM credentials from Windows Credential Manager.
+///
+/// Async only so that every platform's delete has one shape for `wfm_logout` to
+/// await; `CredDeleteW` itself returns immediately and never prompts.
 #[tauri::command]
 #[cfg(target_os = "windows")]
-fn wfm_delete_credentials() -> Result<(), String> {
+async fn wfm_delete_credentials() -> Result<(), String> {
     use windows_sys::Win32::Security::Credentials::{CredDeleteW, CRED_TYPE_GENERIC};
     use std::ffi::OsStr;
     use std::os::windows::ffi::OsStrExt;
@@ -1830,9 +1832,11 @@ fn wfm_delete_credentials() -> Result<(), String> {
 /// appear not to have happened. The delete sits here rather than at the call
 /// site so every route to a logout inherits it.
 #[tauri::command]
-fn wfm_logout(state: State<AppState>) -> Result<(), String> {
+async fn wfm_logout(state: State<'_, AppState>) -> Result<(), String> {
+    // Binding the guard to a name would hold a std mutex across the await below
+    // and make the future non-Send.
     *state.wfm_session.lock().unwrap_or_else(|e| e.into_inner()) = None;
-    wfm_delete_credentials()
+    wfm_delete_credentials().await
 }
 
 /// Return (username, status) for the current session, or None if not logged in.

--- a/src/WfmTrading.tsx
+++ b/src/WfmTrading.tsx
@@ -123,7 +123,7 @@ function LoginPanel({ onLogin }: { onLogin: (u: string) => void }) {
       const username = await invoke<string>("wfm_login", { email, password });
       if (remember) {
         const tokenJson = await invoke<string | null>("wfm_get_jwt").catch(() => null);
-        if (tokenJson) invoke("wfm_save_credentials", { email, password: tokenJson }).catch(() => {});
+        if (tokenJson) invoke("wfm_save_credentials", { email, token: tokenJson }).catch(() => {});
       }
       onLogin(username);
     } catch (e) { setError(String(e)); setLoading(false); }
@@ -905,9 +905,12 @@ export default function WfmTrading({ wfmLookup: _wfmLookup, wfmItems, imageMap, 
         if (creds) {
           try {
             [resolvedUser] = await invoke<[string, string]>("wfm_set_jwt", { jwt: creds[1] });
-            // Re-save with any newly-fetched CSRF token so it persists across restarts
+            // Re-save with any newly-fetched CSRF token so it persists across
+            // restarts, under the same email it was stored with. Failing here
+            // is not worth reporting: nobody asked for it, and the token
+            // already on disk still works.
             const tokenJson = await invoke<string | null>("wfm_get_jwt").catch(() => null);
-            if (tokenJson) await invoke("wfm_save_credentials", { email: "token", password: tokenJson }).catch(() => {});
+            if (tokenJson) await invoke("wfm_save_credentials", { email: creds[0], token: tokenJson }).catch(() => {});
           } catch { /* token expired — show login form */ }
         }
       }


### PR DESCRIPTION
**Logging out does not log you out.** `wfm_logout` clears the in-memory session
but leaves the token in the Credential Manager. The startup restore in
`App.tsx` reads it back on the next launch and logs the user straight in, so a
restart undoes the logout. The delete now
happens inside `wfm_logout` rather than beside the call, so any later logout
path inherits it, and the command returns `Result<(), String>` because a delete
that fails leaves a credential behind.

**The stored value is called a password.** `wfm_save_credentials` takes it as
`password` while every caller passes a JSON token bundle, and the email
alongside it is accepted only to be dropped:

```rust
let _ = email; // kept for API compatibility
```

The email is now stored in the credential's username field, which is what that
field is for, and the load hands it back. That gives the restore path in
`WfmTrading.tsx` the real email to re-save under, instead of the literal string
`"token"` it had been overwriting the username with on every launch.

`wfm_delete_credentials` also becomes async, so `wfm_logout` can await it.
`CredDeleteW` itself neither blocks nor prompts.

### Testing

I work on Linux and cannot build the Windows target, and this repository runs no
checks on pull requests, so nothing has compiled these changes yet. They are
confined to parameter names, two signatures, and one added call, but a Windows
build before merging would be worth it.
