### PR TITLE
ci: gate jobs on relevant path changes

### DIFF
--- a/.github/actions/linux-build-deps/action.yml
+++ b/.github/actions/linux-build-deps/action.yml
@@ -1,0 +1,27 @@
+---
+name: Linux build dependencies
+description: Install the system packages needed to build FrameForge on Linux.
+
+runs:
+  using: composite
+  steps:
+    # `libtesseract-dev`, `libleptonica-dev` and `libxcb1-dev` are the fork's own
+    # additions, for the OCR and X11 capture paths. `libappindicator3-dev` is
+    # absent on purpose, since nothing here uses a tray icon.
+    #
+    # These are headers, not the runtime dependencies the packages declare —
+    # derive those with `ldd` on the built binary.
+    - shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install --no-install-recommends -y \
+          libwebkit2gtk-4.1-dev \
+          librsvg2-dev \
+          patchelf \
+          libxdo-dev \
+          libssl-dev \
+          build-essential \
+          curl wget file \
+          libtesseract-dev \
+          libleptonica-dev \
+          libxcb1-dev

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+---
+# Everything here is monthly and grouped into one pull request per ecosystem.
+# The fork rebases onto upstream release tags, so every commit landing on `main`
+# is a commit to replay on the next sync. Lockfiles are the worst of those,
+# since they conflict more readily than anything else in the tree. Security
+# advisories are not affected by the interval; those open as they are published.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      gha-bump:
+        applies-to: version-updates
+        update-types:
+          - "patch"
+          - "minor"
+
+  # Dependabot has no `pnpm` ecosystem — `npm` covers all three lockfile
+  # formats, and reads `pnpm-lock.yaml` here.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+    groups:
+      npm:
+        patterns:
+          - "*"
+
+  # There is no manifest at the repository root; the crate lives in `src-tauri`.
+  - package-ecosystem: cargo
+    directory: /src-tauri
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+    groups:
+      cargo:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,14 +68,19 @@ jobs:
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # tag=v6.0.9
         with:
-          version: 10
+          version: 11
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # tag=v7.0.0
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
-      - run: pnpm install --frozen-lockfile
+      # esbuild is the only dependency that asks to run an install script, and
+      # its platform binary comes through optionalDependencies, so skipping
+      # loses nothing. Approving it instead would mean tracking
+      # pnpm-workspace.yaml: pnpm 11 reads build approvals from nowhere else,
+      # and that is one more file in the delta.
+      - run: pnpm install --frozen-lockfile --ignore-scripts
 
       - run: pnpm build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,9 @@ name: CI
 on:
   push:
     branches: [main]
+
   pull_request:
+
   workflow_dispatch:
 
 concurrency:
@@ -18,22 +20,24 @@ jobs:
   rust:
     name: Rust build and tests
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # tag=v7.0.1
 
       - uses: ./.github/actions/linux-build-deps
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install rust stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # branch=master
+        with:
+          toolchain: stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # tag=v2.9.1
         with:
           workspaces: src-tauri
 
       # The script pins the model by checksum, so hashing the script identifies
       # the model, and the 23 MB download happens once per model change.
       - name: Cache the Tesseract model
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # tag=v6.1.0
         with:
           path: src-tauri/tessdata
           key: tessdata-${{ hashFiles('scripts/fetch-tessdata.sh') }}
@@ -45,24 +49,28 @@ jobs:
       - name: Stand in for the frontend build
         run: mkdir -p dist
 
-      - name: Build
+      - name: cargo build --locked
         run: cargo build --manifest-path src-tauri/Cargo.toml --locked
 
-      - name: Test
+      - name: cargo test --locked
         run: cargo test --manifest-path src-tauri/Cargo.toml --locked
+
+      # https://github.com/rust-lang/cargo/issues/6669
+      - name: cargo test --doc
+        run: cargo test --doc --manifest-path src-tauri/Cargo.toml --locked
 
   frontend:
     name: Frontend typecheck and build
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # tag=v7.0.1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # tag=v6.0.9
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # tag=v7.0.0
         with:
           node-version: 22
           cache: pnpm
@@ -76,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # tag=v7.0.1
 
       - run: shellcheck scripts/*.sh
 
@@ -85,6 +93,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # tag=v7.0.1
 
       - run: bash scripts/check-version.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,90 @@
+# Clippy is left out on purpose. The inherited upstream code has never been
+# linted, and a wall of pre-existing warnings would train everyone to ignore the
+# badge. Add it once there is a clean baseline to hold it to.
+
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rust:
+    name: Rust build and tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/linux-build-deps
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      # The script pins the model by checksum, so hashing the script identifies
+      # the model, and the 23 MB download happens once per model change.
+      - name: Cache the Tesseract model
+        uses: actions/cache@v4
+        with:
+          path: src-tauri/tessdata
+          key: tessdata-${{ hashFiles('scripts/fetch-tessdata.sh') }}
+
+      # `frontendDist` is `../dist`, gitignored and so absent on a fresh
+      # checkout, and `generate_context!` panics on a path that does not exist.
+      # It tests existence and nothing more, so an empty directory compiles. The
+      # frontend job builds the real assets; nothing here serves them.
+      - name: Stand in for the frontend build
+        run: mkdir -p dist
+
+      - name: Build
+        run: cargo build --manifest-path src-tauri/Cargo.toml --locked
+
+      - name: Test
+        run: cargo test --manifest-path src-tauri/Cargo.toml --locked
+
+  frontend:
+    name: Frontend typecheck and build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build
+
+  scripts:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: shellcheck scripts/*.sh
+
+  version:
+    name: Version consistency
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: bash scripts/check-version.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,50 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+      scripts: ${{ steps.filter.outputs.scripts }}
+      version: ${{ steps.filter.outputs.version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # tag=v7.0.1
+        with:
+          fetch-depth: 0
+
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # tag=v4.0.2
+        id: filter
+        with:
+          filters: |
+            rust:
+              - 'src-tauri/**'
+              - '.github/workflows/ci.yml'
+              - '.github/actions/linux-build-deps/**'
+              - 'scripts/fetch-tessdata.sh'
+            frontend:
+              - 'src/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'tsconfig*.json'
+              - 'vite.config.*'
+              - 'index.html'
+              - '.github/workflows/ci.yml'
+            scripts:
+              - 'scripts/**'
+              - '.github/workflows/ci.yml'
+            version:
+              - 'package.json'
+              - 'src-tauri/Cargo.toml'
+              - 'src-tauri/tauri.conf.json'
+              - 'scripts/check-version.sh'
+              - '.github/workflows/ci.yml'
+
   rust:
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true'
     name: Rust build and tests
     runs-on: ubuntu-latest
     steps:
@@ -60,6 +103,8 @@ jobs:
         run: cargo test --doc --manifest-path src-tauri/Cargo.toml --locked
 
   frontend:
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.frontend == 'true'
     name: Frontend typecheck and build
     runs-on: ubuntu-latest
 
@@ -85,6 +130,8 @@ jobs:
       - run: pnpm build
 
   scripts:
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.scripts == 'true'
     name: Shellcheck
     runs-on: ubuntu-latest
 
@@ -94,6 +141,8 @@ jobs:
       - run: shellcheck scripts/*.sh
 
   version:
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.version == 'true'
     name: Version consistency
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,11 @@ jobs:
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # tag=v6.0.9
         with:
-          version: 10
+          version: 11
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # tag=v7.0.0
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - name: Install rust stable
@@ -50,7 +50,7 @@ jobs:
           key: tessdata-${{ hashFiles('scripts/fetch-tessdata.sh') }}
 
       - name: Install frontend dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       # NO_STRIP=true is needed only for the AppImage: linuxdeploy bundles an
       # old `strip` that cannot read the `.relr.dyn` sections modern

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release
+
+on:
+  push:
+    tags:
+      # `<upstream-version>+linux.<n>`, e.g. v2.7.0+linux.1. Semver build
+      # metadata, so it sorts equal to upstream's v2.7.0 rather than before it,
+      # which is what a `-linux.1` prerelease suffix would have done.
+      - 'v*+linux.*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # First, so a tree whose version disagrees with the tag costs a second
+      # rather than a ~10 minute build and an upload.
+      - name: Check the tag matches the configured version
+        run: bash scripts/check-version.sh "${GITHUB_REF#refs/tags/v}"
+
+      - uses: ./.github/actions/linux-build-deps
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Cache the Tesseract model
+        uses: actions/cache@v4
+        with:
+          path: src-tauri/tessdata
+          key: tessdata-${{ hashFiles('scripts/fetch-tessdata.sh') }}
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      # NO_STRIP=true is needed only for the AppImage: linuxdeploy bundles an
+      # old `strip` that cannot read the `.relr.dyn` sections modern
+      # distributions emit, and it aborts the bundle rather than skipping the
+      # library.
+      - name: Build bundles
+        run: NO_STRIP=true pnpm tauri build --bundles deb,rpm,appimage
+
+      # Release notes are written by hand rather than generated from commits.
+      # Every release has to state the upstream release it is based on, what was
+      # verified and on which distro, session type and compositor, and that
+      # Windows is unsupported here. None of that is derivable from the tree,
+      # which is also why the release is drafted rather than published.
+      - name: Draft the release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          name: ${{ github.ref_name }}
+          files: |
+            src-tauri/target/release/bundle/deb/*.deb
+            src-tauri/target/release/bundle/rpm/*.rpm
+            src-tauri/target/release/bundle/appimage/*.AppImage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,15 @@ jobs:
       - name: Build bundles
         run: NO_STRIP=true pnpm tauri build --bundles deb,rpm,appimage
 
+      # linuxdeploy leaves the AppImage's root .desktop and .DirIcon as
+      # symlinks that launcher-integration tools cannot read, so the repack
+      # materializes them.
+      - name: Materialize the AppImage root metadata
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends squashfs-tools
+          bash scripts/fix-appimage.sh src-tauri/target/release/bundle/appimage/*.AppImage
+
       # Release notes are written by hand rather than generated from commits.
       # Every release has to state the upstream release it is based on, what was
       # verified and on which distro, session type and compositor, and that

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       # `<upstream-version>+linux.<n>`, e.g. v2.7.0+linux.1. Semver build
       # metadata, so it sorts equal to upstream's v2.7.0 rather than before it,
       # which is what a `-linux.1` prerelease suffix would have done.
-      - 'v*+linux.*'
+      - 'v*\+linux.*'
 
 permissions:
   contents: write
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # tag=v7.0.1
 
       # First, so a tree whose version disagrees with the tag costs a second
       # rather than a ~10 minute build and an upload.
@@ -25,23 +25,26 @@ jobs:
 
       - uses: ./.github/actions/linux-build-deps
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # tag=v6.0.9
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # tag=v7.0.0
         with:
           node-version: 22
           cache: pnpm
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install rust stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # branch=master
+        with:
+          toolchain: stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # tag=v2.9.1
         with:
           workspaces: src-tauri
 
       - name: Cache the Tesseract model
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # tag=v6.1.0
         with:
           path: src-tauri/tessdata
           key: tessdata-${{ hashFiles('scripts/fetch-tessdata.sh') }}
@@ -71,7 +74,7 @@ jobs:
       # Windows is unsupported here. None of that is derivable from the tree,
       # which is also why the release is drafted rather than published.
       - name: Draft the release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # tag=v3.0.2
         with:
           draft: true
           name: ${{ github.ref_name }}

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ build-and-release.bat
 # Tauri build output
 src-tauri/target/
 
+# Tesseract model fetched by scripts/fetch-tessdata.sh at bundle time —
+# 23 MB of upstream binary, pinned by checksum rather than committed
+src-tauri/tessdata/
+
 # Editor directories and files
 .vscode/
 .idea

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 A desktop companion for Warframe — live inventory, market prices, trading, timers, relic overlay, and riven analysis. Read-only, no game modification.
 
-> **Windows 10/11 only.** Inventory scanning requires Warframe to be running; all other features work standalone.
+> **Windows 10/11 for the full feature set.** Inventory scanning requires Warframe to be running; all other features work standalone.
+>
+> **Linux** runs from source against Warframe under Steam Proton: inventory and credential scanning work on a best-effort basis through `/proc`, but the relic overlay (screen capture + OCR) and the saved warframe.market session are Windows-only.
 
 ---
 
@@ -96,7 +98,7 @@ Source code is fully public under GPLv3 — build and verify it yourself.
 
 ## Requirements
 
-- Windows 10 or 11 (64-bit)
+- Windows 10 or 11 (64-bit), or Linux running Warframe through Steam Proton (from source only — see below)
 - Warframe installed for inventory scanning (other features work without it)
 - [warframe.market](https://warframe.market) account for trading features (optional)
 
@@ -122,6 +124,26 @@ pnpm install
 pnpm tauri dev      # dev mode with hot reload
 pnpm tauri build    # installer → src-tauri/target/release/bundle/
 ```
+
+### Linux
+
+Linux is a source-only, development-grade target: there is no packaging step,
+and the frontend and backend are started separately.
+
+```sh
+pnpm install
+pnpm dev
+
+# In another terminal:
+cd src-tauri
+cargo run
+```
+
+Warframe must be running through Steam Proton — `EE.log` is read from the
+Proton prefix, and memory scanning reads `/proc/<pid>/mem`, which requires
+`kernel.yama.ptrace_scope` to permit same-user process access. OCR, the relic
+overlay, and persistent warframe.market sessions are unavailable; the affected
+controls are disabled in the UI.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A desktop companion for Warframe — live inventory, market prices, trading, tim
 
 > **Windows 10/11 for the full feature set.** Inventory scanning requires Warframe to be running; all other features work standalone.
 >
-> **Linux** runs from source against Warframe under Steam Proton: inventory and credential scanning work on a best-effort basis through `/proc`, but the relic overlay (screen capture + OCR) and the saved warframe.market session are Windows-only.
+> **Linux** runs against Warframe under Steam Proton: inventory, credential, and diagnostic memory scanning work on a best-effort basis through `/proc`, but the relic overlay (screen capture + OCR) and the saved warframe.market session are Windows-only.
 
 ---
 
@@ -98,7 +98,7 @@ Source code is fully public under GPLv3 — build and verify it yourself.
 
 ## Requirements
 
-- Windows 10 or 11 (64-bit), or Linux running Warframe through Steam Proton (from source only — see below)
+- Windows 10 or 11 (64-bit), or Linux running Warframe through Steam Proton (build it yourself — see below)
 - Warframe installed for inventory scanning (other features work without it)
 - [warframe.market](https://warframe.market) account for trading features (optional)
 
@@ -127,8 +127,8 @@ pnpm tauri build    # installer → src-tauri/target/release/bundle/
 
 ### Linux
 
-Linux is a source-only, development-grade target: there is no packaging step,
-and the frontend and backend are started separately.
+No Linux release is published, so build it yourself. For development the
+frontend and backend are started separately:
 
 ```sh
 pnpm install
@@ -138,6 +138,17 @@ pnpm dev
 cd src-tauri
 cargo run
 ```
+
+Packages build with the normal command:
+
+```sh
+NO_STRIP=true pnpm tauri build   # deb, rpm and AppImage in src-tauri/target/release/bundle/
+```
+
+`NO_STRIP=true` is only needed for the AppImage: linuxdeploy ships an old
+`strip` that cannot read the `.relr.dyn` sections modern distributions use, and
+it aborts the bundle rather than skipping the library. Building only `deb` and
+`rpm` (`--bundles deb,rpm`) does not need it.
 
 Warframe must be running through Steam Proton — `EE.log` is read from the
 Proton prefix, and memory scanning reads `/proc/<pid>/mem`, which requires

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FrameForge — Warframe Companion `v2.8.0+linux.1`
+# FrameForge — Warframe Companion `v2.8.0+linux.2`
 
 A desktop companion for Warframe — live inventory, market prices, trading, timers, relic overlay, and riven analysis. Read-only, no game modification.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ A desktop companion for Warframe — live inventory, market prices, trading, tim
 
 ---
 
+## About this fork
+
+This is the Linux fork of [WyrmStudios/FrameForge](https://github.com/WyrmStudios/FrameForge). The app, its name and its bundle identifier are unchanged from upstream, so the version string is what separates the two: `2.7.0+linux.1` is upstream's 2.7.0 plus this fork's Linux work, and `+linux.<n>` counts the Linux-only releases cut on that base.
+
+Releases here are Linux only: `.deb`, `.rpm` and `.AppImage`. **Windows users want [upstream's releases](https://github.com/WyrmStudios/FrameForge/releases)**, not this repository. The port reworks code the Windows paths also run — `7689b61` (log watcher), `f5ed489` (riven flag read) and `6ed6dc8` (inventory blob seed) — and none of it has been exercised on Windows, so building this fork for Windows is not the same as building upstream.
+
+The overlay stack, the `EE.log` discovery and several cross-platform fixes started from [xamionex/FrameForge-Linux](https://github.com/xamionex/FrameForge-Linux). That material was reworked here rather than taken as-is, so defects in it are ours and belong in this repository's issues, not theirs.
+
+This fork's git history is not a stability promise — it is rebased onto upstream releases, so commits move. The artifacts are the product.
+
+---
+
 ## Features
 
 ### Live Inventory
@@ -98,7 +110,7 @@ Source code is fully public under GPLv3 — build and verify it yourself.
 
 ## Requirements
 
-- Windows 10 or 11 (64-bit), or Linux running Warframe through Steam Proton (build it yourself — see below)
+- Windows 10 or 11 (64-bit) from upstream, or Linux with glibc 2.39 or newer running Warframe through Steam Proton
 - Warframe installed for inventory scanning (other features work without it)
 - [warframe.market](https://warframe.market) account for trading features (optional)
 
@@ -106,9 +118,9 @@ Source code is fully public under GPLv3 — build and verify it yourself.
 
 ## Installation
 
-1. Download the latest installer from [**Releases**](../../releases)
-2. Run it — click **More info → Run anyway** if SmartScreen warns you (no code-signing certificate)
-3. Launch FrameForge from Start or the desktop shortcut
+**Linux** — download the `.deb`, `.rpm` or `.AppImage` from [**Releases**](../../releases). Ubuntu 24.04, Debian 13 and Fedora 40 are all above the glibc floor; Debian 12 is below it and will install cleanly but fail to launch.
+
+**Windows** — download the installer from [upstream's Releases](https://github.com/WyrmStudios/FrameForge/releases), run it (click **More info → Run anyway** if SmartScreen warns you — there is no code-signing certificate), and launch FrameForge from Start or the desktop shortcut.
 
 ---
 
@@ -127,8 +139,8 @@ pnpm tauri build    # installer → src-tauri/target/release/bundle/
 
 ### Linux
 
-No Linux release is published, so build it yourself. For development the
-frontend and backend are started separately:
+Releases carry the three packages, so building is for development or for a
+branch no release covers. The frontend and backend are started separately:
 
 ```sh
 pnpm install

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A desktop companion for Warframe — live inventory, market prices, trading, tim
 
 This is the Linux fork of [WyrmStudios/FrameForge](https://github.com/WyrmStudios/FrameForge). It exists because the Linux port was declined upstream, not because of a disagreement: upstream is the project, this is its platform branch, and fixes that are not Linux-specific are still sent upstream as individual pull requests. The app, its name and its bundle identifier are unchanged from upstream, so the version string is what separates the two: `2.8.0+linux.1` is upstream's 2.8.0 plus this fork's Linux work, and `+linux.<n>` counts the Linux-only releases cut on that base.
 
-Releases here are Linux only: `.deb`, `.rpm` and `.AppImage`. **Windows users want [upstream's releases](https://github.com/WyrmStudios/FrameForge/releases)**, not this repository. The port reworks code the Windows paths also run — `7689b61` (log watcher), `f5ed489` (riven flag read) and `6ed6dc8` (inventory blob seed) — and none of it has been exercised on Windows, so building this fork for Windows is not the same as building upstream.
+Releases here are Linux only: `.deb`, `.rpm` and `.AppImage`. **Windows users want [upstream's releases](https://github.com/WyrmStudios/FrameForge/releases)**, not this repository.
 
 The overlay stack, the `EE.log` discovery and several cross-platform fixes started from [xamionex/FrameForge-Linux](https://github.com/xamionex/FrameForge-Linux). That material was reworked here rather than taken as-is, so defects in it are ours and belong in this repository's issues, not theirs.
 
@@ -150,8 +150,8 @@ branch no release covers.
 ```sh
 # Prerequisites: Node.js 20+, pnpm, a Rust toolchain, and the system
 # development headers listed in .github/actions/linux-build-deps/action.yml
-git clone https://github.com/Lyrex/FrameForge.git
-cd FrameForge
+git clone https://github.com/Lyrex/FrameForge-Linux.git
+cd FrameForge-Linux
 pnpm install
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A desktop companion for Warframe — live inventory, market prices, trading, tim
 
 > **Windows 10/11 for the full feature set.** Inventory scanning requires Warframe to be running; all other features work standalone.
 >
-> **Linux** runs against Warframe under Steam Proton: inventory, credential, and diagnostic memory scanning work on a best-effort basis through `/proc`, but the relic overlay (screen capture + OCR) and the saved warframe.market session are Windows-only.
+> **Linux** runs against Warframe under Steam Proton: memory scanning goes through `/proc`, and screen capture and OCR through X11 and Tesseract. Only the saved warframe.market session is Windows-only, since there is no OS credential store behind it.
 
 ---
 
@@ -152,9 +152,9 @@ it aborts the bundle rather than skipping the library. Building only `deb` and
 
 Warframe must be running through Steam Proton — `EE.log` is read from the
 Proton prefix, and memory scanning reads `/proc/<pid>/mem`, which requires
-`kernel.yama.ptrace_scope` to permit same-user process access. OCR, the relic
-overlay, and persistent warframe.market sessions are unavailable; the affected
-controls are disabled in the UI.
+`kernel.yama.ptrace_scope` to permit same-user process access. Persistent
+warframe.market sessions are unavailable, and the "remember me" control is
+hidden rather than offered.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ Source code is fully public under GPLv3 — build and verify it yourself.
 
 ## Building From Source
 
+### Windows
+
+Build Windows from upstream rather than from this fork — see [About this
+fork](#about-this-fork) for why.
+
 ```powershell
 # Prerequisites: Node.js 20+, pnpm, Rust MSVC toolchain
 rustup default stable-x86_64-pc-windows-msvc
@@ -140,10 +145,19 @@ pnpm tauri build    # installer → src-tauri/target/release/bundle/
 ### Linux
 
 Releases carry the three packages, so building is for development or for a
-branch no release covers. The frontend and backend are started separately:
+branch no release covers.
 
 ```sh
+# Prerequisites: Node.js 20+, pnpm, a Rust toolchain, and the system
+# development headers listed in .github/actions/linux-build-deps/action.yml
+git clone https://github.com/Lyrex/FrameForge.git
+cd FrameForge
 pnpm install
+```
+
+The frontend and backend are started separately:
+
+```sh
 pnpm dev
 
 # In another terminal:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FrameForge — Warframe Companion `v2.8.0`
+# FrameForge — Warframe Companion `v2.8.0+linux.1`
 
 A desktop companion for Warframe — live inventory, market prices, trading, timers, relic overlay, and riven analysis. Read-only, no game modification.
 
@@ -10,13 +10,13 @@ A desktop companion for Warframe — live inventory, market prices, trading, tim
 
 ## About this fork
 
-This is the Linux fork of [WyrmStudios/FrameForge](https://github.com/WyrmStudios/FrameForge). The app, its name and its bundle identifier are unchanged from upstream, so the version string is what separates the two: `2.7.0+linux.1` is upstream's 2.7.0 plus this fork's Linux work, and `+linux.<n>` counts the Linux-only releases cut on that base.
+This is the Linux fork of [WyrmStudios/FrameForge](https://github.com/WyrmStudios/FrameForge). It exists because the Linux port was declined upstream, not because of a disagreement: upstream is the project, this is its platform branch, and fixes that are not Linux-specific are still sent upstream as individual pull requests. The app, its name and its bundle identifier are unchanged from upstream, so the version string is what separates the two: `2.8.0+linux.1` is upstream's 2.8.0 plus this fork's Linux work, and `+linux.<n>` counts the Linux-only releases cut on that base.
 
 Releases here are Linux only: `.deb`, `.rpm` and `.AppImage`. **Windows users want [upstream's releases](https://github.com/WyrmStudios/FrameForge/releases)**, not this repository. The port reworks code the Windows paths also run — `7689b61` (log watcher), `f5ed489` (riven flag read) and `6ed6dc8` (inventory blob seed) — and none of it has been exercised on Windows, so building this fork for Windows is not the same as building upstream.
 
 The overlay stack, the `EE.log` discovery and several cross-platform fixes started from [xamionex/FrameForge-Linux](https://github.com/xamionex/FrameForge-Linux). That material was reworked here rather than taken as-is, so defects in it are ours and belong in this repository's issues, not theirs.
 
-This fork's git history is not a stability promise — it is rebased onto upstream releases, so commits move. The artifacts are the product.
+Upstream releases are merged in, tag by tag ([docs/UPSTREAM-SYNC.md](docs/UPSTREAM-SYNC.md)); `main` is not rewritten.
 
 ---
 
@@ -68,10 +68,10 @@ Live dashboard from DE's worldstate API:
 - **Item Report** — track any item's quantity over time with daily snapshots and drag-to-reorder cards
 
 ### Riven Analyzer
-Analyses riven rolls against the community-curated [44bananas spreadsheet](https://docs.google.com/spreadsheets/d/1zbaeJBuBn44cbVKzJins_E3hTDpnmvOk8heYN-G8yy8) (413+ weapons). Click **Check Riven** while the riven screen is open for instant per-stat quality ratings. Comparison mode shows old vs new roll side-by-side after each cycle. Supports primary, secondary, melee, and archwing weapons.
+Analyses riven rolls against the community-curated [44bananas spreadsheet](https://docs.google.com/spreadsheets/d/1zbaeJBuBn44cbVKzJins_E3hTDpnmvOk8heYN-G8yy8) (413+ weapons). Click **Check Riven** while the riven screen is open for instant per-stat quality ratings. Comparison mode shows old vs new roll side-by-side after each cycle. Supports primary, secondary, melee, and archwing weapons. On Linux, Alt-Tab out of the game before clicking the overlay's buttons — the game keeps the pointer grab until it loses focus.
 
 ### OCR Relic Reward Overlay
-When a void fissure reward screen opens, FrameForge automatically captures it via Windows OCR and shows a transparent overlay with platinum price, ducat value, and set completion for each card. Priority mode: Completion / Plat / Ducats / Set Value.
+When a void fissure reward screen opens, FrameForge automatically captures it — via WinRT OCR on Windows, Tesseract on Linux — and shows a transparent overlay with platinum price, ducat value, and set completion for each card. Priority mode: Completion / Plat / Ducats / Set Value.
 
 The item catalog used for OCR matching is built exclusively from known relic reward names — no false matches from non-reward items. Survival fissure multi-round sessions are fully supported: the selected relic carries over between rounds correctly.
 
@@ -102,7 +102,7 @@ Everything else (Foundry, Market, Relics, Timers, Statistics) runs on public dat
 | Memory access | Read-only `ReadProcessMemory` — never writes, never injects |
 | Game modification | None |
 | Network | warframe.market, DE worldstate, WFCD GitHub repos, FrameForgePricing mirror. No FrameForge server, no telemetry |
-| Credentials | WFM token in Windows Credential Manager. Warframe API credentials never written to disk |
+| Credentials | WFM token in Windows Credential Manager (on Linux the session is not saved). Warframe API credentials never written to disk |
 
 Source code is fully public under GPLv3 — build and verify it yourself.
 
@@ -200,7 +200,7 @@ hidden rather than offered.
 
 - No account required for most features
 - No telemetry — no FrameForge server
-- All data stored locally at `%LOCALAPPDATA%\warframe-companion\`
+- All data stored locally at `%LOCALAPPDATA%\warframe-companion\` (Windows) or `~/.local/share/warframe-companion/` (Linux)
 - WFM session token stored in Windows Credential Manager if "Stay logged in" is enabled
 
 ---

--- a/docs/UPSTREAM-SYNC.md
+++ b/docs/UPSTREAM-SYNC.md
@@ -1,0 +1,128 @@
+# Syncing with upstream
+
+This fork tracks [WyrmStudios/FrameForge](https://github.com/WyrmStudios/FrameForge)
+and pulls its releases in for as long as the fork lives. This document is the
+procedure for one sync, and the ledger of our changes that upstream has since
+absorbed.
+
+## Rules
+
+- **Merge, never rebase.** `main` is published history; it is never rewritten.
+  Upstream arrives as a merge commit.
+- **Merge upstream release tags only, never `upstream/main`.** Upstream tags
+  whatever their tip happens to be, so the tip routinely runs ahead of the
+  newest tag. Our version string (`<upstream-version>+linux.<n>`) claims an
+  exact upstream base; merging an untagged tip would make it a lie.
+- **Sync when we intend to cut a fork release**, not on every upstream
+  release. The fork's value can only be verified in a manual session against
+  the live game, and that session happens at release time; a synced-but-
+  unverified `main` is a branch nobody has run. Sync early only when upstream
+  ships something we specifically want, or when one of our fixes lands
+  upstream.
+- **Version scheme:** `<upstream-version>+linux.<n>`. `n` counts fork releases
+  on the same upstream base and resets to 1 on each sync. Build metadata, not
+  a prerelease: `2.8.0-linux.1` would sort *before* upstream's `2.8.0`, which
+  is backwards.
+
+## Procedure
+
+```sh
+# one-time, per clone
+git config rerere.enabled true
+
+# 0. preconditions
+git status --porcelain              # must be empty
+
+# 1. fetch upstream, pick the newest RELEASE TAG (never main)
+git fetch upstream --tags
+git tag --sort=-v:refname --merged upstream/main | head -1
+# -> TAG, e.g. v2.8.0. --merged excludes our own v*+linux.* tags,
+#    which are not ancestors of upstream/main.
+
+# 2. read the delta before touching anything
+git log --no-merges --reverse \
+  --format='%h %s%n    %(trailers:key=Fork-delta,valueonly)' \
+  upstream/main..main
+# Cross-check against the ledger below: commits listed there have been
+# absorbed upstream, and their conflicts resolve toward upstream's side.
+
+# 3. merge the tag
+git merge TAG
+```
+
+Resolve conflicts by this playbook:
+
+- **Version files** (`package.json`, `src-tauri/Cargo.toml`,
+  `src-tauri/tauri.conf.json`): guaranteed to conflict — upstream bumps the
+  same three lines every release. Never take either side. Recompute:
+  `<TAG version>+linux.1`.
+- **`Cargo.lock`:** regenerate, never hand-merge. `git checkout TAG --
+  src-tauri/Cargo.lock`, then `cargo check` (which re-adds our dependencies
+  and stamps the fork version), then stage it. Note upstream has shipped this
+  file stale before (v2.8.0's lock still said 2.7.0), so do not trust their
+  side either.
+- **Our own code coming back at us:** a conflict where upstream's side
+  contains a fix we wrote means it was absorbed into their release squash.
+  Take upstream's side, then record the commit in the ledger below — in the
+  same commit as the merge.
+- **Everything else:** preserve both intents; upstream's platform-neutral
+  code plus our `cfg`-gated Linux code is the normal resolution shape.
+
+```sh
+# 4. after the merge commit: checks that must pass before anything publishes
+cargo test --locked --manifest-path src-tauri/Cargo.toml
+pnpm build
+shellcheck scripts/*.sh
+bash scripts/check-version.sh
+```
+
+Two known silent hazards to check by hand — neither reliably *conflicts*:
+
+- The Linux test module in `src-tauri/src/memory_scanner.rs`. Upstream has no
+  Linux code, so a merge can drop or duplicate tests there without a
+  conflict. Diff the module against pre-merge `main`.
+- Upstream additions that call Windows APIs ungated (v2.8.0's
+  `get_system_locale` called `windows_sys` from shared code). The Linux build
+  catches these; the fix is a `cfg`-gated variant, kept as its own commit
+  with a `Fork-delta: port` trailer.
+
+```sh
+# 5. verify live, then release
+# Manual session against Warframe under Proton: inventory scan populates,
+# relic overlay over a fullscreen game (click-through, disappears on
+# dismiss), riven overlay buttons clickable. Nothing below runs until this
+# passes.
+git push origin main
+git tag v<TAG-version>+linux.1
+git push origin v<TAG-version>+linux.1     # triggers the release workflow
+```
+
+## Delta classification
+
+Every fork commit carries a `Fork-delta:` trailer, written when the commit is
+made:
+
+- `port` — Linux implementation of something Windows already does. Never goes
+  upstream.
+- `upstreamable` — platform-agnostic fix that should become an upstream PR.
+  This is the extraction queue.
+- `fork-only` — packaging, CI, README, identity.
+
+The current delta is the inventory command in step 2, minus the ledger below.
+Under merge, history never shrinks: absorbed commits stay in `git log`
+forever, so the ledger is the only record that they no longer count.
+
+## Ledger: absorbed by upstream
+
+Append-only. One line per fork change upstream has absorbed, added in the
+same commit as the sync merge that confirmed it. Upstream applies PRs by hand
+inside release squashes and closes them unmerged, so PR state is not evidence
+— confirm by diffing the PR branch's additions against the release tree.
+
+| Upstream release | Fork change | Upstream PR |
+|---|---|---|
+| v2.8.0 | UTF-8-safe truncation of log previews (`truncate_chars`) | #22 |
+| v2.8.0 | OCR reward matching: exact 4-char words, evenly spaced rarity bars | #23 |
+| v2.8.0 | Blob scan seeded at the enclosing brace | #25 |
+| v2.8.0 | Market list shows known price instead of loading spinner | #26 |
+| v2.8.0 | Riven OCR reads the whole card without its border | #27 |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "warframe-companion",
   "private": true,
-  "version": "2.8.0",
+  "version": "2.8.0+linux.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "warframe-companion",
   "private": true,
-  "version": "2.8.0+linux.1",
+  "version": "2.8.0+linux.2",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -10,18 +10,18 @@
     "tauri": "tauri"
   },
   "dependencies": {
-    "@tauri-apps/api": "^2",
-    "@tauri-apps/plugin-opener": "^2",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "@tauri-apps/api": "^2.11.1",
+    "@tauri-apps/plugin-opener": "^2.5.4",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8"
   },
   "devDependencies": {
-    "@tauri-apps/cli": "^2",
-    "@types/react": "^19.1.8",
-    "@types/react-dom": "^19.1.6",
-    "@vitejs/plugin-react": "^4.6.0",
-    "terser": "^5.48.0",
+    "@tauri-apps/cli": "^2.11.4",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^4.7.0",
+    "terser": "^5.49.0",
     "typescript": "~5.8.3",
-    "vite": "^7.0.4"
+    "vite": "^7.3.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,277 +9,277 @@ importers:
   .:
     dependencies:
       '@tauri-apps/api':
-        specifier: ^2
-        version: 2.10.1
+        specifier: ^2.11.1
+        version: 2.11.1
       '@tauri-apps/plugin-opener':
-        specifier: ^2
-        version: 2.5.3
+        specifier: ^2.5.4
+        version: 2.5.4
       react:
-        specifier: ^19.1.0
-        version: 19.2.5
+        specifier: ^19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: ^19.1.0
-        version: 19.2.5(react@19.2.5)
+        specifier: ^19.2.8
+        version: 19.2.8(react@19.2.8)
     devDependencies:
       '@tauri-apps/cli':
-        specifier: ^2
-        version: 2.10.1
+        specifier: ^2.11.4
+        version: 2.11.4
       '@types/react':
-        specifier: ^19.1.8
-        version: 19.2.14
+        specifier: ^19.2.17
+        version: 19.2.17
       '@types/react-dom':
-        specifier: ^19.1.6
-        version: 19.2.3(@types/react@19.2.14)
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
-        specifier: ^4.6.0
-        version: 4.7.0(vite@7.3.2(terser@5.48.0))
+        specifier: ^4.7.0
+        version: 4.7.0(vite@7.3.6(terser@5.49.0))
       terser:
-        specifier: ^5.48.0
-        version: 5.48.0
+        specifier: ^5.49.0
+        version: 5.49.0
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
       vite:
-        specifier: ^7.0.4
-        version: 7.3.2(terser@5.48.0)
+        specifier: ^7.3.6
+        version: 7.3.6(terser@5.49.0)
 
 packages:
 
-  '@babel/code-frame@7.29.0':
-    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.29.0':
-    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.29.0':
-    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.29.1':
-    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-compilation-targets@7.28.6':
-    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-globals@7.28.0':
-    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-imports@7.28.6':
-    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-transforms@7.28.6':
-    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-plugin-utils@7.28.6':
-    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-option@7.27.1':
-    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.29.2':
-    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.29.2':
-    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1':
-    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1':
-    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/template@7.28.6':
-    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.29.0':
-    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -306,225 +306,225 @@ packages:
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
-  '@rollup/rollup-android-arm-eabi@4.60.2':
-    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+  '@rollup/rollup-android-arm-eabi@4.62.3':
+    resolution: {integrity: sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.60.2':
-    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+  '@rollup/rollup-android-arm64@4.62.3':
+    resolution: {integrity: sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.60.2':
-    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+  '@rollup/rollup-darwin-arm64@4.62.3':
+    resolution: {integrity: sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.60.2':
-    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+  '@rollup/rollup-darwin-x64@4.62.3':
+    resolution: {integrity: sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.60.2':
-    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+  '@rollup/rollup-freebsd-arm64@4.62.3':
+    resolution: {integrity: sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.60.2':
-    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+  '@rollup/rollup-freebsd-x64@4.62.3':
+    resolution: {integrity: sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
-    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.3':
+    resolution: {integrity: sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
-    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+  '@rollup/rollup-linux-arm-musleabihf@4.62.3':
+    resolution: {integrity: sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.2':
-    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+  '@rollup/rollup-linux-arm64-gnu@4.62.3':
+    resolution: {integrity: sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm64-musl@4.60.2':
-    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+  '@rollup/rollup-linux-arm64-musl@4.62.3':
+    resolution: {integrity: sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.2':
-    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+  '@rollup/rollup-linux-loong64-gnu@4.62.3':
+    resolution: {integrity: sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-loong64-musl@4.60.2':
-    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+  '@rollup/rollup-linux-loong64-musl@4.62.3':
+    resolution: {integrity: sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==}
     cpu: [loong64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
-    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+  '@rollup/rollup-linux-ppc64-gnu@4.62.3':
+    resolution: {integrity: sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-ppc64-musl@4.60.2':
-    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+  '@rollup/rollup-linux-ppc64-musl@4.62.3':
+    resolution: {integrity: sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==}
     cpu: [ppc64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
-    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+  '@rollup/rollup-linux-riscv64-gnu@4.62.3':
+    resolution: {integrity: sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-riscv64-musl@4.60.2':
-    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+  '@rollup/rollup-linux-riscv64-musl@4.62.3':
+    resolution: {integrity: sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.2':
-    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+  '@rollup/rollup-linux-s390x-gnu@4.62.3':
+    resolution: {integrity: sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.60.2':
-    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+  '@rollup/rollup-linux-x64-gnu@4.62.3':
+    resolution: {integrity: sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.60.2':
-    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+  '@rollup/rollup-linux-x64-musl@4.62.3':
+    resolution: {integrity: sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-openbsd-x64@4.60.2':
-    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+  '@rollup/rollup-openbsd-x64@4.62.3':
+    resolution: {integrity: sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==}
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openharmony-arm64@4.60.2':
-    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+  '@rollup/rollup-openharmony-arm64@4.62.3':
+    resolution: {integrity: sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.2':
-    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+  '@rollup/rollup-win32-arm64-msvc@4.62.3':
+    resolution: {integrity: sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.2':
-    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+  '@rollup/rollup-win32-ia32-msvc@4.62.3':
+    resolution: {integrity: sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.60.2':
-    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+  '@rollup/rollup-win32-x64-gnu@4.62.3':
+    resolution: {integrity: sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ==}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.60.2':
-    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+  '@rollup/rollup-win32-x64-msvc@4.62.3':
+    resolution: {integrity: sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g==}
     cpu: [x64]
     os: [win32]
 
-  '@tauri-apps/api@2.10.1':
-    resolution: {integrity: sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==}
+  '@tauri-apps/api@2.11.1':
+    resolution: {integrity: sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==}
 
-  '@tauri-apps/cli-darwin-arm64@2.10.1':
-    resolution: {integrity: sha512-Z2OjCXiZ+fbYZy7PmP3WRnOpM9+Fy+oonKDEmUE6MwN4IGaYqgceTjwHucc/kEEYZos5GICve35f7ZiizgqEnQ==}
+  '@tauri-apps/cli-darwin-arm64@2.11.4':
+    resolution: {integrity: sha512-1ryOF3ZhpZ/nemHV5zVwBQBz9jDGKmKPvWPADOhc83ig0P4bMc2iER4NbC6r9sjeIZ6RVQ4g3RZIYvezhcl4TQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@tauri-apps/cli-darwin-x64@2.10.1':
-    resolution: {integrity: sha512-V/irQVvjPMGOTQqNj55PnQPVuH4VJP8vZCN7ajnj+ZS8Kom1tEM2hR3qbbIRoS3dBKs5mbG8yg1WC+97dq17Pw==}
+  '@tauri-apps/cli-darwin-x64@2.11.4':
+    resolution: {integrity: sha512-uFsGQAAfuyz1k/yGLmkWfkBlgKAqZfxqlHmLWx81QU27RJWfmbNHCIq8T8w1e+VClleIuZUjpHWfoE4E3DLo3A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@tauri-apps/cli-linux-arm-gnueabihf@2.10.1':
-    resolution: {integrity: sha512-Hyzwsb4VnCWKGfTw+wSt15Z2pLw2f0JdFBfq2vHBOBhvg7oi6uhKiF87hmbXOBXUZaGkyRDkCHsdzJcIfoJC2w==}
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.11.4':
+    resolution: {integrity: sha512-IaHZn5CdBL21oUmjiVOS1ctw6Ip1O0pjp70FwOWmYz1myWe0SY96ZIj2FYf7pT0m8bI2h/hrs5ZbEXXh44/MkQ==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
 
-  '@tauri-apps/cli-linux-arm64-gnu@2.10.1':
-    resolution: {integrity: sha512-OyOYs2t5GkBIvyWjA1+h4CZxTcdz1OZPCWAPz5DYEfB0cnWHERTnQ/SLayQzncrT0kwRoSfSz9KxenkyJoTelA==}
+  '@tauri-apps/cli-linux-arm64-gnu@2.11.4':
+    resolution: {integrity: sha512-N41/ukTRVe6XSuUTESuFdGeOW2i7k62tK+6gHK5Kd5/q5RPvvi19GaWAVPPb9u95HSGmTChSolBfzynUsssFaA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@tauri-apps/cli-linux-arm64-musl@2.10.1':
-    resolution: {integrity: sha512-MIj78PDDGjkg3NqGptDOGgfXks7SYJwhiMh8SBoZS+vfdz7yP5jN18bNaLnDhsVIPARcAhE1TlsZe/8Yxo2zqg==}
+  '@tauri-apps/cli-linux-arm64-musl@2.11.4':
+    resolution: {integrity: sha512-v277UnT/fB64xAfSroL5N3Km3tLmvATWqJJw/wRI+g6o+HkeD0slyE7gOhNs1MbjE41R7bQOTxMVoL3aomUJmw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@tauri-apps/cli-linux-riscv64-gnu@2.10.1':
-    resolution: {integrity: sha512-X0lvOVUg8PCVaoEtEAnpxmnkwlE1gcMDTqfhbefICKDnOTJ5Est3qL0SrWxizDackIOKBcvtpejrSiVpuJI1kw==}
+  '@tauri-apps/cli-linux-riscv64-gnu@2.11.4':
+    resolution: {integrity: sha512-qqgNkQ2u1yZHxjhxsZaxUtRDW8dIqIYm33rx/mzwQv0SfY9x1B+iraj8vWeFiXjjSVVhEMepXSOts1TqPzvXNQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@tauri-apps/cli-linux-x64-gnu@2.10.1':
-    resolution: {integrity: sha512-2/12bEzsJS9fAKybxgicCDFxYD1WEI9kO+tlDwX5znWG2GwMBaiWcmhGlZ8fi+DMe9CXlcVarMTYc0L3REIRxw==}
+  '@tauri-apps/cli-linux-x64-gnu@2.11.4':
+    resolution: {integrity: sha512-2VRNWl84FOH0m2giiDkO2h0QXlcMJeX+zJDpI5kDIQAx6s+geF3v48F4DXfJez4GS/FdoDGnPnw1C2iYGbQ7bQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@tauri-apps/cli-linux-x64-musl@2.10.1':
-    resolution: {integrity: sha512-Y8J0ZzswPz50UcGOFuXGEMrxbjwKSPgXftx5qnkuMs2rmwQB5ssvLb6tn54wDSYxe7S6vlLob9vt0VKuNOaCIQ==}
+  '@tauri-apps/cli-linux-x64-musl@2.11.4':
+    resolution: {integrity: sha512-o9GyhYor/nc7xarmwDE3ka2szuW3uuZzXjHWh64Q8YX5AtSgxdQkFWzrY4O8KiGtVNvFBI14H3Q49Qj5TOIP/A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@tauri-apps/cli-win32-arm64-msvc@2.10.1':
-    resolution: {integrity: sha512-iSt5B86jHYAPJa/IlYw++SXtFPGnWtFJriHn7X0NFBVunF6zu9+/zOn8OgqIWSl8RgzhLGXQEEtGBdR4wzpVgg==}
+  '@tauri-apps/cli-win32-arm64-msvc@2.11.4':
+    resolution: {integrity: sha512-ld5Ehb598m0VkYyylRPNeCFsBe/km0jxis6KgMpl3IGY6I/i1RwQXO05I1AsXUXO2WC6AvB/Lw4qTf/asiuEiQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@tauri-apps/cli-win32-ia32-msvc@2.10.1':
-    resolution: {integrity: sha512-gXyxgEzsFegmnWywYU5pEBURkcFN/Oo45EAwvZrHMh+zUSEAvO5E8TXsgPADYm31d1u7OQU3O3HsYfVBf2moHw==}
+  '@tauri-apps/cli-win32-ia32-msvc@2.11.4':
+    resolution: {integrity: sha512-12Hxi0XX/H5VFxO/bGgHkFWhml9VMgEOu9CidjeCeTNQ1l6fpUlbiGgSP7CLI3PFtW9/FfbeHieZ+kyWK5H7CA==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
 
-  '@tauri-apps/cli-win32-x64-msvc@2.10.1':
-    resolution: {integrity: sha512-6Cn7YpPFwzChy0ERz6djKEmUehWrYlM+xTaNzGPgZocw3BD7OfwfWHKVWxXzdjEW2KfKkHddfdxK1XXTYqBRLg==}
+  '@tauri-apps/cli-win32-x64-msvc@2.11.4':
+    resolution: {integrity: sha512-+vDiqBIU5dMISg/wNvX3sF+ZHfgJGJ5T0AcO+EHNXV9GGAG+P5fzodlDXD3QdKCRgZxMoCm5PPvj3BqLNjBthw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@tauri-apps/cli@2.10.1':
-    resolution: {integrity: sha512-jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g==}
+  '@tauri-apps/cli@2.11.4':
+    resolution: {integrity: sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ==}
     engines: {node: '>= 10'}
     hasBin: true
 
-  '@tauri-apps/plugin-opener@2.5.3':
-    resolution: {integrity: sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==}
+  '@tauri-apps/plugin-opener@2.5.4':
+    resolution: {integrity: sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -538,16 +538,16 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
-  '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
       '@types/react': ^19.2.0
 
-  '@types/react@19.2.14':
-    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -555,26 +555,26 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  acorn@8.16.0:
-    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  baseline-browser-mapping@2.10.20:
-    resolution: {integrity: sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==}
+  baseline-browser-mapping@2.11.7:
+    resolution: {integrity: sha512-APw5YuIQAg6L9w4sHDI6j26DGFJI6RpYOhnkMPdC9lWbkKvsyPHzDsve1yd73lk21yz7Y09Kci8B2Pp9FonzWA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  browserslist@4.28.2:
-    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+  browserslist@4.28.7:
+    resolution: {integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
-  caniuse-lite@1.0.30001788:
-    resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
+  caniuse-lite@1.0.30001806:
+    resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -594,11 +594,11 @@ packages:
       supports-color:
         optional: true
 
-  electron-to-chromium@1.5.340:
-    resolution: {integrity: sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==}
+  electron-to-chromium@1.5.398:
+    resolution: {integrity: sha512-AsvhAxopJGh6museTDMIjn6JpDYOfgu4RLlygomt87MUwBUqTfd/1EiPtx10/LZE8xpTvkP2E9Gafq7lkLtodQ==}
 
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -643,40 +643,41 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  node-releases@2.0.37:
-    resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
+  node-releases@2.0.51:
+    resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
+    engines: {node: '>=18'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@4.0.4:
-    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
-  react-dom@19.2.5:
-    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+  react-dom@19.2.8:
+    resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
     peerDependencies:
-      react: ^19.2.5
+      react: ^19.2.8
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
-  react@19.2.5:
-    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
+  react@19.2.8:
+    resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
     engines: {node: '>=0.10.0'}
 
-  rollup@4.60.2:
-    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+  rollup@4.62.3:
+    resolution: {integrity: sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -698,13 +699,13 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
-  terser@5.48.0:
-    resolution: {integrity: sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==}
+  terser@5.49.0:
+    resolution: {integrity: sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==}
     engines: {node: '>=10'}
     hasBin: true
 
-  tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
   typescript@5.8.3:
@@ -718,8 +719,8 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
-  vite@7.3.2:
-    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -763,25 +764,25 @@ packages:
 
 snapshots:
 
-  '@babel/code-frame@7.29.0':
+  '@babel/code-frame@7.29.7':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.29.0': {}
+  '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.0':
+  '@babel/core@7.29.7':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helpers': 7.29.2
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
@@ -791,166 +792,166 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@7.29.1':
+  '@babel/generator@7.29.7':
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
-  '@babel/helper-compilation-targets@7.28.6':
+  '@babel/helper-compilation-targets@7.29.7':
     dependencies:
-      '@babel/compat-data': 7.29.0
-      '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.2
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.7
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-globals@7.28.0': {}
+  '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-module-imports@7.28.6':
+  '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-plugin-utils@7.28.6': {}
+  '@babel/helper-plugin-utils@7.29.7': {}
 
-  '@babel/helper-string-parser@7.27.1': {}
+  '@babel/helper-string-parser@7.29.7': {}
 
-  '@babel/helper-validator-identifier@7.28.5': {}
+  '@babel/helper-validator-identifier@7.29.7': {}
 
-  '@babel/helper-validator-option@7.27.1': {}
+  '@babel/helper-validator-option@7.29.7': {}
 
-  '@babel/helpers@7.29.2':
+  '@babel/helpers@7.29.7':
     dependencies:
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
 
-  '@babel/parser@7.29.2':
+  '@babel/parser@7.29.7':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/template@7.28.6':
+  '@babel/template@7.29.7':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.0':
+  '@babel/traverse@7.29.7':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/types@7.29.0':
+  '@babel/types@7.29.7':
     dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
-  '@esbuild/aix-ppc64@0.27.7':
+  '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.27.7':
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.27.7':
+  '@esbuild/android-arm@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.27.7':
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.7':
+  '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.7':
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.7':
+  '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.7':
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.7':
+  '@esbuild/linux-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.27.7':
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.7':
+  '@esbuild/linux-ia32@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.7':
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.7':
+  '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.7':
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.7':
+  '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.7':
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-x64@0.27.7':
+  '@esbuild/linux-x64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.7':
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.7':
+  '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.7':
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.7':
+  '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.7':
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.7':
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.7':
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.7':
+  '@esbuild/win32-ia32@0.28.1':
     optional: true
 
-  '@esbuild/win32-x64@0.27.7':
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -979,192 +980,192 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
-  '@rollup/rollup-android-arm-eabi@4.60.2':
+  '@rollup/rollup-android-arm-eabi@4.62.3':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.60.2':
+  '@rollup/rollup-android-arm64@4.62.3':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.60.2':
+  '@rollup/rollup-darwin-arm64@4.62.3':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.60.2':
+  '@rollup/rollup-darwin-x64@4.62.3':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.60.2':
+  '@rollup/rollup-freebsd-arm64@4.62.3':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.60.2':
+  '@rollup/rollup-freebsd-x64@4.62.3':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.3':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+  '@rollup/rollup-linux-arm-musleabihf@4.62.3':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+  '@rollup/rollup-linux-arm64-gnu@4.62.3':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.60.2':
+  '@rollup/rollup-linux-arm64-musl@4.62.3':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+  '@rollup/rollup-linux-loong64-gnu@4.62.3':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.60.2':
+  '@rollup/rollup-linux-loong64-musl@4.62.3':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+  '@rollup/rollup-linux-ppc64-gnu@4.62.3':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+  '@rollup/rollup-linux-ppc64-musl@4.62.3':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+  '@rollup/rollup-linux-riscv64-gnu@4.62.3':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+  '@rollup/rollup-linux-riscv64-musl@4.62.3':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+  '@rollup/rollup-linux-s390x-gnu@4.62.3':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.60.2':
+  '@rollup/rollup-linux-x64-gnu@4.62.3':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.60.2':
+  '@rollup/rollup-linux-x64-musl@4.62.3':
     optional: true
 
-  '@rollup/rollup-openbsd-x64@4.60.2':
+  '@rollup/rollup-openbsd-x64@4.62.3':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.60.2':
+  '@rollup/rollup-openharmony-arm64@4.62.3':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+  '@rollup/rollup-win32-arm64-msvc@4.62.3':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+  '@rollup/rollup-win32-ia32-msvc@4.62.3':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.60.2':
+  '@rollup/rollup-win32-x64-gnu@4.62.3':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.60.2':
+  '@rollup/rollup-win32-x64-msvc@4.62.3':
     optional: true
 
-  '@tauri-apps/api@2.10.1': {}
+  '@tauri-apps/api@2.11.1': {}
 
-  '@tauri-apps/cli-darwin-arm64@2.10.1':
+  '@tauri-apps/cli-darwin-arm64@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-darwin-x64@2.10.1':
+  '@tauri-apps/cli-darwin-x64@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-linux-arm-gnueabihf@2.10.1':
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-linux-arm64-gnu@2.10.1':
+  '@tauri-apps/cli-linux-arm64-gnu@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-linux-arm64-musl@2.10.1':
+  '@tauri-apps/cli-linux-arm64-musl@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-linux-riscv64-gnu@2.10.1':
+  '@tauri-apps/cli-linux-riscv64-gnu@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-linux-x64-gnu@2.10.1':
+  '@tauri-apps/cli-linux-x64-gnu@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-linux-x64-musl@2.10.1':
+  '@tauri-apps/cli-linux-x64-musl@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-win32-arm64-msvc@2.10.1':
+  '@tauri-apps/cli-win32-arm64-msvc@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-win32-ia32-msvc@2.10.1':
+  '@tauri-apps/cli-win32-ia32-msvc@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-win32-x64-msvc@2.10.1':
+  '@tauri-apps/cli-win32-x64-msvc@2.11.4':
     optional: true
 
-  '@tauri-apps/cli@2.10.1':
+  '@tauri-apps/cli@2.11.4':
     optionalDependencies:
-      '@tauri-apps/cli-darwin-arm64': 2.10.1
-      '@tauri-apps/cli-darwin-x64': 2.10.1
-      '@tauri-apps/cli-linux-arm-gnueabihf': 2.10.1
-      '@tauri-apps/cli-linux-arm64-gnu': 2.10.1
-      '@tauri-apps/cli-linux-arm64-musl': 2.10.1
-      '@tauri-apps/cli-linux-riscv64-gnu': 2.10.1
-      '@tauri-apps/cli-linux-x64-gnu': 2.10.1
-      '@tauri-apps/cli-linux-x64-musl': 2.10.1
-      '@tauri-apps/cli-win32-arm64-msvc': 2.10.1
-      '@tauri-apps/cli-win32-ia32-msvc': 2.10.1
-      '@tauri-apps/cli-win32-x64-msvc': 2.10.1
+      '@tauri-apps/cli-darwin-arm64': 2.11.4
+      '@tauri-apps/cli-darwin-x64': 2.11.4
+      '@tauri-apps/cli-linux-arm-gnueabihf': 2.11.4
+      '@tauri-apps/cli-linux-arm64-gnu': 2.11.4
+      '@tauri-apps/cli-linux-arm64-musl': 2.11.4
+      '@tauri-apps/cli-linux-riscv64-gnu': 2.11.4
+      '@tauri-apps/cli-linux-x64-gnu': 2.11.4
+      '@tauri-apps/cli-linux-x64-musl': 2.11.4
+      '@tauri-apps/cli-win32-arm64-msvc': 2.11.4
+      '@tauri-apps/cli-win32-ia32-msvc': 2.11.4
+      '@tauri-apps/cli-win32-x64-msvc': 2.11.4
 
-  '@tauri-apps/plugin-opener@2.5.3':
+  '@tauri-apps/plugin-opener@2.5.4':
     dependencies:
-      '@tauri-apps/api': 2.10.1
+      '@tauri-apps/api': 2.11.1
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.28.0
 
   '@types/babel__generator@7.27.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@types/babel__traverse@7.28.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
-  '@types/estree@1.0.8': {}
+  '@types/estree@1.0.9': {}
 
-  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.17
 
-  '@types/react@19.2.14':
+  '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
 
-  '@vitejs/plugin-react@4.7.0(vite@7.3.2(terser@5.48.0))':
+  '@vitejs/plugin-react@4.7.0(vite@7.3.6(terser@5.49.0))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.3.2(terser@5.48.0)
+      vite: 7.3.6(terser@5.49.0)
     transitivePeerDependencies:
       - supports-color
 
-  acorn@8.16.0: {}
+  acorn@8.18.0: {}
 
-  baseline-browser-mapping@2.10.20: {}
+  baseline-browser-mapping@2.11.7: {}
 
-  browserslist@4.28.2:
+  browserslist@4.28.7:
     dependencies:
-      baseline-browser-mapping: 2.10.20
-      caniuse-lite: 1.0.30001788
-      electron-to-chromium: 1.5.340
-      node-releases: 2.0.37
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+      baseline-browser-mapping: 2.11.7
+      caniuse-lite: 1.0.30001806
+      electron-to-chromium: 1.5.398
+      node-releases: 2.0.51
+      update-browserslist-db: 1.2.3(browserslist@4.28.7)
 
   buffer-from@1.1.2: {}
 
-  caniuse-lite@1.0.30001788: {}
+  caniuse-lite@1.0.30001806: {}
 
   commander@2.20.3: {}
 
@@ -1176,42 +1177,42 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  electron-to-chromium@1.5.340: {}
+  electron-to-chromium@1.5.398: {}
 
-  esbuild@0.27.7:
+  esbuild@0.28.1:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
-  fdir@6.5.0(picomatch@4.0.4):
+  fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   fsevents@2.3.3:
     optional: true
@@ -1230,58 +1231,58 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.16: {}
 
-  node-releases@2.0.37: {}
+  node-releases@2.0.51: {}
 
   picocolors@1.1.1: {}
 
-  picomatch@4.0.4: {}
+  picomatch@4.0.5: {}
 
-  postcss@8.5.10:
+  postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  react-dom@19.2.5(react@19.2.5):
+  react-dom@19.2.8(react@19.2.8):
     dependencies:
-      react: 19.2.5
+      react: 19.2.8
       scheduler: 0.27.0
 
   react-refresh@0.17.0: {}
 
-  react@19.2.5: {}
+  react@19.2.8: {}
 
-  rollup@4.60.2:
+  rollup@4.62.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.60.2
-      '@rollup/rollup-android-arm64': 4.60.2
-      '@rollup/rollup-darwin-arm64': 4.60.2
-      '@rollup/rollup-darwin-x64': 4.60.2
-      '@rollup/rollup-freebsd-arm64': 4.60.2
-      '@rollup/rollup-freebsd-x64': 4.60.2
-      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
-      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
-      '@rollup/rollup-linux-arm64-gnu': 4.60.2
-      '@rollup/rollup-linux-arm64-musl': 4.60.2
-      '@rollup/rollup-linux-loong64-gnu': 4.60.2
-      '@rollup/rollup-linux-loong64-musl': 4.60.2
-      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
-      '@rollup/rollup-linux-ppc64-musl': 4.60.2
-      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
-      '@rollup/rollup-linux-riscv64-musl': 4.60.2
-      '@rollup/rollup-linux-s390x-gnu': 4.60.2
-      '@rollup/rollup-linux-x64-gnu': 4.60.2
-      '@rollup/rollup-linux-x64-musl': 4.60.2
-      '@rollup/rollup-openbsd-x64': 4.60.2
-      '@rollup/rollup-openharmony-arm64': 4.60.2
-      '@rollup/rollup-win32-arm64-msvc': 4.60.2
-      '@rollup/rollup-win32-ia32-msvc': 4.60.2
-      '@rollup/rollup-win32-x64-gnu': 4.60.2
-      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      '@rollup/rollup-android-arm-eabi': 4.62.3
+      '@rollup/rollup-android-arm64': 4.62.3
+      '@rollup/rollup-darwin-arm64': 4.62.3
+      '@rollup/rollup-darwin-x64': 4.62.3
+      '@rollup/rollup-freebsd-arm64': 4.62.3
+      '@rollup/rollup-freebsd-x64': 4.62.3
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.3
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.3
+      '@rollup/rollup-linux-arm64-gnu': 4.62.3
+      '@rollup/rollup-linux-arm64-musl': 4.62.3
+      '@rollup/rollup-linux-loong64-gnu': 4.62.3
+      '@rollup/rollup-linux-loong64-musl': 4.62.3
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.3
+      '@rollup/rollup-linux-ppc64-musl': 4.62.3
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.3
+      '@rollup/rollup-linux-riscv64-musl': 4.62.3
+      '@rollup/rollup-linux-s390x-gnu': 4.62.3
+      '@rollup/rollup-linux-x64-gnu': 4.62.3
+      '@rollup/rollup-linux-x64-musl': 4.62.3
+      '@rollup/rollup-openbsd-x64': 4.62.3
+      '@rollup/rollup-openharmony-arm64': 4.62.3
+      '@rollup/rollup-win32-arm64-msvc': 4.62.3
+      '@rollup/rollup-win32-ia32-msvc': 4.62.3
+      '@rollup/rollup-win32-x64-gnu': 4.62.3
+      '@rollup/rollup-win32-x64-msvc': 4.62.3
       fsevents: 2.3.3
 
   scheduler@0.27.0: {}
@@ -1297,36 +1298,36 @@ snapshots:
 
   source-map@0.6.1: {}
 
-  terser@5.48.0:
+  terser@5.49.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.16.0
+      acorn: 8.18.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
-  tinyglobby@0.2.16:
+  tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   typescript@5.8.3: {}
 
-  update-browserslist-db@1.2.3(browserslist@4.28.2):
+  update-browserslist-db@1.2.3(browserslist@4.28.7):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.7
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  vite@7.3.2(terser@5.48.0):
+  vite@7.3.6(terser@5.49.0):
     dependencies:
-      esbuild: 0.27.7
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.10
-      rollup: 4.60.2
-      tinyglobby: 0.2.16
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.25
+      rollup: 4.62.3
+      tinyglobby: 0.2.17
     optionalDependencies:
       fsevents: 2.3.3
-      terser: 5.48.0
+      terser: 5.49.0
 
   yallist@3.1.1: {}

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Write a new version into every file that carries one, then verify they
+# agree. The version lives in five places with nothing tying them together:
+# package.json, src-tauri/Cargo.toml, src-tauri/tauri.conf.json, the crate's
+# own entry in src-tauri/Cargo.lock, and the README title. check-version.sh
+# catches drift between the first three at release time; this script is how
+# they move in lockstep in the first place.
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "usage: $0 <version>   e.g. $0 2.8.0+linux.2" >&2
+  exit 1
+fi
+new="$1"
+
+# The fork's scheme is <upstream-semver>+linux.<n>; anything else is a typo
+# or an upstream version that forgot its build metadata.
+case "$new" in
+  [0-9]*.[0-9]*.[0-9]*+linux.[0-9]*) ;;
+  *)
+    echo "version must look like <upstream>+linux.<n>, e.g. 2.8.0+linux.2" >&2
+    exit 1
+    ;;
+esac
+
+root="$(dirname "$0")/.."
+
+# First occurrence only, mirroring how check-version.sh reads each file:
+# both JSON files carry other "version" keys further down (dependencies,
+# bundle sections) that must not be touched.
+sed -i "0,/\"version\": \".*\"/s//\"version\": \"$new\"/" "$root/package.json"
+sed -i "0,/\"version\": \".*\"/s//\"version\": \"$new\"/" "$root/src-tauri/tauri.conf.json"
+sed -i "0,/^version = \".*\"/s//version = \"$new\"/" "$root/src-tauri/Cargo.toml"
+
+# The README's title names the current release; the other versions in its
+# prose are worked examples and stay as written.
+sed -i "s/Companion \`v[^\`]*\`/Companion \`v$new\`/" "$root/README.md"
+
+# Resync the lock file's warframe-companion entry from the manifest. Offline:
+# only the workspace member's version changes, no dependency needs resolving.
+# Upstream once shipped a lock that lagged its manifest (v2.8.0); a --locked
+# build catches that only after this script has already prevented it.
+(cd "$root/src-tauri" && cargo update --workspace --offline --quiet)
+
+bash "$root/scripts/check-version.sh" "$new"
+grep -A1 'name = "warframe-companion"' "$root/src-tauri/Cargo.lock"

--- a/scripts/check-version.sh
+++ b/scripts/check-version.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Assert the three files carrying the version agree, and — when one is passed as
+# $1 — that they agree with it too.
+#
+# The version is written out in three places with nothing tying them together.
+# A drift is invisible until release time, when it surfaces as artifact
+# filenames that contradict the release title, after the build has already run.
+set -euo pipefail
+
+expected="${1:-}"
+root="$(dirname "$0")/.."
+
+package_version=$(grep -m1 '"version"' "$root/package.json" | cut -d'"' -f4)
+cargo_version=$(grep -m1 '^version = ' "$root/src-tauri/Cargo.toml" | cut -d'"' -f2)
+tauri_version=$(grep -m1 '"version"' "$root/src-tauri/tauri.conf.json" | cut -d'"' -f4)
+
+echo "package.json:     $package_version"
+echo "Cargo.toml:       $cargo_version"
+echo "tauri.conf.json:  $tauri_version"
+if [ -n "$expected" ]; then
+    echo "expected:         $expected"
+fi
+
+if [ "$cargo_version" != "$package_version" ] || [ "$cargo_version" != "$tauri_version" ]; then
+    echo "::error::the three version files disagree"
+    exit 1
+fi
+
+if [ -n "$expected" ] && [ "$expected" != "$cargo_version" ]; then
+    echo "::error::expected $expected but the tree is at $cargo_version"
+    exit 1
+fi

--- a/scripts/fetch-tessdata.sh
+++ b/scripts/fetch-tessdata.sh
@@ -13,14 +13,21 @@
 # pins the exact file rather than tracking the branch.
 set -euo pipefail
 
-readonly URL="https://raw.githubusercontent.com/tesseract-ocr/tessdata/main/eng.traineddata"
+# Pinned to a commit rather than `main`: a branch URL serves whatever it points at
+# now, so when upstream regenerates the file the checksum below stops matching and
+# the old bytes are unfetchable, and the only way forward is to accept a
+# different, unmeasured model. A tag would not do either, since tags can be
+# repointed. So the SHA256 guards transport and tampering, not upstream drift.
+# This is the last commit to touch the file, in May 2018.
+readonly URL="https://raw.githubusercontent.com/tesseract-ocr/tessdata/c2b2e0df86272ce11be323f23f96cf656565ed41/eng.traineddata"
 readonly SHA256="daa0c97d651c19fba3b25e81317cd697e9908c8208090c94c3905381c23fc047"
 
 dest_dir="$(dirname "$0")/../src-tauri/tessdata"
 dest="${dest_dir}/eng.traineddata"
 
-# Nothing to do when the pinned file is already in place — this runs on every
-# bundle, and the download is 23 MB.
+# `build.rs` re-runs this whenever the script or the model changes, and on any
+# fresh target directory, so this guard is what keeps the 23 MB download to once
+# per model.
 if [ -f "$dest" ] && echo "${SHA256}  ${dest}" | sha256sum --check --status; then
     exit 0
 fi

--- a/scripts/fetch-tessdata.sh
+++ b/scripts/fetch-tessdata.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Fetch the Tesseract English model the bundler ships inside every Linux bundle.
+#
+# The AppImage has no package manager to declare a dependency to, and the deb
+# and rpm cannot name one model across distributions that package different
+# variants, so all three carry this file instead.
+#
+# Which model matters. The LSTM-only variants (tessdata_fast, tessdata_best)
+# read the reward screen fine but come back empty on a riven card — its text is
+# small and low-contrast, and only the main repository's model, which still
+# carries the legacy engine alongside the LSTM one, transcribes it. That model
+# is also what this project's OCR was measured against, so the checksum below
+# pins the exact file rather than tracking the branch.
+set -euo pipefail
+
+readonly URL="https://raw.githubusercontent.com/tesseract-ocr/tessdata/main/eng.traineddata"
+readonly SHA256="daa0c97d651c19fba3b25e81317cd697e9908c8208090c94c3905381c23fc047"
+
+dest_dir="$(dirname "$0")/../src-tauri/tessdata"
+dest="${dest_dir}/eng.traineddata"
+
+# Nothing to do when the pinned file is already in place — this runs on every
+# bundle, and the download is 23 MB.
+if [ -f "$dest" ] && echo "${SHA256}  ${dest}" | sha256sum --check --status; then
+    exit 0
+fi
+
+mkdir -p "$dest_dir"
+echo "fetching eng.traineddata (23 MB) for the bundle…" >&2
+curl --fail --location --silent --show-error --output "${dest}.part" "$URL"
+
+# Verify before moving into place: a truncated or substituted model would fail
+# at OCR time inside a packaged app, where there is nothing left to debug with.
+if echo "${SHA256}  ${dest}.part" | sha256sum --check --status; then
+    mv "${dest}.part" "$dest"
+else
+    rm -f "${dest}.part"
+    echo "eng.traineddata checksum mismatch — refusing to bundle it" >&2
+    exit 1
+fi

--- a/scripts/fix-appimage.sh
+++ b/scripts/fix-appimage.sh
@@ -32,6 +32,16 @@ head -c "$offset" "$appimage" > runtime
 
 "$appimage" --appimage-extract > /dev/null
 
+# EGL comes from the host's Mesa, and Mesa built against wayland >= 1.23
+# calls wl_display_create_queue_with_name. The libwayland-client that
+# linuxdeploy bundles from the build distro predates that symbol, Mesa binds
+# to the bundled copy, and EGL display creation fails with EGL_BAD_PARAMETER:
+# WebKit's render process aborts and every window is blank. Same reason the
+# AppImage excludelist bans exactly this library (mesa#11316); the sibling
+# libwayland-* libs are fine to bundle and stay. -f, because a linuxdeploy
+# with the updated excludelist will stop bundling it.
+rm -f squashfs-root/usr/lib/libwayland-client.so.0
+
 # The desktop file's real copy lives under usr/share/applications, and the
 # root FrameForge.png is already a regular file, so both are safe sources.
 rm squashfs-root/FrameForge.desktop squashfs-root/.DirIcon

--- a/scripts/fix-appimage.sh
+++ b/scripts/fix-appimage.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Repack an AppImage so its root FrameForge.desktop and .DirIcon are regular
+# files rather than the symlinks linuxdeploy leaves behind.
+#
+# Launcher integration tools (shelly, appimaged and friends) read exactly
+# those two root entries by partial extraction, where a symlink resolves to
+# nothing. Worse, linuxdeploy's .DirIcon symlink is absolute into the build
+# tree, so it is broken on every machine except the build host. The result is
+# a nameless, iconless launcher entry. There is no Tauri hook between
+# linuxdeploy and the squashfs packing, hence the repack after the fact.
+set -euo pipefail
+
+if [ $# -ne 1 ] || [ ! -f "$1" ]; then
+  echo "usage: $0 <AppImage>" >&2
+  exit 1
+fi
+appimage=$(realpath "$1")
+
+if ! command -v mksquashfs > /dev/null; then
+  echo "mksquashfs not found - install squashfs-tools" >&2
+  exit 1
+fi
+
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT
+cd "$workdir"
+
+# Everything before the squashfs is the runtime. Reusing it byte-for-byte
+# keeps whatever runtime and embedded update information Tauri shipped.
+offset=$("$appimage" --appimage-offset)
+head -c "$offset" "$appimage" > runtime
+
+"$appimage" --appimage-extract > /dev/null
+
+# The desktop file's real copy lives under usr/share/applications, and the
+# root FrameForge.png is already a regular file, so both are safe sources.
+rm squashfs-root/FrameForge.desktop squashfs-root/.DirIcon
+cp squashfs-root/usr/share/applications/FrameForge.desktop squashfs-root/
+cp squashfs-root/FrameForge.png squashfs-root/.DirIcon
+grep -q '^Name=FrameForge$' squashfs-root/FrameForge.desktop
+
+# Match the original filesystem's compression so the repack changes nothing
+# but the two entries above.
+comp=$(unsquashfs -s -offset "$offset" "$appimage" | awk '/^Compression/{print $2}')
+mksquashfs squashfs-root filesystem.img \
+  -comp "$comp" -b 131072 -noappend -all-root -quiet > /dev/null
+
+cat runtime filesystem.img > repacked
+chmod 755 repacked
+mv repacked "$appimage"
+
+# The failure this script exists for is a root entry a partial extraction
+# cannot read, so that is what gets verified.
+mkdir verify && cd verify
+"$appimage" --appimage-extract FrameForge.desktop > /dev/null
+"$appimage" --appimage-extract .DirIcon > /dev/null
+grep -q '^Name=FrameForge$' squashfs-root/FrameForge.desktop
+[ -s squashfs-root/.DirIcon ] && [ ! -L squashfs-root/.DirIcon ]
+
+echo "repacked: $appimage"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5023,6 +5023,7 @@ dependencies = [
  "dirs 5.0.1",
  "lzma-rs",
  "native-tls",
+ "raw-window-handle",
  "regex",
  "rusqlite",
  "serde",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -37,9 +37,9 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
@@ -55,9 +55,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "async-broadcast"
@@ -152,7 +152,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -181,13 +181,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -221,9 +221,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -254,7 +254,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash 1.1.0",
- "shlex",
+ "shlex 1.3.0",
  "syn 1.0.109",
  "which",
 ]
@@ -282,9 +282,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
@@ -322,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -333,25 +333,34 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.20.2"
+name = "bs58"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "byteorder"
@@ -367,9 +376,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -380,7 +389,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -401,9 +410,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.2.2"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+checksum = "bb1307f12aa967b5a58416e87b3653360e0fd614a016b6e970db08fecbb1b80d"
 dependencies = [
  "serde_core",
 ]
@@ -428,7 +437,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -443,12 +452,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -495,9 +504,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -509,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.8.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
 dependencies = [
  "glob",
  "libc",
@@ -536,12 +545,6 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cookie"
@@ -575,7 +578,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-graphics-types",
  "foreign-types 0.5.0",
@@ -588,7 +591,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "core-foundation",
  "libc",
 ]
@@ -613,9 +616,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -628,18 +631,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
@@ -653,23 +656,6 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.29.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93d03419cb5950ccfd3daf3ff1c7a36ace64609a1a8746d493df1ca0afde0fa"
-dependencies = [
- "cssparser-macros",
- "dtoa-short",
- "itoa",
- "matches",
- "phf 0.10.1",
- "proc-macro2",
- "quote",
- "smallvec",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "cssparser"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
@@ -677,7 +663,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf 0.13.1",
+ "phf",
  "smallvec",
 ]
 
@@ -688,18 +674,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "ctor"
-version = "0.2.9"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+checksum = "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98"
 dependencies = [
- "quote",
- "syn 2.0.117",
+ "ctor-proc-macro",
+ "dtor",
 ]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "darling"
@@ -721,7 +713,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -732,7 +724,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -742,26 +734,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "dbus"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab69f03cc8c4340c9c8e315114e1658e6775a9b16a04357973aa21cec22b32e"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -782,7 +771,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -843,7 +832,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -851,13 +840,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -880,7 +869,7 @@ checksum = "0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -890,12 +879,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
  "bit-set",
- "cssparser 0.36.0",
- "foldhash 0.2.0",
- "html5ever 0.38.0",
+ "cssparser",
+ "foldhash",
+ "html5ever",
  "precomputed-hash",
- "selectors 0.36.1",
- "tendril 0.5.0",
+ "selectors",
+ "tendril",
 ]
 
 [[package]]
@@ -923,6 +912,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtor"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,14 +946,14 @@ checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "embed-resource"
-version = "3.0.8"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63a1d0de4f2249aa0ff5884d7080814f446bb241a559af6c170a41e878ed2d45"
+checksum = "fbfdaacccebec3b28e4866b8973543c7647797db5ada1bdab552e48fe665fbbd"
 dependencies = [
  "cc",
  "memchr",
  "rustc_version",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "vswhom",
  "winreg",
 ]
@@ -984,7 +988,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1016,11 +1020,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -1049,9 +1052,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fdeflate"
@@ -1096,12 +1099,6 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -1127,13 +1124,13 @@ dependencies = [
 
 [[package]]
 name = "foreign-types-macros"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1158,35 +1155,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "futf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
-dependencies = [
- "mac",
- "new_debug_unreachable",
-]
-
-[[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1195,9 +1182,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-lite"
@@ -1214,32 +1201,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -1249,15 +1236,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -1371,24 +1349,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -1405,15 +1372,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1454,7 +1419,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -1482,7 +1447,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1497,9 +1462,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "gobject-sys"
@@ -1561,7 +1526,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1581,18 +1546,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -1638,31 +1594,19 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
-dependencies = [
- "log",
- "mac",
- "markup5ever 0.14.1",
- "match_token",
-]
-
-[[package]]
-name = "html5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
 dependencies = [
  "log",
- "markup5ever 0.38.0",
+ "markup5ever",
 ]
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1670,9 +1614,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -1680,9 +1624,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1699,9 +1643,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1857,12 +1801,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1881,9 +1819,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1920,7 +1858,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1939,16 +1877,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is-docker"
@@ -2039,18 +1967,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2082,21 +2009,9 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "serde",
  "unicode-segmentation",
-]
-
-[[package]]
-name = "kuchikiki"
-version = "0.8.8-speedreader"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2"
-dependencies = [
- "cssparser 0.29.6",
- "html5ever 0.29.1",
- "indexmap 2.14.0",
- "selectors 0.24.0",
 ]
 
 [[package]]
@@ -2110,12 +2025,6 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "leptonica-plumbing"
@@ -2165,9 +2074,18 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -2191,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
 ]
@@ -2238,9 +2156,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lzma-rs"
@@ -2253,58 +2171,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "mac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
-
-[[package]]
-name = "markup5ever"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
-dependencies = [
- "log",
- "phf 0.11.3",
- "phf_codegen 0.11.3",
- "string_cache 0.8.9",
- "string_cache_codegen 0.5.4",
- "tendril 0.4.3",
-]
-
-[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
 dependencies = [
  "log",
- "tendril 0.5.0",
+ "tendril",
  "web_atoms",
 ]
 
 [[package]]
-name = "match_token"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
-
-[[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memoffset"
@@ -2339,12 +2220,12 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.61.2",
 ]
 
@@ -2360,9 +2241,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.17.2"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177"
+checksum = "1dd04e60bc0b07438a6771710ee1698f98f6ebbc7f89b61264af1563b8aeb878"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -2373,10 +2254,10 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png 0.17.16",
+ "png 0.18.1",
  "serde",
- "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "thiserror 2.0.19",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2402,7 +2283,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys",
@@ -2410,12 +2291,6 @@ dependencies = [
  "raw-window-handle",
  "thiserror 1.0.69",
 ]
-
-[[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
@@ -2433,12 +2308,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2450,9 +2319,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -2482,7 +2351,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2501,10 +2370,31 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "block2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -2514,7 +2404,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
 ]
@@ -2525,11 +2415,43 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
 ]
 
 [[package]]
@@ -2553,7 +2475,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "block2",
  "objc2",
  "objc2-core-foundation",
@@ -2565,7 +2487,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2576,7 +2498,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -2588,9 +2510,28 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
+ "block2",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -2600,7 +2541,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "block2",
  "objc2",
  "objc2-app-kit",
@@ -2616,23 +2557,22 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "open"
-version = "5.3.4"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3bab717c29a857abf75fcef718d441ec7cb2725f937343c734740a985d37fd"
+checksum = "a0b3d059e795d52b8a72fef45658620edd4d9c359b338564aa14391ffa511ed5"
 dependencies = [
  "dunce",
  "is-wsl",
  "libc",
- "pathdiff",
 ]
 
 [[package]]
 name = "openssl"
-version = "0.10.80"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -2648,7 +2588,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2659,9 +2599,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.116"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -2740,12 +2680,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
-
-[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2759,63 +2693,13 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
-dependencies = [
- "phf_shared 0.8.0",
-]
-
-[[package]]
-name = "phf"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
-dependencies = [
- "phf_macros 0.10.0",
- "phf_shared 0.10.0",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros 0.13.1",
- "phf_shared 0.13.1",
+ "phf_macros",
+ "phf_shared",
  "serde",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815"
-dependencies = [
- "phf_generator 0.8.0",
- "phf_shared 0.8.0",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -2824,38 +2708,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
-dependencies = [
- "phf_shared 0.8.0",
- "rand 0.7.3",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
-dependencies = [
- "phf_shared 0.10.0",
- "rand 0.8.6",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared 0.11.3",
- "rand 0.8.6",
+ "phf_generator",
+ "phf_shared",
 ]
 
 [[package]]
@@ -2865,34 +2719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
-dependencies = [
- "phf_generator 0.10.0",
- "phf_shared 0.10.0",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "phf_shared",
 ]
 
 [[package]]
@@ -2901,38 +2728,11 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
-dependencies = [
- "siphasher 0.3.11",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
-dependencies = [
- "siphasher 0.3.11",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher 1.0.2",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2941,7 +2741,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
- "siphasher 1.0.2",
+ "siphasher",
 ]
 
 [[package]]
@@ -2969,13 +2769,13 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml 0.38.4",
+ "quick-xml 0.41.0",
  "serde",
  "time",
 ]
@@ -2999,7 +2799,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -3051,16 +2851,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3086,7 +2876,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -3114,25 +2904,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pxfm"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quick-xml"
@@ -3145,18 +2929,18 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -3175,57 +2959,12 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
- "rand_pcg",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -3235,25 +2974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
+ "rand_core",
 ]
 
 [[package]]
@@ -3263,24 +2984,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -3295,7 +2998,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -3317,34 +3020,34 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3354,9 +3057,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3365,15 +3068,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3423,7 +3126,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -3439,9 +3142,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -3458,7 +3161,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3471,7 +3174,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -3480,9 +3183,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "log",
  "once_cell",
@@ -3495,18 +3198,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3515,9 +3218,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "same-file"
@@ -3566,9 +3269,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -3585,7 +3288,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3600,7 +3303,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3619,38 +3322,20 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416"
-dependencies = [
- "bitflags 1.3.2",
- "cssparser 0.29.6",
- "derive_more 0.99.20",
- "fxhash",
- "log",
- "phf 0.8.0",
- "phf_codegen 0.8.0",
- "precomputed-hash",
- "servo_arc 0.2.0",
- "smallvec",
-]
-
-[[package]]
-name = "selectors"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
 dependencies = [
- "bitflags 2.11.1",
- "cssparser 0.36.0",
- "derive_more 2.1.1",
+ "bitflags 2.13.1",
+ "cssparser",
+ "derive_more",
  "log",
  "new_debug_unreachable",
- "phf 0.13.1",
- "phf_codegen 0.13.1",
+ "phf",
+ "phf_codegen",
  "precomputed-hash",
- "rustc-hash 2.1.2",
- "servo_arc 0.4.3",
+ "rustc-hash 2.1.3",
+ "servo_arc",
  "smallvec",
 ]
 
@@ -3666,9 +3351,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -3688,22 +3373,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3714,14 +3399,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -3732,13 +3417,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3761,17 +3446,18 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -3780,14 +3466,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3809,17 +3495,7 @@ checksum = "772ee033c0916d670af7860b6e1ef7d658a4629a6d0b4c8c3e67f09b3765b75d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "servo_arc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52aa42f8fdf0fed91e5ce7f23d8138441002fa31dca008acf47e6fd4721f741"
-dependencies = [
- "nodrop",
- "stable_deref_trait",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3833,9 +3509,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3860,6 +3536,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3871,21 +3553,15 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "siphasher"
-version = "0.3.11"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
-
-[[package]]
-name = "siphasher"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -3895,15 +3571,15 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -3965,39 +3641,14 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "string_cache"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared 0.11.3",
- "precomputed-hash",
- "serde",
-]
-
-[[package]]
-name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared 0.13.1",
+ "phf_shared",
  "precomputed-hash",
-]
-
-[[package]]
-name = "string_cache_codegen"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
 ]
 
 [[package]]
@@ -4006,8 +3657,8 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
 ]
@@ -4048,9 +3699,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4074,7 +3736,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4092,15 +3754,16 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.34.8"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
+checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "block2",
  "core-foundation",
  "core-graphics",
  "crossbeam-channel",
+ "dbus",
  "dispatch2",
  "dlopen2",
  "dpi",
@@ -4111,13 +3774,14 @@ dependencies = [
  "libc",
  "log",
  "ndk",
- "ndk-context",
  "ndk-sys",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
+ "objc2-ui-kit",
  "once_cell",
  "parking_lot",
+ "percent-encoding",
  "raw-window-handle",
  "tao-macros",
  "unicode-segmentation",
@@ -4130,13 +3794,13 @@ dependencies = [
 
 [[package]]
 name = "tao-macros"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
+checksum = "5f7eeb6d99155545da6150a1795945f16ac9c178deb2a5f2e74d776107bd5849"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4147,9 +3811,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.10.3"
+version = "2.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da77cc00fb9028caf5b5d4650f75e31f1ef3693459dfca7f7e506d1ecef0ba2d"
+checksum = "667b20e2726d572dea2de7370da16e188eb06008faf9a92fab7cdc46791190b5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4187,7 +3851,7 @@ dependencies = [
  "tauri-runtime",
  "tauri-runtime-wry",
  "tauri-utils",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tray-icon",
  "url",
@@ -4199,9 +3863,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.5.6"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bbc990d1dbf57a8e1c7fa2327f2a614d8b757805603c1b9ba5c81bade09fd4d"
+checksum = "bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -4215,15 +3879,14 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "tauri-winres",
- "toml 0.9.12+spec-1.1.0",
  "walkdir",
 ]
 
 [[package]]
 name = "tauri-codegen"
-version = "2.5.5"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a24476afd977c5d5d169f72425868613d82747916dd29e0a357c84c4bd6d29"
+checksum = "08279169ff42f8fc45a1dbc9dcae888893ba95288142e5880c59b93a26d2cfc5"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -4237,9 +3900,9 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "syn 2.0.117",
+ "syn 2.0.119",
  "tauri-utils",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "url",
  "uuid",
@@ -4248,23 +3911,23 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.5.5"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39b349a98dadaffebb73f0a40dcd1f23c999211e5a2e744403db384d0c33de7"
+checksum = "e8b394794f399a421811d06966343e7933fcae92d59f5180b9388d1174497a45"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "tauri-codegen",
  "tauri-utils",
 ]
 
 [[package]]
 name = "tauri-plugin"
-version = "2.5.4"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddde7d51c907b940fb573006cdda9a642d6a7c8153657e88f8a5c3c9290cd4aa"
+checksum = "74be5dd4bed9afbd145e5716b5fa2ec28cbc29c34ffa61c258c9273d896c8020"
 dependencies = [
  "anyhow",
  "glob",
@@ -4273,15 +3936,14 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri-utils",
- "toml 0.9.12+spec-1.1.0",
  "walkdir",
 ]
 
 [[package]]
 name = "tauri-plugin-opener"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc624469b06f59f5a29f874bbc61a2ed737c0f9c23ef09855a292c389c42e83f"
+checksum = "17e1bea14edce6b793a04e2417e3fd924b9bc4faae83cdee7d714156cceeed29"
 dependencies = [
  "dunce",
  "glob",
@@ -4293,7 +3955,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "url",
  "windows 0.61.3",
  "zbus",
@@ -4301,9 +3963,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.10.1"
+version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2826d79a3297ed08cd6ea7f412644ef58e32969504bc4fbd8d7dbeabc4445ea2"
+checksum = "b0b4bc95aed361b0019067d189a1174a603d460d0f6c72606512d59fc9c12ec8"
 dependencies = [
  "cookie",
  "dpi",
@@ -4317,7 +3979,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri-utils",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "url",
  "webkit2gtk",
  "webview2-com",
@@ -4326,9 +3988,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.10.1"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11ea2e6f801d275fdd890d6c9603736012742a1c33b96d0db788c9cdebf7f9e"
+checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http",
@@ -4352,24 +4014,24 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.8.3"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219a1f983a2af3653f75b5747f76733b0da7ff03069c7a41901a5eb3ace4557d"
+checksum = "3e176a18e67764923c4f1ce66f25ae4abe5f688384d5eb1a0fa6c77f3d90f887"
 dependencies = [
  "anyhow",
  "brotli",
  "cargo_metadata",
  "ctor",
+ "dom_query",
  "dunce",
  "glob",
- "html5ever 0.29.1",
  "http",
  "infer",
  "json-patch",
- "kuchikiki",
  "log",
  "memchr",
- "phf 0.11.3",
+ "phf",
+ "plist",
  "proc-macro2",
  "quote",
  "regex",
@@ -4380,8 +4042,8 @@ dependencies = [
  "serde_json",
  "serde_with",
  "swift-rs",
- "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "thiserror 2.0.19",
+ "toml 1.1.4+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -4390,13 +4052,13 @@ dependencies = [
 
 [[package]]
 name = "tauri-winres"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1087b111fe2b005e42dbdc1990fc18593234238d47453b0c99b7de1c9ab2c1e0"
+checksum = "cc65d45c68858bfe420dd29e834b5d15dbecf8a07a8a16cf4d532c7b1f69d4b6"
 dependencies = [
  "dunce",
  "embed-resource",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
 ]
 
 [[package]]
@@ -4406,7 +4068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -4414,23 +4076,11 @@ dependencies = [
 
 [[package]]
 name = "tendril"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
-dependencies = [
- "futf",
- "mac",
- "utf-8",
-]
-
-[[package]]
-name = "tendril"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
 dependencies = [
  "new_debug_unreachable",
- "utf-8",
 ]
 
 [[package]]
@@ -4478,11 +4128,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -4493,28 +4143,27 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -4524,15 +4173,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4549,10 +4198,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.52.1"
+name = "tinyvec"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -4564,9 +4228,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4600,6 +4264,21 @@ dependencies = [
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -4655,23 +4334,23 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.1",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 1.0.1",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -4697,20 +4376,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -4744,7 +4423,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4758,9 +4437,9 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.21.3"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
+checksum = "045979e3f037cd18ad1cb2a419dfda133c5c29c9f3453370079f2255d46c257e"
 dependencies = [
  "crossbeam-channel",
  "dirs 6.0.0",
@@ -4772,10 +4451,10 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "once_cell",
- "png 0.17.16",
+ "png 0.18.1",
  "serde",
- "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "thiserror 2.0.19",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4796,9 +4475,9 @@ dependencies = [
  "httparse",
  "log",
  "native-tls",
- "rand 0.9.4",
+ "rand",
  "sha1",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "utf-8",
 ]
 
@@ -4810,9 +4489,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uds_windows"
@@ -4874,15 +4553,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "untrusted"
@@ -4947,11 +4620,11 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -5016,7 +4689,7 @@ dependencies = [
 
 [[package]]
 name = "warframe-companion"
-version = "2.8.0+linux.1"
+version = "2.8.0+linux.2"
 dependencies = [
  "aho-corasick",
  "chrono",
@@ -5043,39 +4716,24 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5086,9 +4744,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5096,9 +4754,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5106,46 +4764,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
 ]
 
 [[package]]
@@ -5162,22 +4798,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5185,14 +4809,14 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
 dependencies = [
- "phf 0.13.1",
- "phf_codegen 0.13.1",
- "string_cache 0.9.0",
- "string_cache_codegen 0.6.1",
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]
@@ -5245,14 +4869,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5279,7 +4903,7 @@ checksum = "67a921c1b6914c367b2b823cd4cde6f96beec77d30a939c8199bb377cf9b9b54"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5288,7 +4912,7 @@ version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "windows 0.61.3",
  "windows-core 0.61.2",
 ]
@@ -5450,7 +5074,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5461,7 +5085,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5472,7 +5096,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5483,7 +5107,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5601,15 +5225,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -5656,28 +5271,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link 0.2.1",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5717,12 +5315,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5739,12 +5331,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5765,22 +5351,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5801,12 +5375,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5823,12 +5391,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5849,12 +5411,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5873,12 +5429,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5895,9 +5445,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -5914,97 +5464,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "indexmap 2.14.0",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.1",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -6014,9 +5476,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wry"
-version = "0.54.4"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a8135d8676225e5744de000d4dff5a082501bf7db6a1c1495034f8c314edbc"
+checksum = "186f9871daa55fd9c016578b810d149de58367113db7fb72b462d2323ce19514"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6045,7 +5507,7 @@ dependencies = [
  "sha2",
  "soup3",
  "tao-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "url",
  "webkit2gtk",
  "webkit2gtk-sys",
@@ -6090,9 +5552,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -6107,7 +5569,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -6140,7 +5602,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow 1.0.1",
+ "winnow 1.0.4",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -6155,7 +5617,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -6168,35 +5630,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
 dependencies = [
  "serde",
- "winnow 1.0.1",
+ "winnow 1.0.4",
  "zvariant",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -6209,15 +5671,15 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
@@ -6249,14 +5711,14 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zvariant"
@@ -6267,7 +5729,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow 1.0.1",
+ "winnow 1.0.4",
  "zvariant_derive",
  "zvariant_utils",
 ]
@@ -6281,7 +5743,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "zvariant_utils",
 ]
 
@@ -6294,6 +5756,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.117",
- "winnow 1.0.1",
+ "syn 2.0.119",
+ "winnow 1.0.4",
 ]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -110,7 +110,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -141,7 +141,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -167,7 +167,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -236,6 +236,28 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bindgen"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
+dependencies = [
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 1.0.109",
+ "which",
+]
 
 [[package]]
 name = "bit-set"
@@ -436,6 +458,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfb"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,6 +505,17 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -891,6 +933,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "embed-resource"
@@ -1580,6 +1628,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2043,10 +2100,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "leptonica-plumbing"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7a74c43d6f090d39158d233f326f47cd8bba545217595c93662b4e31156f42"
+dependencies = [
+ "leptonica-sys",
+ "libc",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "leptonica-sys"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da627c72b2499a8106f4dd33143843015e4a631f445d561f3481f7fba35b6151"
+dependencies = [
+ "bindgen",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "libappindicator"
@@ -2068,7 +2159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
 dependencies = [
  "gtk-sys",
- "libloading",
+ "libloading 0.7.4",
  "once_cell",
 ]
 
@@ -2086,6 +2177,16 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2107,6 +2208,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2213,6 +2320,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2324,6 +2437,16 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "num-conv"
@@ -2623,6 +2746,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2846,7 +2975,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -2887,7 +3016,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3004,6 +3133,15 @@ name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-xml"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quick-xml"
@@ -3295,6 +3433,12 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
@@ -3310,6 +3454,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3317,7 +3474,7 @@ dependencies = [
  "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -3492,7 +3649,7 @@ dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
  "precomputed-hash",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "servo_arc 0.4.3",
  "smallvec",
 ]
@@ -4251,7 +4408,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4274,6 +4431,40 @@ checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
 dependencies = [
  "new_debug_unreachable",
  "utf-8",
+]
+
+[[package]]
+name = "tesseract"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28e64963c0b5582cf02ed5d8b4798f8c48ea9812ed2b19ed653cb976e7daa351"
+dependencies = [
+ "tesseract-plumbing",
+ "tesseract-sys",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "tesseract-plumbing"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ed025d755abb7f5af8d16cd5663742a08c8ae7c4032c8bf4b70c51d412fe378"
+dependencies = [
+ "leptonica-plumbing",
+ "tesseract-sys",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "tesseract-sys"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e1297ece7aa841bd33a4f80046a6682c4e58fca0f8600e868d822359eef7bde"
+dependencies = [
+ "bindgen",
+ "leptonica-sys",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -4485,9 +4676,9 @@ dependencies = [
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -4839,12 +5030,14 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
+ "tesseract",
  "tokio",
  "tungstenite",
  "ureq",
  "whirlpool",
  "windows 0.58.0",
  "windows-sys 0.52.0",
+ "xcb",
 ]
 
 [[package]]
@@ -5097,6 +5290,18 @@ dependencies = [
  "thiserror 2.0.18",
  "windows 0.61.3",
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -5686,9 +5891,6 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"
@@ -5875,6 +6077,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "xcb"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4c580d8205abb0a5cf4eb7e927bd664e425b6c3263f9c5310583da96970cf6"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "quick-xml 0.30.0",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5899,9 +6112,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.14.0"
+version = "5.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
+checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -5919,14 +6132,14 @@ dependencies = [
  "hex",
  "libc",
  "ordered-stream",
- "rustix",
+ "rustix 1.1.4",
  "serde",
  "serde_repr",
  "tracing",
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow 0.7.15",
+ "winnow 1.0.1",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -5934,9 +6147,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.14.0"
+version = "5.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
+checksum = "fe96480bed92df2b442a1a30df364e12d08eed03aeb061f2b8dc6afb2be91119"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -5949,12 +6162,12 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "4.3.1"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
 dependencies = [
  "serde",
- "winnow 0.7.15",
+ "winnow 1.0.1",
  "zvariant",
 ]
 
@@ -6046,23 +6259,23 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zvariant"
-version = "5.10.0"
+version = "5.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
+checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow 0.7.15",
+ "winnow 1.0.1",
  "zvariant_derive",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.10.0"
+version = "5.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
+checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -6073,13 +6286,13 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
  "syn 2.0.117",
- "winnow 0.7.15",
+ "winnow 1.0.1",
 ]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5016,7 +5016,7 @@ dependencies = [
 
 [[package]]
 name = "warframe-companion"
-version = "2.7.0"
+version = "2.8.0+linux.1"
 dependencies = [
  "aho-corasick",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "warframe-companion"
-version = "2.8.0"
+version = "2.8.0+linux.1"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,5 +61,6 @@ windows = { version = "0.58", features = [
 ] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
+raw-window-handle = "0.6"
 tesseract = "0.15.2"
 xcb = "1.7"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -59,3 +59,7 @@ windows = { version = "0.58", features = [
     "Win32_Graphics_Direct3D",
     "Win32_Graphics_Direct3D11",
 ] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+tesseract = "0.15.2"
+xcb = "1.7"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "warframe-companion"
-version = "2.8.0+linux.1"
+version = "2.8.0+linux.2"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,44 @@
 fn main() {
+    // The Linux bundles carry their own Tesseract model, declared as a bundle
+    // resource in `tauri.linux.conf.json`. `tauri_build::build()` below refuses
+    // to compile the crate when a declared resource is missing, so the model has
+    // to be on disk before that call.
+    //
+    // This is the only placement early enough. `beforeBundleCommand`, the obvious
+    // home, fires after the crate compiles: on a checkout without the model (it
+    // is untracked, at 23 MB) the build fails right here, before that hook
+    // ever runs. Doing it in the build script also covers a plain `cargo run`,
+    // which no Tauri hook reaches at all.
+    //
+    // Shelling out keeps the download and its SHA256 check in one place instead
+    // of duplicating them in Rust. That would mean an HTTP client and a hasher in
+    // `[build-dependencies]`, a separate graph from `[dependencies]`, so `ureq`
+    // and its TLS stack would compile a second time for the host. A missing
+    // `curl` here also fails the build loudly, on the machine of whoever can fix
+    // it, rather than failing on a user's machine the way a runtime shell-out
+    // would.
+    //
+    // Cargo sets `CARGO_CFG_TARGET_OS` to the target, so this stays correct under
+    // cross-compilation, where `cfg!(target_os)` would describe the host instead.
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("linux") {
+        let script = "../scripts/fetch-tessdata.sh";
+        let model = "tessdata/eng.traineddata";
+
+        // Without the model as a trigger, deleting it would leave this build
+        // script cached and the absence unnoticed until the bundler failed much
+        // later.
+        println!("cargo:rerun-if-changed={script}");
+        println!("cargo:rerun-if-changed={model}");
+
+        let status = std::process::Command::new("bash")
+            .arg(script)
+            .status()
+            .unwrap_or_else(|e| panic!("{script} needs bash on PATH: {e}"));
+        assert!(
+            status.success(),
+            "{script} failed, so {model} is missing; see its output above"
+        );
+    }
+
     tauri_build::build()
 }

--- a/src-tauri/examples/riven_flag_hunt.rs
+++ b/src-tauri/examples/riven_flag_hunt.rs
@@ -1,0 +1,329 @@
+//! Differential hunt for the riven reroll screen's validity flag under Proton.
+//!
+//! The Windows scanner locates that flag with an instruction pattern (Pattern
+//! D-2). Ported to Linux the pattern matches exactly one site in the game's
+//! code, but the byte it points at reads 1 both with a reroll screen open and
+//! with the player in the orbiter, so it cannot drive the watcher.
+//!
+//! Rather than trusting the pattern, this finds the flag from its behaviour:
+//! dump the game module's writable memory in each state and keep the bytes that
+//! flip. The flag is a static in the executable, so the search is confined to
+//! the address span the game's own named mappings bracket — a few tens of
+//! megabytes rather than the multi-gigabyte address space.
+//!
+//! Usage, toggling the riven screen in game between snapshots:
+//!
+//!     cargo run --example riven_flag_hunt -- snapshot closed
+//!     cargo run --example riven_flag_hunt -- snapshot open
+//!     cargo run --example riven_flag_hunt -- diff closed open
+//!
+//! `diff` reports the bytes that were 0 in the first state and non-zero in the
+//! second. Repeating with more snapshots narrows the survivors further.
+
+use std::fs::File;
+use std::io::{BufWriter, Read, Write};
+use std::os::unix::fs::FileExt;
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let args: Vec<&str> = args.iter().map(String::as_str).collect();
+    let result = match args.as_slice() {
+        ["snapshot", label] => snapshot(label),
+        ["diff", before, after] => diff(before, after),
+        ["narrow", off, on, off_again] => narrow(off, on, off_again),
+        ["refs", target] => refs(target),
+        ["sig"] => sig(),
+        ["peek", addresses @ ..] if !addresses.is_empty() => peek(addresses),
+        _ => Err("usage: snapshot <label> | diff <before> <after> | peek <hex-address>…".into()),
+    };
+    if let Err(error) = result {
+        eprintln!("error: {error}");
+        std::process::exit(1);
+    }
+}
+
+/// The game's writable mappings, as (address, bytes) pairs.
+fn read_game_data(pid: u32) -> Result<Vec<(usize, Vec<u8>)>, String> {
+    let maps = std::fs::read_to_string(format!("/proc/{pid}/maps")).map_err(|e| e.to_string())?;
+    let memory = File::open(format!("/proc/{pid}/mem")).map_err(|e| {
+        format!("{e}. Ensure kernel.yama.ptrace_scope permits same-user process access")
+    })?;
+
+    // Wine leaves only the PE headers and one data section file-backed, so the
+    // module is the span its named mappings bracket, not the mappings alone.
+    let mut span: Option<(usize, usize)> = None;
+    for line in maps.lines() {
+        if line.to_ascii_lowercase().ends_with("warframe.x64.exe") {
+            let (start, end) = parse_range(line).ok_or("bad maps line")?;
+            span = Some(match span {
+                Some((low, high)) => (low.min(start), high.max(end)),
+                None => (start, end),
+            });
+        }
+    }
+    let (span_start, span_end) = span.ok_or("Warframe.x64.exe is not mapped")?;
+    println!("module span 0x{span_start:x}-0x{span_end:x}");
+
+    let mut regions = Vec::new();
+    for line in maps.lines() {
+        let permissions = line.split_whitespace().nth(1).unwrap_or("");
+        if !permissions.starts_with("rw") {
+            continue;
+        }
+        let Some((start, end)) = parse_range(line) else { continue };
+        if start < span_start || start >= span_end {
+            continue;
+        }
+        let mut buffer = vec![0; end - start];
+        match memory.read_at(&mut buffer, start as u64) {
+            Ok(read) => {
+                buffer.truncate(read);
+                regions.push((start, buffer));
+            }
+            // Mappings can vanish mid-walk; a partial picture is still usable.
+            Err(_) => continue,
+        }
+    }
+    Ok(regions)
+}
+
+fn parse_range(line: &str) -> Option<(usize, usize)> {
+    let (start, end) = line.split_whitespace().next()?.split_once('-')?;
+    Some((
+        usize::from_str_radix(start, 16).ok()?,
+        usize::from_str_radix(end, 16).ok()?,
+    ))
+}
+
+fn snapshot(label: &str) -> Result<(), String> {
+    let pid = find_warframe_pid().ok_or("Warframe is not running")?;
+    let regions = read_game_data(pid)?;
+    let total: usize = regions.iter().map(|(_, bytes)| bytes.len()).sum();
+
+    let path = format!("../tmp/riven-{label}.snapshot");
+    let mut out = BufWriter::new(File::create(&path).map_err(|e| e.to_string())?);
+    for (start, bytes) in &regions {
+        out.write_all(&(*start as u64).to_le_bytes()).map_err(|e| e.to_string())?;
+        out.write_all(&(bytes.len() as u64).to_le_bytes()).map_err(|e| e.to_string())?;
+        out.write_all(bytes).map_err(|e| e.to_string())?;
+    }
+    println!(
+        "wrote {path}: {} regions, {:.1} MiB",
+        regions.len(),
+        total as f64 / 1048576.0
+    );
+    Ok(())
+}
+
+fn load(label: &str) -> Result<Vec<(usize, Vec<u8>)>, String> {
+    let mut file = File::open(format!("../tmp/riven-{label}.snapshot")).map_err(|e| e.to_string())?;
+    let mut raw = Vec::new();
+    file.read_to_end(&mut raw).map_err(|e| e.to_string())?;
+
+    let mut regions = Vec::new();
+    let mut offset = 0;
+    while offset + 16 <= raw.len() {
+        let start = u64::from_le_bytes(raw[offset..offset + 8].try_into().expect("8 bytes")) as usize;
+        let len = u64::from_le_bytes(raw[offset + 8..offset + 16].try_into().expect("8 bytes")) as usize;
+        offset += 16;
+        if offset + len > raw.len() {
+            break;
+        }
+        regions.push((start, raw[offset..offset + len].to_vec()));
+        offset += len;
+    }
+    Ok(regions)
+}
+
+fn diff(before: &str, after: &str) -> Result<(), String> {
+    let before_regions = load(before)?;
+    let after_regions = load(after)?;
+
+    let mut flipped = Vec::new();
+    let mut compared = 0usize;
+    for (start, old) in &before_regions {
+        // Mappings are matched by base address; anything remapped between runs
+        // is skipped rather than compared against unrelated bytes.
+        let Some((_, new)) = after_regions.iter().find(|(other, _)| other == start) else {
+            continue;
+        };
+        let shared = old.len().min(new.len());
+        compared += shared;
+        for index in 0..shared {
+            if old[index] == 0 && new[index] != 0 {
+                flipped.push((start + index, new[index]));
+            }
+        }
+    }
+
+    println!(
+        "compared {:.1} MiB, {} bytes went 0 -> non-zero",
+        compared as f64 / 1048576.0,
+        flipped.len()
+    );
+    for (address, value) in flipped.iter().take(40) {
+        println!("  0x{address:012x} = {value}");
+    }
+    if flipped.len() > 40 {
+        println!("  … {} more", flipped.len() - 40);
+    }
+    Ok(())
+}
+
+/// Scan the game's code for the flag's writer and report where it points.
+///
+/// The sequence is `xchg dword ptr [rip+disp], r14d` followed by
+/// `cmp r14d, 1` — the atomic store the game uses to publish the riven
+/// selection state. Everything except the displacement is fixed, so the
+/// displacement is what yields the flag address on this launch.
+fn sig() -> Result<(), String> {
+    const PREFIX: [u8; 3] = [0x44, 0x87, 0x35];
+    const SUFFIX: [u8; 4] = [0x41, 0x83, 0xfe, 0x01];
+
+    let pid = find_warframe_pid().ok_or("Warframe is not running")?;
+    let maps = std::fs::read_to_string(format!("/proc/{pid}/maps")).map_err(|e| e.to_string())?;
+    let memory = File::open(format!("/proc/{pid}/mem")).map_err(|e| e.to_string())?;
+
+    let mut found = 0;
+    for line in maps.lines() {
+        let permissions = line.split_whitespace().nth(1).unwrap_or("");
+        if !permissions.starts_with("r-x") {
+            continue;
+        }
+        let Some((start, end)) = parse_range(line) else { continue };
+        let mut data = vec![0; end - start];
+        let Ok(read) = memory.read_at(&mut data, start as u64) else { continue };
+        let data = &data[..read];
+
+        for index in 0..data.len().saturating_sub(11) {
+            if data[index..index + 3] != PREFIX {
+                continue;
+            }
+            if data[index + 7..index + 11] != SUFFIX {
+                continue;
+            }
+            let displacement =
+                i32::from_le_bytes(data[index + 3..index + 7].try_into().expect("4 bytes")) as i64;
+            let flag = (start + index + 7) as i64 + displacement;
+            found += 1;
+            println!("site=0x{:012x} flag=0x{flag:x}", start + index);
+        }
+    }
+    println!("{found} signature matches");
+    Ok(())
+}
+
+/// Find the instructions that reference a known address RIP-relative, and print
+/// the bytes around each one.
+///
+/// Once the flag is identified by behaviour, its address is only good for this
+/// launch — the game is relocated on every start. A byte signature of the code
+/// that touches it is what survives, so this dumps the candidate call sites to
+/// build that signature from.
+fn refs(target: &str) -> Result<(), String> {
+    let target = usize::from_str_radix(target.trim_start_matches("0x"), 16)
+        .map_err(|e| format!("{target}: {e}"))?;
+    let pid = find_warframe_pid().ok_or("Warframe is not running")?;
+    let maps = std::fs::read_to_string(format!("/proc/{pid}/maps")).map_err(|e| e.to_string())?;
+    let memory = File::open(format!("/proc/{pid}/mem")).map_err(|e| e.to_string())?;
+
+    let mut hits = 0;
+    for line in maps.lines() {
+        let permissions = line.split_whitespace().nth(1).unwrap_or("");
+        if !permissions.starts_with("r-x") {
+            continue;
+        }
+        let Some((start, end)) = parse_range(line) else { continue };
+        let mut data = vec![0; end - start];
+        let Ok(read) = memory.read_at(&mut data, start as u64) else { continue };
+        let data = &data[..read];
+
+        for index in 0..data.len().saturating_sub(8) {
+            let displacement =
+                i32::from_le_bytes(data[index..index + 4].try_into().expect("4 bytes")) as i64;
+            // The displacement is relative to the end of the instruction, and
+            // instructions carry up to a few bytes of immediate after it, so
+            // every plausible tail length is tried.
+            let matches = (0..=8).any(|tail| {
+                (start + index + 4 + tail) as i64 + displacement == target as i64
+            });
+            if !matches {
+                continue;
+            }
+            hits += 1;
+            let context_start = index.saturating_sub(8);
+            let context: Vec<String> = data[context_start..(index + 8).min(data.len())]
+                .iter()
+                .map(|byte| format!("{byte:02x}"))
+                .collect();
+            println!(
+                "0x{:012x}  disp_at=+{}  bytes: {}",
+                start + context_start,
+                index - context_start,
+                context.join(" ")
+            );
+        }
+    }
+    println!("{hits} references found");
+    Ok(())
+}
+
+/// Keep only the bytes that track the screen across a full toggle: zero while
+/// it is closed, non-zero while it is open, zero again afterwards.
+///
+/// A single open/closed pair leaves thousands of survivors, because the game
+/// writes constantly. Requiring the byte to return to zero is what separates a
+/// flag from ordinary churn.
+fn narrow(off: &str, on: &str, off_again: &str) -> Result<(), String> {
+    let first = load(off)?;
+    let open = load(on)?;
+    let second = load(off_again)?;
+
+    let mut survivors = Vec::new();
+    for (start, closed) in &first {
+        let Some((_, opened)) = open.iter().find(|(other, _)| other == start) else { continue };
+        let Some((_, reclosed)) = second.iter().find(|(other, _)| other == start) else { continue };
+        let shared = closed.len().min(opened.len()).min(reclosed.len());
+        for index in 0..shared {
+            if closed[index] == 0 && opened[index] != 0 && reclosed[index] == 0 {
+                survivors.push((start + index, opened[index]));
+            }
+        }
+    }
+
+    println!("{} bytes follow the screen (0 / non-zero / 0)", survivors.len());
+    for (address, value) in survivors.iter().take(40) {
+        println!("  0x{address:012x} open-value={value}");
+    }
+    if survivors.len() > 40 {
+        println!("  … {} more", survivors.len() - 40);
+    }
+    Ok(())
+}
+
+/// Read individual bytes by address — for watching a candidate flag across game
+/// states without dumping anything.
+fn peek(addresses: &[&str]) -> Result<(), String> {
+    let pid = find_warframe_pid().ok_or("Warframe is not running")?;
+    let memory = File::open(format!("/proc/{pid}/mem")).map_err(|e| e.to_string())?;
+    println!("pid={pid}");
+    for address in addresses {
+        let parsed = usize::from_str_radix(address.trim_start_matches("0x"), 16)
+            .map_err(|e| format!("{address}: {e}"))?;
+        let mut byte = [0u8; 1];
+        match memory.read_at(&mut byte, parsed as u64) {
+            Ok(1) => println!("0x{parsed:012x} = {}", byte[0]),
+            _ => println!("0x{parsed:012x} = unreadable"),
+        }
+    }
+    Ok(())
+}
+
+fn find_warframe_pid() -> Option<u32> {
+    std::fs::read_dir("/proc").ok()?.filter_map(Result::ok).find_map(|entry| {
+        let pid = entry.file_name().to_str()?.parse().ok()?;
+        let command = std::fs::read(entry.path().join("cmdline")).ok()?;
+        let command = String::from_utf8_lossy(&command).to_ascii_lowercase();
+        (command.contains("warframe.x64.exe") && !command.contains("launcher.exe")).then_some(pid)
+    })
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,6 +23,10 @@ mod db;
 mod log_parser;
 mod memory_scanner;
 mod ocr;
+// Overlay placement is X11 work with no Windows counterpart — the Windows
+// overlay needs nothing beyond the window options Tauri already sets.
+#[cfg(target_os = "linux")]
+mod overlay_linux;
 mod wfcd;
 
 use db::{QuantityChange, SnapshotPoint, Trade, TrackedItem};
@@ -8618,6 +8622,37 @@ pub fn run() {
                 // monitors, and KWin clamps one to y=0 outright — either way the
                 // window has to be put away again right after show().
                 park_overlay_offscreen(app.handle(), "relic-overlay");
+                #[cfg(target_os = "linux")]
+                {
+                    // The band reports on the rewards and is never clicked, so
+                    // the pointer belongs to the game underneath it.
+                    let _ = win.set_ignore_cursor_events(true);
+                    overlay_linux::hint_before_map(&win, overlay_linux::AfterHinting::LeaveHidden);
+                }
+            }
+
+            // The riven panel is created from the frontend on demand and is on
+            // screen the moment it exists, so its hints are written from here
+            // rather than at a call site that would have to know about X11.
+            #[cfg(target_os = "linux")]
+            {
+                use tauri::Listener;
+                let handle = app.handle().clone();
+                app.listen("tauri://window-created", move |event| {
+                    #[derive(serde::Deserialize)]
+                    struct Created {
+                        label: String,
+                    }
+                    let Ok(created) = serde_json::from_str::<Created>(event.payload()) else {
+                        return;
+                    };
+                    if created.label != "riven-overlay" {
+                        return;
+                    }
+                    if let Some(win) = handle.get_webview_window(&created.label) {
+                        overlay_linux::hint_before_map(&win, overlay_linux::AfterHinting::ShowAgain);
+                    }
+                });
             }
 
             // Load relics.run prices in the background. On a cache hit (today's file exists)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2091,6 +2091,14 @@ fn parse_stat_groups(s: &str) -> Vec<Vec<String>> {
     all
 }
 
+/// Whether `text` (already lowercased) carries the riven screen's "FITS IN"
+/// panel label. The label is small enough on a 4K frame that Tesseract closes
+/// the word gap and reports "FITSIN", so both sides are compared with spaces
+/// removed — matching the spaced form alone rejected every screen tested.
+fn says_fits_in(text: &str) -> bool {
+    text.replace(' ', "").contains("fitsin")
+}
+
 /// Rejoin a riven card's OCR text into one line per stat.
 ///
 /// A stat starts with `+<digit>`, `-<digit>` or `x<digit>`; the digit matters
@@ -2457,6 +2465,7 @@ async fn ocr_riven_screen() -> Result<serde_json::Value, String> {
 
     let mut text = String::new();
     let mut full_text_for_fallback = String::new();
+    let mut panel_for_weapon = String::new();
     let mut confirmed = false;
 
     for attempt in 0..MAX_ATTEMPTS {
@@ -2480,7 +2489,15 @@ async fn ocr_riven_screen() -> Result<serde_json::Value, String> {
             // "FITS IN" is a two-word label in the far right panel. Over a whole
             // 4K frame it is small enough to be missed, so it gets the same
             // dedicated crop that riven_screen_visible reads it from.
-            let panel_text = ocr::ocr_pixels_rect_raw(&pixels, w, h, 0.73, 1.0, 0.30, 0.80, ocr::OcrLayout::Block)
+            //
+            // The crop runs to 95% of frame height because the weapon name sits
+            // under the panel's weapon icon at about 86% — below both this crop's
+            // old 80% bound and the full-frame pass's 82%, which is why the name
+            // was unreadable from anywhere. It is worth reaching for: the panel
+            // names the actual weapon ("Kuva Nukor") while the mod name above the
+            // card gives only the base weapon ("Nukor Crita-hexapha"), and the two
+            // carry different riven dispositions.
+            let panel_text = ocr::ocr_pixels_rect_raw(&pixels, w, h, 0.73, 1.0, 0.30, 0.95, ocr::OcrLayout::Block)
                 .unwrap_or_default();
             let _ = append_to_file(&riven_log2, &format!(
                 "[STEP 2] OCR attempt {} — {}\n├─ Full text:\n{}\n├─ Panel text:\n{}\n└─ Card text:\n{}\n\n",
@@ -2492,8 +2509,7 @@ async fn ocr_riven_screen() -> Result<serde_json::Value, String> {
         let (full_text, panel_text, card_text) = attempt_result;
         let lower = full_text.to_lowercase();
         let has_header  = lower.contains("inventory") || lower.contains("mods");
-        let has_fits_in = lower.contains("fits in")
-            || panel_text.to_lowercase().contains("fits in");
+        let has_fits_in = says_fits_in(&lower) || says_fits_in(&panel_text.to_lowercase());
 
         let _ = append_to_file(&riven_log, &format!(
             "[STEP 2] attempt {} — header={} fits_in={}\n",
@@ -2511,6 +2527,7 @@ async fn ocr_riven_screen() -> Result<serde_json::Value, String> {
         if (has_header && has_fits_in) || (has_header && comparison_likely) {
             text = card_text;
             full_text_for_fallback = full_text;
+            panel_for_weapon = panel_text;
             confirmed = true;
             if comparison_likely && !has_fits_in {
                 let _ = append_to_file(&riven_log, &format!(
@@ -2521,6 +2538,7 @@ async fn ocr_riven_screen() -> Result<serde_json::Value, String> {
         }
         text = card_text;
         full_text_for_fallback = full_text;
+        panel_for_weapon = panel_text;
     }
 
     if !confirmed {
@@ -2602,13 +2620,20 @@ async fn ocr_riven_screen() -> Result<serde_json::Value, String> {
         None
     };
 
-    let weapon = lines.iter().enumerate()
-        .find(|(_, l)| l.to_lowercase().contains("fits in"))
-        .and_then(|(i, _)| lines.get(i + 1))
-        .and_then(|l| {
-            let lc = l.trim().to_lowercase();
-            find_in_db(&lc).or(Some(lc))
-        })
+    // The "FITS IN" panel is the only place the game states the weapon outright,
+    // and it states the real one: a Kuva Nukor riven is titled "Nukor Crita-
+    // hexapha" above the card, which resolves to the ordinary Nukor and its
+    // different disposition. Take any panel line the database recognises — the
+    // surrounding panel chrome ("SHOW RANKED", icon debris) matches nothing.
+    let weapon = panel_for_weapon.lines()
+        .find_map(|l| find_in_db(&l.trim().to_lowercase()))
+        .or_else(|| lines.iter().enumerate()
+            .find(|(_, l)| says_fits_in(&l.to_lowercase()))
+            .and_then(|(i, _)| lines.get(i + 1))
+            .and_then(|l| {
+                let lc = l.trim().to_lowercase();
+                find_in_db(&lc).or(Some(lc))
+            }))
         // Fallback: first non-stat, non-UI line is the mod name "WeaponName RivenId".
         // Only accept if it matches a weapon in the DB — avoids returning currency values
         // like "D '5,598" (Endo count) that pass the basic filter.
@@ -8885,6 +8910,15 @@ X N,
             join_wrapped_stat_lines("+50% Critical Chance\nMR-1\n"),
             vec!["+50% Critical Chance"]
         );
+    }
+
+    /// Tesseract closes the gap in the panel label on every screen tested.
+    #[test]
+    fn the_fits_in_marker_is_matched_without_its_space() {
+        assert!(says_fits_in("fitsin"));
+        assert!(says_fits_in("fits in"));
+        assert!(says_fits_in("e\nfitsin\nkuva bramma"));
+        assert!(!says_fits_in("inventory/mods"));
     }
 
     /// Titles must not glue onto a stat, and a negative stat is a real curse

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7440,6 +7440,12 @@ fn show_overlay_window(
     ));
     let _ = win.show();
     let _ = win.set_always_on_top(true);
+    // The move above is only honoured on a later turn of the GTK main loop, and
+    // the window manager owns the window's position until then. Ask X directly
+    // so the band is on the game's monitor for its first frame rather than a
+    // second later.
+    #[cfg(target_os = "linux")]
+    overlay_linux::place(&win, x, y, w, h);
 
     // On Windows 10, WebView2 defers loading the page when the window starts
     // off-screen. If it's still on about:blank, navigate to the overlay URL now.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2503,9 +2503,9 @@ async fn ocr_riven_screen() -> Result<serde_json::Value, String> {
             let ts = chrono::Local::now().format("%H:%M:%S%.3f").to_string();
             let px = ocr::capture_warframe_pixels().map_err(|e| format!("Capture: {}", e))?;
             let (pixels, w, h) = px;
-            let full_text = ocr::ocr_pixels_rect(&pixels, w, h, 0.0, 1.0, 0.0, 0.82, ocr::OcrLayout::Scattered)
+            let full_text = ocr::ocr_pixels_rect(&pixels, w, h, 0.0, 1.0, 0.0, 0.82)
                 .unwrap_or_default();
-            let card_text = ocr::ocr_pixels_rect(&pixels, w, h, 0.20, 0.65, 0.28, 0.82, ocr::OcrLayout::Block)
+            let card_text = ocr::ocr_pixels_rect(&pixels, w, h, 0.20, 0.65, 0.28, 0.82)
                 .unwrap_or_default();
             // "FITS IN" is a two-word label in the far right panel. Over a whole
             // 4K frame it is small enough to be missed, so it gets the same
@@ -2518,7 +2518,7 @@ async fn ocr_riven_screen() -> Result<serde_json::Value, String> {
             // names the actual weapon ("Kuva Nukor") while the mod name above the
             // card gives only the base weapon ("Nukor Crita-hexapha"), and the two
             // carry different riven dispositions.
-            let panel_text = ocr::ocr_pixels_rect_raw(&pixels, w, h, 0.73, 1.0, 0.30, 0.95, ocr::OcrLayout::Block)
+            let panel_text = ocr::ocr_pixels_rect_raw(&pixels, w, h, 0.73, 1.0, 0.30, 0.95)
                 .unwrap_or_default();
             let _ = append_to_file(&riven_log2, &format!(
                 "[STEP 2] OCR attempt {} — {}\n├─ Full text:\n{}\n├─ Panel text:\n{}\n└─ Card text:\n{}\n\n",
@@ -2588,8 +2588,8 @@ async fn ocr_riven_screen() -> Result<serde_json::Value, String> {
             match ocr::capture_warframe_pixels() {
                 Ok((px, w, h)) => {
                     // Wider y range to catch element-icon stat lines near card bottom
-                    let left  = ocr::ocr_pixels_rect(&px, w, h, 0.18, 0.44, 0.25, 0.84, ocr::OcrLayout::Block).unwrap_or_default();
-                    let right = ocr::ocr_pixels_rect(&px, w, h, 0.44, 0.68, 0.25, 0.84, ocr::OcrLayout::Block).unwrap_or_default();
+                    let left  = ocr::ocr_pixels_rect(&px, w, h, 0.18, 0.44, 0.25, 0.84).unwrap_or_default();
+                    let right = ocr::ocr_pixels_rect(&px, w, h, 0.44, 0.68, 0.25, 0.84).unwrap_or_default();
                     let _ = append_to_file(&riven_log3, &format!(
                         "[STEP 2] Original (left):\n{}\n\nNew roll (right):\n{}\n\n", left, right
                     ));
@@ -3083,7 +3083,7 @@ fn riven_screen_status() -> String {
         return "unknown".into();
     };
 
-    let header = ocr::ocr_pixels_rect_raw(&pixels, w, h, 0.0, 0.55, 0.0, 0.10, ocr::OcrLayout::Block)
+    let header = ocr::ocr_pixels_rect_raw(&pixels, w, h, 0.0, 0.55, 0.0, 0.10)
         .unwrap_or_default();
     let in_inventory = header.to_lowercase().contains("inventory");
 
@@ -3092,7 +3092,7 @@ fn riven_screen_status() -> String {
         return "unknown".into();
     }
 
-    let right = ocr::ocr_pixels_rect_raw(&pixels, w, h, 0.73, 1.0, 0.30, 0.80, ocr::OcrLayout::Block)
+    let right = ocr::ocr_pixels_rect_raw(&pixels, w, h, 0.73, 1.0, 0.30, 0.80)
         .unwrap_or_default();
     let rl = right.to_lowercase();
     // In comparison mode "FITS IN" may be partially cut off, reading as "SIN", "IN", "TS IN" etc.
@@ -3126,7 +3126,7 @@ fn riven_screen_visible() -> bool {
 
     // Check header (x 0–55%, y 0–10%) for "INVENTORY" — confirms Warframe is focused
     // and we're in the mods screen. If header is absent, user alt-tabbed; keep overlay.
-    let header = ocr::ocr_pixels_rect_raw(&pixels, w, h, 0.0, 0.55, 0.0, 0.10, ocr::OcrLayout::Block)
+    let header = ocr::ocr_pixels_rect_raw(&pixels, w, h, 0.0, 0.55, 0.0, 0.10)
         .unwrap_or_default();
     let in_inventory = header.to_lowercase().contains("inventory");
 
@@ -3138,7 +3138,7 @@ fn riven_screen_visible() -> bool {
     }
 
     // Check right panel (x 73–100%, y 30–80%) for "FITS IN"
-    let right = ocr::ocr_pixels_rect_raw(&pixels, w, h, 0.73, 1.0, 0.30, 0.80, ocr::OcrLayout::Block)
+    let right = ocr::ocr_pixels_rect_raw(&pixels, w, h, 0.73, 1.0, 0.30, 0.80)
         .unwrap_or_default();
     let fits_in_visible = right.to_lowercase().contains("fits");
     let right_preview = right.lines().filter(|l| !l.trim().is_empty()).collect::<Vec<_>>().join(" | ");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -648,10 +648,18 @@ async fn scan_warframe_api_urls() -> Result<Vec<String>, String> {
     }).await.map_err(|e| e.to_string())?
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "linux")]
 #[tauri::command]
 async fn scan_warframe_api_urls() -> Result<Vec<String>, String> {
-    Err("Only supported on Windows".into())
+    tauri::async_runtime::spawn_blocking(memory_scanner::scan_api_url_strings)
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
+#[tauri::command]
+async fn scan_warframe_api_urls() -> Result<Vec<String>, String> {
+    Err("Only supported on Windows and Linux".into())
 }
 
 /// Persist mastery data (unique_name → rank 0-30) from the Companion API or any other source.
@@ -3089,17 +3097,11 @@ fn riven_screen_visible() -> bool {
 /// Read the riven validity flag byte. Returns None if Warframe is not running.
 /// Returns Some(true) = screen open, Some(false) = screen closed.
 /// Fails open (Some(true)) on read errors so the overlay is never falsely dismissed.
-#[cfg(target_os = "windows")]
+///
+/// Both platforms locate the flag the same way — the instruction pattern lives
+/// in the game's own image, which Proton maps unchanged — so only the one-byte
+/// read differs, and that lives behind `memory_scanner::read_process_byte`.
 fn read_riven_flag_byte() -> Option<bool> {
-    use windows_sys::Win32::{
-        Foundation::CloseHandle,
-        System::{
-            Diagnostics::Debug::ReadProcessMemory,
-            Threading::{OpenProcess, PROCESS_QUERY_INFORMATION, PROCESS_VM_READ},
-        },
-    };
-    use std::ffi::c_void;
-
     let pid = memory_scanner::find_warframe_pid_pub()?;
 
     let cache = RIVEN_FLAG_VA.get_or_init(|| std::sync::Mutex::new(None));
@@ -3117,23 +3119,10 @@ fn read_riven_flag_byte() -> Option<bool> {
     };
     drop(cached);
 
-    let handle = unsafe { OpenProcess(PROCESS_VM_READ | PROCESS_QUERY_INFORMATION, 0, pid) };
-    if handle == 0 { return Some(true); }
-
-    let mut byte: u8 = 0;
-    let mut read = 0usize;
-    let ok = unsafe {
-        ReadProcessMemory(handle, flag_va as *const c_void,
-            &mut byte as *mut u8 as *mut c_void, 1, &mut read)
-    };
-    unsafe { CloseHandle(handle); }
-
-    if ok == 0 || read == 0 { return Some(true); } // read failed — fail open
-    Some(byte != 0)
+    // Read failure means the mapping moved or access was lost, not that the
+    // screen closed — fail open so an active overlay is never dismissed.
+    Some(memory_scanner::read_process_byte(pid, flag_va).map_or(true, |byte| byte != 0))
 }
-
-#[cfg(not(target_os = "windows"))]
-fn read_riven_flag_byte() -> Option<bool> { None }
 
 /// Background thread: polls the riven validity flag every 200 ms and emits
 /// riven-screen-open-mem / riven-screen-close-mem on state transitions.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8566,6 +8566,13 @@ pub fn run() {
         .setup(|app| {
             use tauri::Manager;
 
+            // Every Linux bundle carries its own Tesseract language model. Point
+            // the OCR engine at it before anything can call it.
+            #[cfg(target_os = "linux")]
+            if let Ok(dir) = app.path().resource_dir() {
+                ocr::use_bundled_tessdata(&dir);
+            }
+
             // Spin up a tiny local HTTP server that serves cached item images from disk.
             // This is more reliable than convertFileSrc (which needs assetProtocol scope).
             // Bind the std listener here (sync) to get the port, then convert to tokio

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2091,6 +2091,27 @@ fn parse_stat_groups(s: &str) -> Vec<Vec<String>> {
     all
 }
 
+/// Weapon-name candidates from the "FITS IN" panel's OCR, top to bottom.
+///
+/// The panel is mostly icon and border debris — single glyphs, punctuation —
+/// with the weapon name and the panel's own buttons as the only real words, so a
+/// candidate is a line of at least four letters that is not one of those
+/// buttons. The name sits below the "FITS IN" label and above "SHOW RANKED",
+/// which is why callers take the last candidate rather than the first.
+fn panel_weapon_candidates(panel: &str) -> Vec<String> {
+    panel
+        .lines()
+        .map(|l| l.trim().to_lowercase())
+        .filter(|l| {
+            l.chars().filter(|c| c.is_alphabetic()).count() >= 4
+                && !says_fits_in(l)
+                && !l.contains("show ranked")
+                && !l.contains("close")
+                && !l.contains("cancel")
+        })
+        .collect()
+}
+
 /// Whether `text` (already lowercased) carries the riven screen's "FITS IN"
 /// panel label. The label is small enough on a 4K frame that Tesseract closes
 /// the word gap and reports "FITSIN", so both sides are compared with spaces
@@ -2625,8 +2646,17 @@ async fn ocr_riven_screen() -> Result<serde_json::Value, String> {
     // hexapha" above the card, which resolves to the ordinary Nukor and its
     // different disposition. Take any panel line the database recognises — the
     // surrounding panel chrome ("SHOW RANKED", icon debris) matches nothing.
-    let weapon = panel_for_weapon.lines()
-        .find_map(|l| find_in_db(&l.trim().to_lowercase()))
+    //
+    // The grading sheet is a curated list, not a weapon index — it carries
+    // "kuva bramma" but not "kuva nukor" — so a panel name it does not know is
+    // still the right answer. Reporting it unmatched costs the roll analysis
+    // (`analyze_riven` returns nothing for an unknown weapon, which the UI
+    // already handles) and buys not silently grading a Kuva Nukor as the base
+    // Nukor it is titled after, on a different disposition.
+    let panel_candidates = panel_weapon_candidates(&panel_for_weapon);
+    let weapon = panel_candidates.iter()
+        .find_map(|l| find_in_db(l))
+        .or_else(|| panel_candidates.last().cloned())
         .or_else(|| lines.iter().enumerate()
             .find(|(_, l)| says_fits_in(&l.to_lowercase()))
             .and_then(|(i, _)| lines.get(i + 1))
@@ -8910,6 +8940,26 @@ X N,
             join_wrapped_stat_lines("+50% Critical Chance\nMR-1\n"),
             vec!["+50% Critical Chance"]
         );
+    }
+
+    /// Verbatim panel OCR from the three example screens. The weapon name has to
+    /// survive whether or not the grading sheet lists it — "kuva nukor" is not in
+    /// the sheet, and reporting the base Nukor in its place would grade the roll
+    /// against a different weapon's disposition.
+    #[test]
+    fn the_panel_yields_the_weapon_name_over_its_own_chrome() {
+        let nukor = "o\n=\n\\\n[\"\no\nIN\nﬁ ‘A l“')\n—\nKuva Nukor\n";
+        assert_eq!(panel_weapon_candidates(nukor).last().unwrap(), "kuva nukor");
+
+        let bramma = "-\nD\n)\nA\n~\n3\n¥\nFITSIN\ne\nKuva Bramma\nSHOW RANKED\n";
+        assert_eq!(panel_weapon_candidates(bramma).last().unwrap(), "kuva bramma");
+
+        // The single-card screen adds a CLOSE button below SHOW RANKED.
+        let single = "\\\nE_ 3\n-\n-~\nFITSIN\n@\nKuva Bramma\nSHOW RANKED\nCLOSE\n";
+        assert_eq!(panel_weapon_candidates(single).last().unwrap(), "kuva bramma");
+
+        // A panel that read as nothing but debris must not name a weapon.
+        assert!(panel_weapon_candidates("\\“ \\\n>~ ‘\n").is_empty());
     }
 
     /// Tesseract closes the gap in the panel label on every screen tested.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2473,21 +2473,27 @@ async fn ocr_riven_screen() -> Result<serde_json::Value, String> {
             let ts = chrono::Local::now().format("%H:%M:%S%.3f").to_string();
             let px = ocr::capture_warframe_pixels().map_err(|e| format!("Capture: {}", e))?;
             let (pixels, w, h) = px;
-            let full_text = ocr::ocr_pixels_rect(&pixels, w, h, 0.0, 1.0, 0.0, 0.82)
+            let full_text = ocr::ocr_pixels_rect(&pixels, w, h, 0.0, 1.0, 0.0, 0.82, ocr::OcrLayout::Scattered)
                 .unwrap_or_default();
-            let card_text = ocr::ocr_pixels_rect(&pixels, w, h, 0.20, 0.65, 0.28, 0.82)
+            let card_text = ocr::ocr_pixels_rect(&pixels, w, h, 0.20, 0.65, 0.28, 0.82, ocr::OcrLayout::Block)
+                .unwrap_or_default();
+            // "FITS IN" is a two-word label in the far right panel. Over a whole
+            // 4K frame it is small enough to be missed, so it gets the same
+            // dedicated crop that riven_screen_visible reads it from.
+            let panel_text = ocr::ocr_pixels_rect_raw(&pixels, w, h, 0.73, 1.0, 0.30, 0.80, ocr::OcrLayout::Block)
                 .unwrap_or_default();
             let _ = append_to_file(&riven_log2, &format!(
-                "[STEP 2] OCR attempt {} — {}\n├─ Full text:\n{}\n└─ Card text:\n{}\n\n",
-                attempt + 1, ts, full_text, card_text
+                "[STEP 2] OCR attempt {} — {}\n├─ Full text:\n{}\n├─ Panel text:\n{}\n└─ Card text:\n{}\n\n",
+                attempt + 1, ts, full_text, panel_text, card_text
             ));
-            Ok::<_, String>((full_text, card_text))
+            Ok::<_, String>((full_text, panel_text, card_text))
         }).await.map_err(|e| format!("Task: {}", e))??;
 
-        let (full_text, card_text) = attempt_result;
+        let (full_text, panel_text, card_text) = attempt_result;
         let lower = full_text.to_lowercase();
         let has_header  = lower.contains("inventory") || lower.contains("mods");
-        let has_fits_in = lower.contains("fits in");
+        let has_fits_in = lower.contains("fits in")
+            || panel_text.to_lowercase().contains("fits in");
 
         let _ = append_to_file(&riven_log, &format!(
             "[STEP 2] attempt {} — header={} fits_in={}\n",
@@ -2543,8 +2549,8 @@ async fn ocr_riven_screen() -> Result<serde_json::Value, String> {
             match ocr::capture_warframe_pixels() {
                 Ok((px, w, h)) => {
                     // Wider y range to catch element-icon stat lines near card bottom
-                    let left  = ocr::ocr_pixels_rect(&px, w, h, 0.18, 0.44, 0.25, 0.84).unwrap_or_default();
-                    let right = ocr::ocr_pixels_rect(&px, w, h, 0.44, 0.68, 0.25, 0.84).unwrap_or_default();
+                    let left  = ocr::ocr_pixels_rect(&px, w, h, 0.18, 0.44, 0.25, 0.84, ocr::OcrLayout::Block).unwrap_or_default();
+                    let right = ocr::ocr_pixels_rect(&px, w, h, 0.44, 0.68, 0.25, 0.84, ocr::OcrLayout::Block).unwrap_or_default();
                     let _ = append_to_file(&riven_log3, &format!(
                         "[STEP 2] Original (left):\n{}\n\nNew roll (right):\n{}\n\n", left, right
                     ));
@@ -3022,7 +3028,7 @@ fn riven_screen_status() -> String {
         return "unknown".into();
     };
 
-    let header = ocr::ocr_pixels_rect_raw(&pixels, w, h, 0.0, 0.55, 0.0, 0.10)
+    let header = ocr::ocr_pixels_rect_raw(&pixels, w, h, 0.0, 0.55, 0.0, 0.10, ocr::OcrLayout::Block)
         .unwrap_or_default();
     let in_inventory = header.to_lowercase().contains("inventory");
 
@@ -3031,7 +3037,7 @@ fn riven_screen_status() -> String {
         return "unknown".into();
     }
 
-    let right = ocr::ocr_pixels_rect_raw(&pixels, w, h, 0.73, 1.0, 0.30, 0.80)
+    let right = ocr::ocr_pixels_rect_raw(&pixels, w, h, 0.73, 1.0, 0.30, 0.80, ocr::OcrLayout::Block)
         .unwrap_or_default();
     let rl = right.to_lowercase();
     // In comparison mode "FITS IN" may be partially cut off, reading as "SIN", "IN", "TS IN" etc.
@@ -3065,7 +3071,7 @@ fn riven_screen_visible() -> bool {
 
     // Check header (x 0–55%, y 0–10%) for "INVENTORY" — confirms Warframe is focused
     // and we're in the mods screen. If header is absent, user alt-tabbed; keep overlay.
-    let header = ocr::ocr_pixels_rect_raw(&pixels, w, h, 0.0, 0.55, 0.0, 0.10)
+    let header = ocr::ocr_pixels_rect_raw(&pixels, w, h, 0.0, 0.55, 0.0, 0.10, ocr::OcrLayout::Block)
         .unwrap_or_default();
     let in_inventory = header.to_lowercase().contains("inventory");
 
@@ -3077,7 +3083,7 @@ fn riven_screen_visible() -> bool {
     }
 
     // Check right panel (x 73–100%, y 30–80%) for "FITS IN"
-    let right = ocr::ocr_pixels_rect_raw(&pixels, w, h, 0.73, 1.0, 0.30, 0.80)
+    let right = ocr::ocr_pixels_rect_raw(&pixels, w, h, 0.73, 1.0, 0.30, 0.80, ocr::OcrLayout::Block)
         .unwrap_or_default();
     let fits_in_visible = right.to_lowercase().contains("fits");
     let right_preview = right.lines().filter(|l| !l.trim().is_empty()).collect::<Vec<_>>().join(" | ");
@@ -3098,12 +3104,11 @@ fn riven_screen_visible() -> bool {
 /// Returns Some(true) = screen open, Some(false) = screen closed.
 /// Fails open (Some(true)) on read errors so the overlay is never falsely dismissed.
 ///
-/// Both platforms locate the flag the same way — the instruction pattern lives
-/// in the game's own image, which Proton maps unchanged — so only the one-byte
-/// read differs, and that lives behind `memory_scanner::read_process_byte`.
-fn read_riven_flag_byte() -> Option<bool> {
-    let pid = memory_scanner::find_warframe_pid_pub()?;
-
+/// Takes the PID from the caller: enumerating processes costs a `/proc` walk on
+/// Linux and a snapshot on Windows, and the only caller polls five times a
+/// second, so looking it up again here would double that for no new
+/// information.
+fn read_riven_flag_byte(pid: u32) -> Option<bool> {
     let cache = RIVEN_FLAG_VA.get_or_init(|| std::sync::Mutex::new(None));
     let mut cached = cache.lock().unwrap_or_else(|e| e.into_inner());
     if cached.map_or(true, |(p, _)| p != pid) {
@@ -3142,8 +3147,8 @@ fn start_riven_memory_watcher(app: tauri::AppHandle) {
         loop {
             std::thread::sleep(std::time::Duration::from_millis(200));
 
-            let pid_found = memory_scanner::find_warframe_pid_pub().is_some();
-            if !pid_found {
+            let pid = memory_scanner::find_warframe_pid_pub();
+            let Some(pid) = pid else {
                 // Warframe not running — reset state
                 if warframe_was_running {
                     prev_open = false;
@@ -3151,10 +3156,10 @@ fn start_riven_memory_watcher(app: tauri::AppHandle) {
                     warframe_was_running = false;
                 }
                 continue;
-            }
+            };
             warframe_was_running = true;
 
-            match read_riven_flag_byte() {
+            match read_riven_flag_byte(pid) {
                 None => {
                     // Warframe running but pattern VA not found yet — don't change state,
                     // just wait. This avoids a false open event on app start.
@@ -5401,9 +5406,7 @@ async fn start_monitor(app: tauri::AppHandle, state: State<'_, AppState>) -> Res
                         ));
                     }
 
-                    if let Some(win) = ee_ocr_app.get_webview_window("relic-overlay") {
-                        let _ = win.set_position(tauri::Position::Physical(tauri::PhysicalPosition { x: 0, y: -3000 }));
-                    }
+                    park_overlay_offscreen(&ee_ocr_app, "relic-overlay");
                     if let Ok(mut g) = ee_ocr_app.state::<AppState>().pending_relic_rewards.lock() { *g = None; }
                     let _ = ee_ocr_app.emit("relic-rewards", serde_json::Value::Null);
                 }
@@ -5770,9 +5773,7 @@ async fn start_monitor(app: tauri::AppHandle, state: State<'_, AppState>) -> Res
                                                 tokio::time::sleep(std::time::Duration::from_secs(20)).await;
                                                 if let Ok(mut g) = app2.state::<AppState>().pending_relic_rewards.lock() { *g = None; }
                                                 let _ = app2.emit("relic-rewards", serde_json::Value::Null);
-                                                if let Some(w) = app2.get_webview_window("relic-overlay") {
-                                                    let _ = w.set_position(tauri::Position::Physical(tauri::PhysicalPosition { x: 0, y: -3000 }));
-                                                }
+                                                park_overlay_offscreen(&app2, "relic-overlay");
                                                 append_to_diag(&slog2,
                                                     "[STEP 4] AUTO-DISMISS (20s safety fallback)\n\n");
                                                 if let Ok(mut g) = diag_arc_fb.lock() {
@@ -5828,9 +5829,7 @@ async fn start_monitor(app: tauri::AppHandle, state: State<'_, AppState>) -> Res
                                             tokio::time::sleep(std::time::Duration::from_secs(20)).await;
                                             if let Ok(mut g) = app2.state::<AppState>().pending_relic_rewards.lock() { *g = None; }
                                             let _ = app2.emit("relic-rewards", serde_json::Value::Null);
-                                            if let Some(w) = app2.get_webview_window("relic-overlay") {
-                                                let _ = w.set_position(tauri::Position::Physical(tauri::PhysicalPosition { x: 0, y: -3000 }));
-                                            }
+                                            park_overlay_offscreen(&app2, "relic-overlay");
                                             let _ = append_to_file(&slog2,
                                                 "[STEP 4] AUTO-DISMISS (20s safety fallback)\n\n");
                                             if let Ok(mut g) = diag_arc_fb.lock() {
@@ -5923,9 +5922,7 @@ async fn start_monitor(app: tauri::AppHandle, state: State<'_, AppState>) -> Res
                                 let _ = app.emit("relic-rewards", &emit_val);
                                 let _ = append_to_file(&slog,
                                     "[STEP 2] OCR TIMEOUT — 45 seconds elapsed, emitting best result\n\n");
-                                if let Some(win) = app.get_webview_window("relic-overlay") {
-                                    let _ = win.set_position(tauri::Position::Physical(tauri::PhysicalPosition { x: 0, y: -3000 }));
-                                }
+                                park_overlay_offscreen(&app, "relic-overlay");
                                 active.store(false, Ordering::SeqCst);
                                 if let Ok(mut g) = diag_arc2.lock() {
                                     if let Some(folder) = g.take() {
@@ -5964,9 +5961,7 @@ async fn start_monitor(app: tauri::AppHandle, state: State<'_, AppState>) -> Res
                         reward_screen_active2.store(false, Ordering::SeqCst);
                         active_since = None;
                         last_dismiss_at = Some(std::time::Instant::now());
-                        if let Some(win) = ee_ocr_app.get_webview_window("relic-overlay") {
-                            let _ = win.set_position(tauri::Position::Physical(tauri::PhysicalPosition { x: 0, y: -3000 }));
-                        }
+                        park_overlay_offscreen(&ee_ocr_app, "relic-overlay");
                         if let Ok(mut g) = ee_ocr_app.state::<AppState>().pending_relic_rewards.lock() { *g = None; }
                         let _ = ee_ocr_app.emit("relic-rewards", serde_json::Value::Null);
                     }
@@ -7347,6 +7342,26 @@ fn debug_create_window(app: tauri::AppHandle) -> Result<String, String> {
     .map_err(|e| format!("build() failed: {e}"))
 }
 
+/// Visually hide an overlay window without destroying it.
+///
+/// The two platforms need opposite primitives here. On Windows the window is
+/// parked off-screen because `hide()` on a transparent WebView2 window breaks
+/// DirectComposition — JS keeps running but its pixels stop reaching the screen,
+/// so the overlay comes back blank. On Linux `hide()` is the only thing that
+/// works: KWin keeps windows inside the desktop and clamps y=-3000 back to 0,
+/// which would leave the transparent overlay parked over the primary monitor.
+fn park_overlay_offscreen(app: &tauri::AppHandle, label: &str) {
+    use tauri::Manager;
+    let Some(win) = app.get_webview_window(label) else { return };
+    #[cfg(target_os = "linux")]
+    let _ = win.hide();
+    #[cfg(not(target_os = "linux"))]
+    let _ = win.set_position(tauri::Position::Physical(tauri::PhysicalPosition {
+        x: 0,
+        y: -3000,
+    }));
+}
+
 /// Reposition the pre-declared relic-overlay window and bring it on screen.
 /// The overlay is pre-declared in tauri.conf.json at y=-3000 (off-screen) so
 /// WebView2 initialises at app startup. We never create/destroy it — just move it.
@@ -7390,12 +7405,7 @@ fn show_overlay_window(
 /// Destroying and recreating transparent WebView2 windows deadlocks on Windows.
 #[tauri::command]
 fn move_overlay_offscreen(app: tauri::AppHandle) -> Result<(), String> {
-    use tauri::Manager;
-    if let Some(win) = app.get_webview_window("relic-overlay") {
-        let _ = win.set_position(tauri::Position::Physical(
-            tauri::PhysicalPosition { x: 0, y: -3000 }
-        ));
-    }
+    park_overlay_offscreen(&app, "relic-overlay");
     Ok(())
 }
 
@@ -7439,9 +7449,7 @@ fn hide_test_overlay_window(app: tauri::AppHandle) -> Result<(), String> {
     let win = app.get_webview_window("overlay-test")
         .ok_or_else(|| "overlay-test window not found".to_string())?;
     let _ = win.set_always_on_top(false);
-    let _ = win.set_position(tauri::Position::Physical(
-        tauri::PhysicalPosition { x: 0, y: -3000 }
-    ));
+    park_overlay_offscreen(&app, "overlay-test");
     eprintln!("[OVERLAY-TEST] hide_test_overlay_window: moved offscreen");
     Ok(())
 }
@@ -7605,7 +7613,9 @@ struct PlatformCapabilities {
 fn get_platform_capabilities() -> PlatformCapabilities {
     PlatformCapabilities {
         linux: cfg!(target_os = "linux"),
-        ocr: cfg!(target_os = "windows"),
+        // Linux grabs the game window over X11 and reads it with Tesseract, so
+        // every screen-reading feature is available there too.
+        ocr: cfg!(any(target_os = "windows", target_os = "linux")),
         persistent_credentials: cfg!(target_os = "windows"),
     }
 }
@@ -7781,8 +7791,12 @@ async fn capture_diagnostics(state: State<'_, AppState>) -> Result<String, Strin
 /// both exclude the window title bar and borders in windowed mode.
 #[tauri::command]
 fn get_warframe_window_rect() -> Result<[i32; 4], String> {
-    #[cfg(not(target_os = "windows"))]
-    { return Err("Windows only".into()); }
+    // Linux reads the geometry from the same X11 window the capture grabs, so the
+    // rect and the captured frame can never describe different areas.
+    #[cfg(target_os = "linux")]
+    { return ocr::warframe_window_rect(); }
+    #[cfg(not(any(target_os = "windows", target_os = "linux")))]
+    { return Err("Windows and Linux only".into()); }
     #[cfg(target_os = "windows")]
     {
         use windows_sys::Win32::Foundation::{POINT, RECT};
@@ -8331,6 +8345,27 @@ fn restore_window_state(app: &tauri::AppHandle, window: &tauri::WebviewWindow, s
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // ==========================================================================
+    // Linux: run the GTK/WebKit side under XWayland, not native Wayland
+    // ==========================================================================
+    //
+    // The relic and riven overlays exist to sit exactly on top of the game
+    // window, and they are hidden by being parked off-screen. Wayland gives a
+    // client no say in where its own surfaces go, so under the native backend
+    // `set_position` silently does nothing: the overlay would appear wherever the
+    // compositor decided, and "hiding" it off-screen would leave it on screen.
+    //
+    // Forcing GDK to the X11 backend restores absolute positioning and
+    // always-on-top, and it costs nothing in fidelity here — Warframe itself runs
+    // under XWayland (it is a Proton/Wine X11 client), so the overlay ends up in
+    // the same coordinate space as the window it tracks.
+    //
+    // Set before any GTK call, which for Tauri means before the builder runs.
+    #[cfg(target_os = "linux")]
+    if std::env::var_os("GDK_BACKEND").is_none() {
+        std::env::set_var("GDK_BACKEND", "x11");
+    }
+
     let data_dir = dirs::data_local_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join("warframe-companion");
@@ -8508,26 +8543,19 @@ pub fn run() {
             }
 
             // Overlay windows start as visible:false in tauri.conf.json.
-            // We call show() here (while they are still at y=-3000) so WebView2 can
-            // initialise their content in the background without flashing on screen.
-            // We NEVER call hide() on relic-overlay — hiding a transparent WebView2
-            // window breaks DirectComposition: JS keeps running but pixels stop reaching
-            // the screen.  Instead we park it at y=-3000 and move it on-screen during
-            // fissures.  overlay-test is not transparent so hide() is safe for it, but
-            // we use the same show()-once pattern for consistency.
-            // show() triggers WebView2 initialisation; immediately park off-screen so
-            // nothing is visible to the user at startup.
-            // We NEVER call hide() on relic-overlay — hiding a transparent WebView2
-            // window breaks DirectComposition.
+            // Overlay windows start as visible:false in tauri.conf.json. show() here
+            // triggers webview initialisation so the first fissure doesn't pay for it,
+            // and the window is put away again immediately so nothing flashes on
+            // screen. How "away" is achieved differs per platform — see
+            // park_overlay_offscreen.
             // Only relic-overlay needs pre-initialization at startup (to avoid the
             // WebView2 init delay on the first fissure).  overlay-test is on-demand only.
             if let Some(win) = app.get_webview_window("relic-overlay") {
                 let _ = win.show();
                 // Windows may reposition a newly-shown window that is outside all
-                // monitors.  Force it back off-screen immediately after show().
-                let _ = win.set_position(tauri::Position::Physical(
-                    tauri::PhysicalPosition { x: 0, y: -3000 }
-                ));
+                // monitors, and KWin clamps one to y=0 outright — either way the
+                // window has to be put away again right after show().
+                park_overlay_offscreen(app.handle(), "relic-overlay");
             }
 
             // Load relics.run prices in the background. On a cache hit (today's file exists)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,6 +18,9 @@ use tauri::{Emitter, Manager, State};
 
 mod console_login; // [console-login feature] remove this line to drop the feature
 mod db;
+// EE.log lives at a different path per platform (Proton prefix on Linux), so
+// path construction lives here rather than being inlined at each watcher.
+mod log_parser;
 mod memory_scanner;
 mod ocr;
 mod wfcd;
@@ -561,64 +564,11 @@ async fn scan_warframe_credentials() -> Result<(String, String, String), String>
 }
 
 fn scan_warframe_credentials_sync() -> Result<(String, String, String), String> {
-    #[cfg(not(target_os = "windows"))]
-    { return Err("Only supported on Windows".into()); }
-    #[cfg(target_os = "windows")]
-    use windows_sys::Win32::{
-        Foundation::CloseHandle,
-        System::{
-            Diagnostics::Debug::ReadProcessMemory,
-            Memory::{VirtualQueryEx, MEMORY_BASIC_INFORMATION, MEM_COMMIT, PAGE_GUARD, PAGE_NOACCESS},
-            Threading::{OpenProcess, PROCESS_QUERY_INFORMATION, PROCESS_VM_READ},
-        },
-    };
-    use std::ffi::c_void;
-    use std::mem;
-
-    let pid = memory_scanner::find_warframe_pid_pub()
-        .ok_or("Warframe is not running")?;
-
-    unsafe {
-        let process = OpenProcess(PROCESS_VM_READ | PROCESS_QUERY_INFORMATION, 0, pid);
-        if process == 0 { return Err("Cannot open Warframe process".into()); }
-
-        let mut address: usize = 0x10000;
-        let mbi_size = mem::size_of::<MEMORY_BASIC_INFORMATION>();
-
-        loop {
-            let mut mbi: MEMORY_BASIC_INFORMATION = mem::zeroed();
-            if VirtualQueryEx(process, address as *const c_void, &mut mbi, mbi_size) == 0 { break; }
-            let region_end = (mbi.BaseAddress as usize).saturating_add(mbi.RegionSize);
-            if region_end <= address { break; }
-            address = region_end;
-
-            if mbi.State != MEM_COMMIT { continue; }
-            let p = mbi.Protect;
-            if p & PAGE_NOACCESS != 0 || p & PAGE_GUARD != 0 { continue; }
-            if p == 0x10 || p == 0x20 { continue; }
-            if mbi.RegionSize > 128 * 1024 * 1024 { continue; }
-
-            let mut buffer = vec![0u8; mbi.RegionSize];
-            let mut bytes_read: usize = 0;
-            let ok = ReadProcessMemory(
-                process, mbi.BaseAddress as *const c_void,
-                buffer.as_mut_ptr() as *mut c_void, mbi.RegionSize, &mut bytes_read,
-            );
-            if ok == 0 || bytes_read == 0 { continue; }
-
-            if let Some((id, nonce)) = memory_scanner::scan_auth_credentials(&buffer[..bytes_read]) {
-                let steam_id = memory_scanner::scan_steam_id(&buffer[..bytes_read]).unwrap_or_default();
-                CloseHandle(process);
-                return Ok((id, nonce, steam_id));
-            }
-        }
-        CloseHandle(process);
-    }
-    Err("Credentials not found in memory. Make sure you are in the orbiter (not loading screen) and Warframe has been running for a few minutes.".into())
-
+    memory_scanner::scan_warframe_credentials_process()
 }
 
 /// Scan Warframe memory for API request URLs — reveals exact endpoints the game uses.
+#[cfg(target_os = "windows")]
 #[tauri::command]
 async fn scan_warframe_api_urls() -> Result<Vec<String>, String> {
     tauri::async_runtime::spawn_blocking(|| {
@@ -696,6 +646,12 @@ async fn scan_warframe_api_urls() -> Result<Vec<String>, String> {
         }
         Ok(found)
     }).await.map_err(|e| e.to_string())?
+}
+
+#[cfg(not(target_os = "windows"))]
+#[tauri::command]
+async fn scan_warframe_api_urls() -> Result<Vec<String>, String> {
+    Err("Only supported on Windows".into())
 }
 
 /// Persist mastery data (unique_name → rank 0-30) from the Companion API or any other source.
@@ -1823,6 +1779,36 @@ fn wfm_delete_credentials() -> Result<(), String> {
     Ok(())
 }
 
+// ==============================================================================
+// Non-Windows credential storage
+// ==============================================================================
+//
+// Persisting the WFM session needs an OS-encrypted store; only the Windows
+// Credential Manager is wired up. Rather than fall back to a plaintext file,
+// Linux refuses to save and reports "no saved session" on load, so the UI hides
+// the "stay logged in" controls and the user logs in each run.
+//
+// ponytail: no Linux keyring; add libsecret/DBus if session persistence is wanted.
+
+#[cfg(not(target_os = "windows"))]
+#[tauri::command]
+fn wfm_save_credentials(email: String, password: String) -> Result<(), String> {
+    let _ = (email, password);
+    Err("Saving credentials is only supported on Windows".into())
+}
+
+#[cfg(not(target_os = "windows"))]
+#[tauri::command]
+fn wfm_load_credentials() -> Result<Option<(String, String)>, String> {
+    Ok(None)
+}
+
+#[cfg(not(target_os = "windows"))]
+#[tauri::command]
+fn wfm_delete_credentials() -> Result<(), String> {
+    Ok(())
+}
+
 /// Clear the stored WFM session.
 #[tauri::command]
 fn wfm_logout(state: State<AppState>) {
@@ -2833,14 +2819,62 @@ fn parse_trade_dialog(raw: &str) -> Option<ParsedTrade> {
     })
 }
 
+// ==============================================================================
+// EE.log wake-up source
+// ==============================================================================
+//
+// Both log watchers want to react the instant Warframe flushes a line. Windows
+// gets that for free from FindFirstChangeNotificationW, which blocks until the
+// log directory is written. Linux has no equivalent wired up here, so it falls
+// back to polling at the caller's interval — a few extra wake-ups per second,
+// but the surrounding loop stays identical on both platforms.
+//
+// ponytail: polling on Linux; switch to inotify if wake-up latency matters.
+
+/// Open a directory-change notification for EE.log's folder, or `None` when the
+/// platform or the call cannot provide one (the caller then polls).
+#[cfg(target_os = "windows")]
+fn open_log_notifier(log_path: &std::path::Path) -> Option<isize> {
+    use windows_sys::Win32::Storage::FileSystem::{
+        FindFirstChangeNotificationW, FILE_NOTIFY_CHANGE_LAST_WRITE,
+    };
+    let dir = log_path.parent().unwrap_or(std::path::Path::new("."));
+    let dir_wide: Vec<u16> = dir.to_string_lossy().encode_utf16().chain(std::iter::once(0)).collect();
+    let handle = unsafe { FindFirstChangeNotificationW(dir_wide.as_ptr(), 0, FILE_NOTIFY_CHANGE_LAST_WRITE) };
+    (handle != -1).then_some(handle) // -1 = INVALID_HANDLE_VALUE
+}
+
+#[cfg(not(target_os = "windows"))]
+fn open_log_notifier(_log_path: &std::path::Path) -> Option<isize> { None }
+
+/// Block until EE.log's directory is written, or until `poll` elapses when no
+/// notifier is available. The 500 ms notification timeout keeps loops that check
+/// a stop flag responsive even while the game is idle.
+#[cfg(target_os = "windows")]
+fn wait_for_log_change(notifier: Option<isize>, poll: std::time::Duration) {
+    use windows_sys::Win32::Storage::FileSystem::FindNextChangeNotification;
+    use windows_sys::Win32::System::Threading::WaitForSingleObject;
+    let Some(handle) = notifier else {
+        std::thread::sleep(poll);
+        return;
+    };
+    unsafe {
+        WaitForSingleObject(handle, 500);
+        FindNextChangeNotification(handle);
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn wait_for_log_change(_notifier: Option<isize>, poll: std::time::Duration) {
+    std::thread::sleep(poll);
+}
+
 /// Start a lightweight EE.log watcher for features that don't need the memory scanner:
 /// riven reroll detection, trade completion detection, WFM whisper detection.
 /// Called unconditionally at app startup — EE.log is plain file I/O, not memory reading.
 #[tauri::command]
 fn start_log_watcher(app: tauri::AppHandle) -> Result<(), String> {
-    let log_path = dirs::data_local_dir()
-        .map(|d| d.join("Warframe").join("EE.log"))
-        .ok_or("Cannot find LocalAppData")?;
+    let log_path = log_parser::default_log_path().ok_or("Cannot find the local data directory")?;
 
     std::thread::spawn(move || {
         use std::io::{Read, Seek, SeekFrom};
@@ -2850,28 +2884,12 @@ fn start_log_watcher(app: tauri::AppHandle) -> Result<(), String> {
         // Guards against the same EE.log buffer being processed twice by React StrictMode listeners.
         let mut last_riven_fire: Option<std::time::Instant> = None;
 
-        // Use FindFirstChangeNotificationW so we wake up the instant EE.log is written,
-        // instead of sleeping and polling. This is how Overwolf achieves low latency.
-        let change_handle: isize = {
-            use windows_sys::Win32::Storage::FileSystem::{
-                FindFirstChangeNotificationW, FILE_NOTIFY_CHANGE_LAST_WRITE,
-            };
-            let dir = log_path.parent().unwrap_or(std::path::Path::new("."));
-            let dir_wide: Vec<u16> = dir.to_string_lossy().encode_utf16().chain(std::iter::once(0)).collect();
-            unsafe { FindFirstChangeNotificationW(dir_wide.as_ptr(), 0, FILE_NOTIFY_CHANGE_LAST_WRITE) }
-        };
-        let use_notify = change_handle != -1; // -1 = INVALID_HANDLE_VALUE
+        // Wake up the instant EE.log is written instead of sleeping and polling.
+        // This is how Overwolf achieves low latency.
+        let notifier = open_log_notifier(&log_path);
 
         loop {
-            if use_notify {
-                use windows_sys::Win32::System::Threading::WaitForSingleObject;
-                use windows_sys::Win32::Storage::FileSystem::FindNextChangeNotification;
-                // Block until EE.log directory has a write — then process immediately
-                unsafe { WaitForSingleObject(change_handle, 500); } // 500ms safety timeout
-                unsafe { FindNextChangeNotification(change_handle); }
-            } else {
-                std::thread::sleep(std::time::Duration::from_millis(50));
-            }
+            wait_for_log_change(notifier, std::time::Duration::from_millis(50));
             let Ok(mut f) = std::fs::File::open(&log_path) else { continue };
             let len = std::fs::metadata(&log_path).map(|m| m.len()).unwrap_or(0);
             if len < file_pos { file_pos = 0; }
@@ -4969,8 +4987,7 @@ async fn start_monitor(app: tauri::AppHandle, state: State<'_, AppState>) -> Res
     // Void Fissure reward selection screen becomes active.  All open-source
     // tools (WFInfo, warframeocr, Sentinel) use this string as their trigger.
     // We tail the log file instead of relying on fragile OCR gate heuristics.
-    let ee_log_path = dirs::data_local_dir()
-        .map(|d| d.join("Warframe").join("EE.log"));
+    let ee_log_path = log_parser::default_log_path();
 
     // Shared flag: true while the reward screen is active according to EE.log
     let reward_screen_active = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -5095,31 +5112,13 @@ async fn start_monitor(app: tauri::AppHandle, state: State<'_, AppState>) -> Res
             // Created at trigger, BMP written after overlay confirmed, session log at dismiss.
             let diag_arc: Arc<Mutex<Option<std::path::PathBuf>>> = Arc::new(Mutex::new(None));
 
-            // Use FindFirstChangeNotificationW so we wake the instant EE.log is
-            // written to disk instead of sleeping 200 ms between checks.
-            let change_handle: isize = {
-                use windows_sys::Win32::Storage::FileSystem::{
-                    FindFirstChangeNotificationW, FILE_NOTIFY_CHANGE_LAST_WRITE,
-                };
-                let dir = log_path.parent().unwrap_or(std::path::Path::new("."));
-                let dir_wide: Vec<u16> = dir.to_string_lossy()
-                    .encode_utf16().chain(std::iter::once(0)).collect();
-                unsafe { FindFirstChangeNotificationW(dir_wide.as_ptr(), 0, FILE_NOTIFY_CHANGE_LAST_WRITE) }
-            };
-            let use_notify = change_handle != -1isize; // -1 = INVALID_HANDLE_VALUE
+            // Wake the instant EE.log is written to disk instead of sleeping
+            // 200 ms between checks.
+            let notifier = open_log_notifier(&log_path);
 
             loop {
                 if !flag.load(Ordering::SeqCst) { break; }
-                if use_notify {
-                    use windows_sys::Win32::System::Threading::WaitForSingleObject;
-                    use windows_sys::Win32::Storage::FileSystem::FindNextChangeNotification;
-                    // Block until a write lands in the EE.log directory (500 ms safety timeout
-                    // keeps the flag check alive even when the game isn't writing).
-                    unsafe { WaitForSingleObject(change_handle, 500); }
-                    unsafe { FindNextChangeNotification(change_handle); }
-                } else {
-                    std::thread::sleep(std::time::Duration::from_millis(200));
-                }
+                wait_for_log_change(notifier, std::time::Duration::from_millis(200));
                 let Ok(mut f) = std::fs::File::open(&log_path) else { continue };
                 let len = std::fs::metadata(&log_path).map(|m| m.len()).unwrap_or(0);
                 if len < file_pos { file_pos = 0; }
@@ -7602,6 +7601,26 @@ async fn prewarm_image_cache(state: tauri::State<'_, AppState>) -> Result<(), St
     Ok(())
 }
 
+/// What the running platform can actually do, so the UI hides controls that
+/// would only ever return an error instead of letting the user discover the
+/// limitation by clicking.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PlatformCapabilities {
+    linux: bool,
+    ocr: bool,
+    persistent_credentials: bool,
+}
+
+#[tauri::command]
+fn get_platform_capabilities() -> PlatformCapabilities {
+    PlatformCapabilities {
+        linux: cfg!(target_os = "linux"),
+        ocr: cfg!(target_os = "windows"),
+        persistent_credentials: cfg!(target_os = "windows"),
+    }
+}
+
 #[tauri::command]
 fn open_debug_folder(state: State<AppState>, which: String) -> Result<(), String> {
     let path: std::path::PathBuf = match which.as_str() {
@@ -7613,7 +7632,10 @@ fn open_debug_folder(state: State<AppState>, which: String) -> Result<(), String
         _ => return Err("Unknown debug folder".into()),
     };
     std::fs::create_dir_all(&path).ok();
-    std::process::Command::new("explorer")
+    // `xdg-open` is the desktop-agnostic equivalent of Windows' `explorer`; it
+    // hands the folder to whichever file manager the session has configured.
+    let file_manager = if cfg!(target_os = "windows") { "explorer" } else { "xdg-open" };
+    std::process::Command::new(file_manager)
         .arg(path.to_string_lossy().as_ref())
         .spawn()
         .map_err(|e| e.to_string())?;
@@ -7813,13 +7835,30 @@ fn get_blueprint_names(state: State<AppState>) -> HashMap<String, String> {
 
 #[tauri::command]
 fn get_system_locale() -> String {
-    let mut buf = [0u16; 85]; // LOCALE_NAME_MAX_LENGTH
-    let len = unsafe { windows_sys::Win32::Globalization::GetUserDefaultLocaleName(buf.as_mut_ptr(), buf.len() as i32) };
-    if len > 1 {
-        String::from_utf16_lossy(&buf[..(len as usize - 1)])
-    } else {
-        "en-US".to_string()
+    #[cfg(target_os = "windows")]
+    {
+        let mut buf = [0u16; 85]; // LOCALE_NAME_MAX_LENGTH
+        let len = unsafe { windows_sys::Win32::Globalization::GetUserDefaultLocaleName(buf.as_mut_ptr(), buf.len() as i32) };
+        if len > 1 {
+            return String::from_utf16_lossy(&buf[..(len as usize - 1)]);
+        }
     }
+    #[cfg(not(target_os = "windows"))]
+    {
+        // POSIX locales look like "de_DE.UTF-8" or "de_DE@euro"; the frontend
+        // feeds this to Intl, which wants a BCP-47 tag like "de-DE". LC_TIME
+        // outranks LANG because the locale only ever picks the clock format.
+        let posix = ["LC_ALL", "LC_TIME", "LANG"].iter()
+            .filter_map(|v| std::env::var(v).ok())
+            .find(|s| !s.is_empty());
+        if let Some(lang) = posix {
+            let tag = lang.split(['.', '@']).next().unwrap_or("").replace('_', "-");
+            if !tag.is_empty() && tag != "C" && tag != "POSIX" {
+                return tag;
+            }
+        }
+    }
+    "en-US".to_string()
 }
 
 // ─── App entry point ──────────────────────────────────────────────────────────
@@ -8599,6 +8638,7 @@ pub fn run() {
             wfm_refresh_token,
             wfm_set_jwt,
             wfm_get_jwt,
+            get_platform_capabilities,
             wfm_save_credentials,
             wfm_load_credentials,
             wfm_delete_credentials,

--- a/src-tauri/src/log_parser.rs
+++ b/src-tauri/src/log_parser.rs
@@ -118,21 +118,490 @@ pub fn get_default_log_path() -> Option<String> {
         .map(|p| p.to_string_lossy().to_string())
 }
 
+// ==============================================================================
+// Linux: locating EE.log across Steam libraries and Wine prefixes
+// ==============================================================================
+//
+// On Linux, Warframe runs under Proton, which keeps its Windows prefix beside
+// the game rather than in one fixed place. Nothing about the location is fixed:
+//
+//   * The prefix lives in whichever Steam *library folder* holds the game, so
+//     an install on a second drive is nowhere near the Steam install. Steam
+//     indexes its libraries in `libraryfolders.vdf`, which we read rather than
+//     guessing at mount points.
+//   * Steam itself sits in one of three places, depending on how it was
+//     packaged — native, the legacy `~/.steam` layout, or Flatpak. Each has its
+//     own library index, so all three are read; a Flatpak Steam with games on a
+//     second drive needs its own vdf just as the native one does.
+//   * The username *inside* the prefix is `steamuser` under Proton, but an
+//     older Proton or a hand-made prefix uses the Linux login name.
+//
+// The result is a list of candidate paths rather than one computed path, which
+// is why this is a search and not a `join`.
+
+/// Warframe's Steam application ID, which names its Proton prefix directory.
+#[cfg(target_os = "linux")]
+const WARFRAME_APPID: &str = "230410";
+
+/// The username Proton creates inside a prefix, regardless of the Linux login.
+#[cfg(target_os = "linux")]
+const PROTON_WIN_USER: &str = "steamuser";
+
+/// The Windows-side walk from a prefix's `drive_c` down to the log.
+#[cfg(target_os = "linux")]
+fn log_within_drive_c(drive_c: &Path, win_user: &str) -> PathBuf {
+    drive_c
+        .join("users")
+        .join(win_user)
+        .join("AppData/Local/Warframe/EE.log")
+}
+
+/// Warframe's Proton prefix inside a given Steam library root.
+///
+/// Steam creates this at install time, before the game has ever run.
+#[cfg(target_os = "linux")]
+fn prefix_within(library: &Path) -> PathBuf {
+    library.join("steamapps/compatdata").join(WARFRAME_APPID)
+}
+
+/// Where EE.log sits inside a given Steam library root, for one prefix user.
+#[cfg(target_os = "linux")]
+fn ee_log_within(library: &Path, win_user: &str) -> PathBuf {
+    log_within_drive_c(&prefix_within(library).join("pfx/drive_c"), win_user)
+}
+
+/// One place EE.log could be, and how to recognise its install without it.
+#[cfg(target_os = "linux")]
+struct Candidate {
+    log: PathBuf,
+    /// The Proton prefix this log belongs to, when the candidate is a Steam
+    /// install. Steam creates the prefix at install time, so its presence
+    /// identifies the right library before the game has written any log at
+    /// all. A plain Wine prefix has no equivalent marker, hence `None`.
+    prefix: Option<PathBuf>,
+}
+
+/// Steam installations to search, most conventional first.
+///
+/// `~/.steam/steam` is usually a symlink into the native path and Flatpak's is
+/// genuinely separate; probing all three costs a few `stat` calls and spares us
+/// having to tell which packaging is in use.
+#[cfg(target_os = "linux")]
+fn steam_roots(data_dir: &Path, home: &Path) -> Vec<PathBuf> {
+    vec![
+        data_dir.join("Steam"),
+        home.join(".steam/steam"),
+        home.join(".var/app/com.valvesoftware.Steam/.local/share/Steam"),
+    ]
+}
+
+/// Every library folder belonging to one Steam install: the root itself, plus
+/// whatever its own index lists.
+///
+/// A missing or unreadable index is not an error — it just means this Steam
+/// root has no extra libraries, or is not the packaging in use on this machine.
+#[cfg(target_os = "linux")]
+fn libraries_under(root: &Path) -> Vec<PathBuf> {
+    let mut libraries = vec![root.to_path_buf()];
+
+    if let Ok(vdf) = std::fs::read_to_string(root.join("steamapps/libraryfolders.vdf")) {
+        // Steam lists the root among its own libraries, so this usually
+        // repeats the entry above; the caller de-duplicates.
+        libraries.extend(library_paths(&vdf));
+    }
+
+    libraries
+}
+
+/// Every path EE.log could occupy on this machine, best-guess first.
+#[cfg(target_os = "linux")]
+fn ee_log_candidates(data_dir: &Path, home: &Path, win_users: &[String]) -> Vec<Candidate> {
+    let mut candidates = Vec::new();
+
+    for root in steam_roots(data_dir, home) {
+        for library in libraries_under(&root) {
+            for win_user in win_users {
+                candidates.push(Candidate {
+                    log: ee_log_within(&library, win_user),
+                    prefix: Some(prefix_within(&library)),
+                });
+            }
+        }
+    }
+
+    // A hand-made Wine prefix, for an install Steam knows nothing about. There
+    // is no compatdata directory to recognise it by, so it can only be found by
+    // the log already being there.
+    for win_user in win_users {
+        candidates.push(Candidate {
+            log: log_within_drive_c(&home.join(".wine/drive_c"), win_user),
+            prefix: None,
+        });
+    }
+
+    // Roots overlap in the common case — the native root is listed in its own
+    // vdf, and `~/.steam/steam` usually points at it — so the same log path can
+    // be reached several ways. Keep the first occurrence of each.
+    let mut seen = std::collections::HashSet::new();
+    candidates.retain(|candidate| seen.insert(candidate.log.clone()));
+
+    candidates
+}
+
+/// The best candidate that something on disk actually corroborates.
+#[cfg(target_os = "linux")]
+fn resolve_candidate(candidates: &[Candidate]) -> Option<PathBuf> {
+    candidates
+        .iter()
+        // An existing EE.log is the strongest signal: that is the prefix
+        // Warframe actually ran from.
+        .find(|candidate| candidate.log.exists())
+        .or_else(|| {
+            // No log yet, which is the normal state before the game's first
+            // run. An existing prefix still says which install will hold it.
+            candidates.iter().find(|candidate| {
+                candidate
+                    .prefix
+                    .as_deref()
+                    .is_some_and(|prefix| prefix.is_dir())
+            })
+        })
+        .map(|candidate| candidate.log.clone())
+}
+
+/// Windows usernames to try inside a prefix, in order of likelihood.
+///
+/// Takes the Linux login name rather than reading the environment itself, so
+/// the "which names are worth trying" rule can be tested without the
+/// process-wide environment mutation that would race other tests.
+#[cfg(target_os = "linux")]
+fn windows_users(login: Option<&str>) -> Vec<String> {
+    let mut users = vec![PROTON_WIN_USER.to_string()];
+
+    // An empty login is what a stripped environment yields; pushing it would
+    // build a path with an empty component that can never match anything.
+    if let Some(login) = login.filter(|user| !user.is_empty() && *user != PROTON_WIN_USER) {
+        users.push(login.to_string());
+    }
+
+    users
+}
+
+/// The library roots listed in a `libraryfolders.vdf`, in file order.
+///
+/// Deliberately not a real VDF parser. The only field we need is the `"path"`
+/// of each entry, and every way the file can be malformed degrades to "no
+/// matches" — which the caller already handles by falling back to the default
+/// library. A parser would add a dependency to gain nothing but stricter
+/// failure.
+///
+/// TODO: VDF escapes backslashes in Windows-style paths (`\\`). Library paths
+/// written by Steam on Linux are POSIX and contain none, so unescaping is
+/// omitted.
+#[cfg(target_os = "linux")]
+fn library_paths(vdf: &str) -> Vec<PathBuf> {
+    let entry = match Regex::new(r#""path"\s*"([^"]+)""#) {
+        Ok(regex) => regex,
+        Err(_) => return vec![],
+    };
+
+    entry
+        .captures_iter(vdf)
+        .filter_map(|caps| caps.get(1))
+        .map(|path| PathBuf::from(path.as_str()))
+        .collect()
+}
+
+/// The search proper, with its two environment inputs passed in so tests can
+/// point it at a fake layout instead of the machine it runs on.
+#[cfg(target_os = "linux")]
+fn linux_log_path_in(data_dir: &Path, home: &Path, win_users: &[String]) -> PathBuf {
+    resolve_candidate(&ee_log_candidates(data_dir, home, win_users))
+        // Nothing on disk corroborates any candidate: Warframe is not
+        // installed, or lives somewhere none of the above covers. The watchers
+        // start before the game does and need a path regardless, so name where
+        // a stock Proton install would put it.
+        .unwrap_or_else(|| ee_log_within(&data_dir.join("Steam"), PROTON_WIN_USER))
+}
+
 #[cfg(target_os = "linux")]
 fn linux_log_path(data_dir: &Path) -> PathBuf {
-    data_dir.join("Steam/steamapps/compatdata/230410/pfx/drive_c/users/steamuser/AppData/Local/Warframe/EE.log")
+    // Without a home directory the Flatpak, legacy and Wine candidates are all
+    // unreachable; `data_dir` still yields the native Steam root, which is the
+    // one that matters.
+    let home = dirs::home_dir().unwrap_or_else(|| data_dir.to_path_buf());
+
+    let login = std::env::var("USER")
+        .or_else(|_| std::env::var("LOGNAME"))
+        .ok();
+
+    linux_log_path_in(data_dir, &home, &windows_users(login.as_deref()))
 }
 
 #[cfg(all(test, target_os = "linux"))]
 mod linux_tests {
     use super::*;
+    use std::fs;
+
+    /// A throwaway directory for one test's fake Steam layout.
+    ///
+    /// Cheaper than a `tempfile` dependency for the handful of tests here, and
+    /// the name is unique per test because each call site passes its own tag.
+    fn scratch_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("ff-eelog-{}-{}", std::process::id(), tag));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("temp dir is writable in a test environment");
+        dir
+    }
+
+    /// Write a `libraryfolders.vdf` listing `libraries`, in Steam's own format.
+    fn write_vdf(steam_root: &Path, libraries: &[&Path]) {
+        let mut vdf = String::from("\"libraryfolders\"\n{\n");
+        for (index, library) in libraries.iter().enumerate() {
+            vdf.push_str(&format!(
+                "\t\"{}\"\n\t{{\n\t\t\"path\"\t\t\"{}\"\n\t\t\"label\"\t\t\"\"\n\t}}\n",
+                index,
+                library.display()
+            ));
+        }
+        vdf.push_str("}\n");
+
+        let steamapps = steam_root.join("steamapps");
+        fs::create_dir_all(&steamapps).expect("scratch dir was just created");
+        fs::write(steamapps.join("libraryfolders.vdf"), vdf).expect("scratch dir is writable");
+    }
+
+    /// Create an empty file at `log`, along with the directories above it.
+    fn plant(log: PathBuf) -> PathBuf {
+        fs::create_dir_all(log.parent().expect("EE.log always has a parent directory"))
+            .expect("scratch dir is writable");
+        fs::write(&log, "").expect("scratch dir is writable");
+        log
+    }
+
+    /// Create an empty EE.log in `library`, as a stock Proton install would.
+    fn plant_ee_log(library: &Path) -> PathBuf {
+        plant(ee_log_within(library, PROTON_WIN_USER))
+    }
+
+    /// The usernames a stock Proton machine would search.
+    fn stock_users() -> Vec<String> {
+        vec![PROTON_WIN_USER.to_string()]
+    }
+
+    /// Run the search against a fake layout, with no home-directory sources.
+    ///
+    /// Tests that care about `~/.steam`, Flatpak or Wine pass their own home.
+    fn search(data_dir: &Path) -> PathBuf {
+        linux_log_path_in(data_dir, Path::new("/nonexistent-home"), &stock_users())
+    }
 
     #[test]
     fn builds_proton_log_path_from_linux_data_dir() {
-        let path = linux_log_path(Path::new("/home/player/.local/share"));
+        let path = search(Path::new("/home/player/.local/share"));
         assert_eq!(
             path,
             Path::new("/home/player/.local/share/Steam/steamapps/compatdata/230410/pfx/drive_c/users/steamuser/AppData/Local/Warframe/EE.log")
         );
+    }
+
+    #[test]
+    fn reads_every_library_root_listed_in_the_vdf() {
+        let vdf = "\"libraryfolders\"\n{\n\
+                   \t\"0\"\n\t{\n\t\t\"path\"\t\t\"/home/player/.local/share/Steam\"\n\t}\n\
+                   \t\"1\"\n\t{\n\t\t\"path\"\t\t\"/mnt/games/SteamLibrary\"\n\t}\n\
+                   }\n";
+
+        assert_eq!(
+            library_paths(vdf),
+            vec![
+                PathBuf::from("/home/player/.local/share/Steam"),
+                PathBuf::from("/mnt/games/SteamLibrary"),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_malformed_vdf_yields_no_libraries_rather_than_an_error() {
+        // Truncated mid-entry, which is what a vdf looks like if Steam was
+        // killed while rewriting it.
+        let vdf = "\"libraryfolders\"\n{\n\t\"0\"\n\t{\n\t\t\"pa";
+
+        assert!(library_paths(vdf).is_empty());
+    }
+
+    #[test]
+    fn finds_ee_log_in_a_secondary_library() {
+        let scratch = scratch_dir("secondary");
+        let data_dir = scratch.join("local-share");
+        let secondary = scratch.join("mnt-games-SteamLibrary");
+
+        write_vdf(
+            &data_dir.join("Steam"),
+            &[&data_dir.join("Steam"), &secondary],
+        );
+        let planted = plant_ee_log(&secondary);
+
+        assert_eq!(search(&data_dir), planted);
+
+        let _ = fs::remove_dir_all(&scratch);
+    }
+
+    #[test]
+    fn points_at_the_library_holding_the_prefix_before_the_game_has_run() {
+        let scratch = scratch_dir("prefix-only");
+        let data_dir = scratch.join("local-share");
+        let secondary = scratch.join("mnt-games-SteamLibrary");
+
+        write_vdf(
+            &data_dir.join("Steam"),
+            &[&data_dir.join("Steam"), &secondary],
+        );
+
+        // Warframe is installed to the secondary library — Steam created the
+        // Proton prefix — but it has never been launched, so there is no
+        // EE.log to find yet.
+        fs::create_dir_all(prefix_within(&secondary).join("pfx")).expect("scratch dir is writable");
+
+        assert_eq!(
+            search(&data_dir),
+            ee_log_within(&secondary, PROTON_WIN_USER)
+        );
+
+        let _ = fs::remove_dir_all(&scratch);
+    }
+
+    #[test]
+    fn falls_back_to_the_default_library_when_the_appid_is_in_no_library() {
+        let scratch = scratch_dir("missing-appid");
+        let data_dir = scratch.join("local-share");
+        let secondary = scratch.join("mnt-games-SteamLibrary");
+
+        // Both libraries exist and are indexed, but neither holds Warframe.
+        write_vdf(
+            &data_dir.join("Steam"),
+            &[&data_dir.join("Steam"), &secondary],
+        );
+
+        // The watchers start before the game does, so we still owe them the
+        // path EE.log *would* occupy in the default library.
+        assert_eq!(
+            search(&data_dir),
+            ee_log_within(&data_dir.join("Steam"), PROTON_WIN_USER)
+        );
+
+        let _ = fs::remove_dir_all(&scratch);
+    }
+
+    #[test]
+    fn finds_ee_log_under_flatpak_steam() {
+        let scratch = scratch_dir("flatpak");
+        let data_dir = scratch.join("local-share");
+        let home = scratch.join("home");
+
+        // Nothing is installed natively; Steam came from Flathub.
+        let flatpak = home.join(".var/app/com.valvesoftware.Steam/.local/share/Steam");
+        let planted = plant_ee_log(&flatpak);
+
+        assert_eq!(linux_log_path_in(&data_dir, &home, &stock_users()), planted);
+
+        let _ = fs::remove_dir_all(&scratch);
+    }
+
+    #[test]
+    fn finds_ee_log_under_the_legacy_steam_root() {
+        let scratch = scratch_dir("legacy-root");
+        let data_dir = scratch.join("local-share");
+        let home = scratch.join("home");
+
+        let planted = plant_ee_log(&home.join(".steam/steam"));
+
+        assert_eq!(linux_log_path_in(&data_dir, &home, &stock_users()), planted);
+
+        let _ = fs::remove_dir_all(&scratch);
+    }
+
+    #[test]
+    fn reads_the_library_index_of_each_steam_root_not_only_the_native_one() {
+        let scratch = scratch_dir("flatpak-secondary");
+        let data_dir = scratch.join("local-share");
+        let home = scratch.join("home");
+        let secondary = scratch.join("mnt-games-SteamLibrary");
+
+        // Flatpak Steam, with the game itself on a second drive: the only
+        // index naming that drive belongs to the Flatpak install, so a search
+        // that reads just the native root's vdf would never see it.
+        let flatpak = home.join(".var/app/com.valvesoftware.Steam/.local/share/Steam");
+        write_vdf(&flatpak, &[&flatpak, &secondary]);
+        let planted = plant_ee_log(&secondary);
+
+        assert_eq!(linux_log_path_in(&data_dir, &home, &stock_users()), planted);
+
+        let _ = fs::remove_dir_all(&scratch);
+    }
+
+    #[test]
+    fn finds_ee_log_in_a_plain_wine_prefix() {
+        let scratch = scratch_dir("wine");
+        let data_dir = scratch.join("local-share");
+        let home = scratch.join("home");
+
+        // A non-Steam install, so the prefix carries the Linux login name and
+        // there is no compatdata directory anywhere.
+        let users = vec![PROTON_WIN_USER.to_string(), "player".to_string()];
+        let planted = plant(log_within_drive_c(&home.join(".wine/drive_c"), "player"));
+
+        assert_eq!(linux_log_path_in(&data_dir, &home, &users), planted);
+
+        let _ = fs::remove_dir_all(&scratch);
+    }
+
+    #[test]
+    fn finds_ee_log_when_the_prefix_uses_the_linux_login_name() {
+        let scratch = scratch_dir("login-name");
+        let data_dir = scratch.join("local-share");
+        let home = scratch.join("home");
+
+        // An older Proton, or a prefix made by hand: same Steam layout, but
+        // the user directory inside it is not `steamuser`.
+        let users = vec![PROTON_WIN_USER.to_string(), "player".to_string()];
+        let planted = plant(ee_log_within(&data_dir.join("Steam"), "player"));
+
+        assert_eq!(linux_log_path_in(&data_dir, &home, &users), planted);
+
+        let _ = fs::remove_dir_all(&scratch);
+    }
+
+    #[test]
+    fn tries_the_linux_login_name_only_when_it_adds_something() {
+        assert_eq!(windows_users(Some("player")), vec!["steamuser", "player"]);
+
+        // Nothing to add: no login, an empty one, or one that already matches
+        // what Proton would have created.
+        assert_eq!(windows_users(None), vec!["steamuser"]);
+        assert_eq!(windows_users(Some("")), vec!["steamuser"]);
+        assert_eq!(windows_users(Some("steamuser")), vec!["steamuser"]);
+    }
+
+    #[test]
+    fn offers_each_candidate_path_only_once() {
+        let scratch = scratch_dir("dedup");
+        let data_dir = scratch.join("local-share");
+        let home = scratch.join("home");
+
+        // Steam names its own root in its index, which is the usual case and
+        // would otherwise yield the same candidate twice.
+        let native = data_dir.join("Steam");
+        write_vdf(&native, &[&native]);
+
+        let candidates = ee_log_candidates(&data_dir, &home, &stock_users());
+        let mut logs: Vec<_> = candidates.iter().map(|c| c.log.clone()).collect();
+        let before = logs.len();
+        logs.sort();
+        logs.dedup();
+
+        assert_eq!(logs.len(), before, "candidate list repeats a path");
+
+        let _ = fs::remove_dir_all(&scratch);
     }
 }

--- a/src-tauri/src/log_parser.rs
+++ b/src-tauri/src/log_parser.rs
@@ -2,6 +2,8 @@ use regex::Regex;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Seek, SeekFrom};
 use std::path::Path;
+#[cfg(target_os = "linux")]
+use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
 pub struct ParsedReward {
@@ -96,7 +98,35 @@ impl LogParser {
 
 pub fn get_default_log_path() -> Option<String> {
     dirs::data_local_dir()
-        .map(|d| d.join("Warframe").join("EE.log"))
+        .map(|data_dir| {
+            #[cfg(target_os = "linux")]
+            {
+                linux_log_path(&data_dir)
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                data_dir.join("Warframe").join("EE.log")
+            }
+        })
         .filter(|p| p.exists())
         .map(|p| p.to_string_lossy().to_string())
+}
+
+#[cfg(target_os = "linux")]
+fn linux_log_path(data_dir: &Path) -> PathBuf {
+    data_dir.join("Steam/steamapps/compatdata/230410/pfx/drive_c/users/steamuser/AppData/Local/Warframe/EE.log")
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod linux_tests {
+    use super::*;
+
+    #[test]
+    fn builds_proton_log_path_from_linux_data_dir() {
+        let path = linux_log_path(Path::new("/home/player/.local/share"));
+        assert_eq!(
+            path,
+            Path::new("/home/player/.local/share/Steam/steamapps/compatdata/230410/pfx/drive_c/users/steamuser/AppData/Local/Warframe/EE.log")
+        );
+    }
 }

--- a/src-tauri/src/log_parser.rs
+++ b/src-tauri/src/log_parser.rs
@@ -1,9 +1,7 @@
 use regex::Regex;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Seek, SeekFrom};
-use std::path::Path;
-#[cfg(target_os = "linux")]
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone)]
 pub struct ParsedReward {
@@ -96,18 +94,26 @@ impl LogParser {
     }
 }
 
+/// Where EE.log lives, whether or not Warframe has written it yet.
+///
+/// The log watchers start before the game does, so they need the path even
+/// when the file is still absent; callers that require an existing file use
+/// [`get_default_log_path`] instead.
+pub fn default_log_path() -> Option<PathBuf> {
+    dirs::data_local_dir().map(|data_dir| {
+        #[cfg(target_os = "linux")]
+        {
+            linux_log_path(&data_dir)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            data_dir.join("Warframe").join("EE.log")
+        }
+    })
+}
+
 pub fn get_default_log_path() -> Option<String> {
-    dirs::data_local_dir()
-        .map(|data_dir| {
-            #[cfg(target_os = "linux")]
-            {
-                linux_log_path(&data_dir)
-            }
-            #[cfg(not(target_os = "linux"))]
-            {
-                data_dir.join("Warframe").join("EE.log")
-            }
-        })
+    default_log_path()
         .filter(|p| p.exists())
         .map(|p| p.to_string_lossy().to_string())
 }

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -1,4 +1,6 @@
-﻿use serde::{Deserialize, Serialize};
+﻿#[cfg(target_os = "linux")]
+use aho_corasick::AhoCorasick;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 #[cfg(target_os = "linux")]
 use std::fs::File;
@@ -1486,6 +1488,21 @@ fn scan_linux_inventory_regions(
     ];
     const PREFIX_BYTES: usize = 8 * 1024 * 1024;
 
+    // Warframe's address space is several gigabytes, and the naive
+    // `windows().any()` form of these searches walks every byte position once
+    // per marker — eight separate passes per region, which dominated the scan
+    // at roughly 60 MiB/s. One Aho-Corasick automaton answers all three
+    // questions in a single SIMD-accelerated pass instead.
+    let markers = AhoCorasick::new(
+        std::iter::once(START_MARKER)
+            .chain(std::iter::once(MISSION_DELTA))
+            .chain(PREFIX_MARKERS.iter().copied()),
+    )
+    .expect("marker set is a valid literal alternation");
+    const START_PATTERN: usize = 0;
+    const MISSION_PATTERN: usize = 1;
+    let end_marker = AhoCorasick::new([END_MARKER]).expect("end marker is a valid literal");
+
     struct ActiveScan {
         data: Vec<u8>,
         start_address: usize,
@@ -1522,9 +1539,7 @@ fn scan_linux_inventory_regions(
                 .data
                 .extend_from_slice(&chunk[..chunk.len().min(remaining)]);
 
-            let complete = scans[index].data[search_from..]
-                .windows(END_MARKER.len())
-                .any(|window| window == END_MARKER)
+            let complete = end_marker.is_match(&scans[index].data[search_from..])
                 && find_blob_end(&scans[index].data).is_some();
             if !complete {
                 if exceeds_limit {
@@ -1543,15 +1558,16 @@ fn scan_linux_inventory_regions(
             }
         }
 
-        let is_mission = chunk
-            .windows(MISSION_DELTA.len())
-            .any(|window| window == MISSION_DELTA);
-        let start_offset = chunk
-            .windows(START_MARKER.len())
-            .position(|window| window == START_MARKER);
-        let has_prefix = PREFIX_MARKERS
-            .iter()
-            .any(|marker| chunk.windows(marker.len()).any(|window| window == *marker));
+        let mut is_mission = false;
+        let mut start_offset = None;
+        let mut has_prefix = false;
+        for found in markers.find_iter(chunk) {
+            match found.pattern().as_usize() {
+                MISSION_PATTERN => is_mission = true,
+                START_PATTERN => start_offset = start_offset.or(Some(found.start())),
+                _ => has_prefix = true,
+            }
+        }
         if start_offset.is_none() && !is_mission && has_prefix {
             while prefix.iter().map(|item| item.data.len()).sum::<usize>() + read > PREFIX_BYTES
                 && !prefix.is_empty()
@@ -1593,14 +1609,7 @@ fn scan_linux_inventory_regions(
         }
         combined.extend_from_slice(chunk);
 
-        let start_offset = combined
-            .windows(START_MARKER.len())
-            .position(|window| window == START_MARKER)
-            .expect("combined data retains the start marker");
-        let json_open = combined[..start_offset + 1]
-            .windows(2)
-            .position(|window| window == b"{\"")
-            .unwrap_or(start_offset);
+        let (_, json_open) = blob_seed_offsets(&combined);
         let start_address = combined_start + json_open;
         let seed = combined[json_open..].to_vec();
 
@@ -2056,6 +2065,44 @@ mod linux_tests {
         let process = LinuxProcess::open(std::process::id()).expect("current process is readable");
         let mut inventory = None;
 
+        scan_linux_inventory_regions(&process, regions, |_, _, parsed| {
+            inventory = Some(parsed);
+            false
+        });
+
+        assert_eq!(inventory.expect("inventory blob is found").credits, 42);
+    }
+
+    /// The blob is rarely the first thing in the stitched buffer. When a mapping
+    /// immediately ahead of it carries a Lotus path it joins the prefix chain,
+    /// and seeding at the earliest `{"` in the chain — rather than at the brace
+    /// enclosing the blob — produced a document that died on its first value
+    /// ("expected value at line 1 column 9") and lost the inventory entirely.
+    #[test]
+    fn linux_inventory_scan_seeds_at_the_blob_not_at_earlier_json() {
+        // Qualifies for the prefix buffer: Lotus path, no start marker, no
+        // mission delta — and opens a JSON object of its own.
+        let mut prefix = br#"{"Mods":garbage/Lotus/Weapons/Tenno/Rifle "#.to_vec();
+        prefix.resize(64_000, b' ');
+        let mut blob =
+            br#"{"SubscribedToEmails":true,"RegularCredits":42,"MiscItems":[{"ItemType":"/Lotus/Types/Items/x"}],"#
+                .to_vec();
+        blob.resize(64_000, b' ');
+        blob.extend_from_slice(br#""DeathSquadable":false}"#);
+        blob.resize(128_000, 0);
+
+        // One arena so the two mappings are genuinely contiguous — adjacency is
+        // what makes the walk chain them.
+        let mut arena = prefix.clone();
+        arena.extend_from_slice(&blob);
+        let base = arena.as_ptr() as usize;
+        let regions = vec![
+            LinuxRegion { start: base, len: prefix.len(), executable: false },
+            LinuxRegion { start: base + prefix.len(), len: blob.len(), executable: false },
+        ];
+        let process = LinuxProcess::open(std::process::id()).expect("current process is readable");
+
+        let mut inventory = None;
         scan_linux_inventory_regions(&process, regions, |_, _, parsed| {
             inventory = Some(parsed);
             false

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -442,9 +442,52 @@ pub fn scan_warframe_credentials_process() -> Result<(String, String, String), S
     Err("Credentials not found in memory. Make sure you are in the orbiter (not loading screen) and Warframe has been running for a few minutes.".into())
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "linux")]
 pub fn scan_warframe_credentials_process() -> Result<(String, String, String), String> {
-    Err("Only supported on Windows".into())
+    let pid = find_warframe_pid_pub().ok_or("Warframe is not running")?;
+    let process = LinuxProcess::open(pid)?;
+    let regions = linux_process_regions(pid)?;
+
+    scan_linux_credential_regions(&process, regions).ok_or_else(|| {
+        "Credentials not found in memory. Make sure you are in the orbiter (not loading screen) \
+         and Warframe has been running for a few minutes."
+            .into()
+    })
+}
+
+/// Walk readable data mappings looking for the login response the game keeps in
+/// memory. Split from the command above so it can be exercised against the test
+/// process, where the mappings and the expected bytes are both known.
+#[cfg(target_os = "linux")]
+fn scan_linux_credential_regions(
+    process: &LinuxProcess,
+    regions: impl IntoIterator<Item = LinuxRegion>,
+) -> Option<(String, String, String)> {
+    // Matches the Windows scanner's per-region ceiling: anything larger is a
+    // texture or heap arena, not the small JSON blob we are after, and reading
+    // it would cost hundreds of megabytes of copies per scan.
+    const MAX_REGION: usize = 128 * 1024 * 1024;
+
+    for region in regions {
+        if region.executable || region.len > MAX_REGION {
+            continue;
+        }
+        let mut buffer = vec![0; region.len];
+        let read = match process.read(region.start, &mut buffer) {
+            Ok(read) if read > 0 => read,
+            Ok(_) | Err(_) => continue,
+        };
+        let data = &buffer[..read];
+        if let Some((id, nonce)) = scan_auth_credentials(data) {
+            return Some((id, nonce, scan_steam_id(data).unwrap_or_default()));
+        }
+    }
+    None
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
+pub fn scan_warframe_credentials_process() -> Result<(String, String, String), String> {
+    Err("Only supported on Windows and Linux".into())
 }
 
 #[cfg(target_os = "linux")]
@@ -1473,18 +1516,21 @@ fn scan_linux_inventory_regions(
         while index < scans.len() {
             let search_from = scans[index].search_from;
             scans[index].search_from = scans[index].data.len().saturating_sub(END_MARKER.len() - 1);
-            scans[index].data.extend_from_slice(chunk);
-
-            if scans[index].data.len() > MAX_SCAN {
-                scans.swap_remove(index);
-                continue;
-            }
+            let remaining = MAX_SCAN.saturating_sub(scans[index].data.len());
+            let exceeds_limit = chunk.len() > remaining;
+            scans[index]
+                .data
+                .extend_from_slice(&chunk[..chunk.len().min(remaining)]);
 
             let complete = scans[index].data[search_from..]
                 .windows(END_MARKER.len())
                 .any(|window| window == END_MARKER)
                 && find_blob_end(&scans[index].data).is_some();
             if !complete {
+                if exceeds_limit {
+                    scans.swap_remove(index);
+                    continue;
+                }
                 index += 1;
                 continue;
             }
@@ -1945,14 +1991,6 @@ mod linux_tests {
     use super::*;
 
     #[test]
-    fn credential_process_scan_is_unsupported() {
-        assert_eq!(
-            scan_warframe_credentials_process(),
-            Err("Only supported on Windows".to_string())
-        );
-    }
-
-    #[test]
     fn linux_reader_reads_its_own_mapping() {
         let marker = b"frameforge-linux-reader";
         let process = LinuxProcess::open(std::process::id()).expect("current process is readable");
@@ -1965,6 +2003,37 @@ mod linux_tests {
     }
 
     #[test]
+    fn linux_credential_scan_skips_executable_and_reads_data_regions() {
+        let login = br#"{"id":"594144e63ade7f2f2091c48e","Nonce":123456789,"steamId=76561198000000000"}"#;
+        let code = login.to_vec();
+        let data = login.to_vec();
+        let regions = vec![
+            LinuxRegion {
+                start: code.as_ptr() as usize,
+                len: code.len(),
+                executable: true,
+            },
+            LinuxRegion {
+                start: data.as_ptr() as usize,
+                len: data.len(),
+                executable: false,
+            },
+        ];
+        let process = LinuxProcess::open(std::process::id()).expect("current process is readable");
+
+        let found = scan_linux_credential_regions(&process, regions);
+
+        assert_eq!(
+            found,
+            Some((
+                "594144e63ade7f2f2091c48e".to_string(),
+                "123456789".to_string(),
+                "76561198000000000".to_string(),
+            ))
+        );
+    }
+
+    #[test]
     fn linux_inventory_scan_stitches_and_parses_regions() {
         let first_json = br#"{"SubscribedToEmails":true,"RegularCredits":42,"MiscItems":[],"#;
         let second_json = br#""DeathSquadable":false}"#;
@@ -1972,6 +2041,37 @@ mod linux_tests {
         first.resize(64_000, b' ');
         let mut second = second_json.to_vec();
         second.resize(64_000, 0);
+        let regions = vec![
+            LinuxRegion {
+                start: first.as_ptr() as usize,
+                len: first.len(),
+                executable: false,
+            },
+            LinuxRegion {
+                start: second.as_ptr() as usize,
+                len: second.len(),
+                executable: false,
+            },
+        ];
+        let process = LinuxProcess::open(std::process::id()).expect("current process is readable");
+        let mut inventory = None;
+
+        scan_linux_inventory_regions(&process, regions, |_, _, parsed| {
+            inventory = Some(parsed);
+            false
+        });
+
+        assert_eq!(inventory.expect("inventory blob is found").credits, 42);
+    }
+
+    #[test]
+    fn linux_inventory_scan_finishes_before_rejecting_large_mapping() {
+        let first_json = br#"{"SubscribedToEmails":true,"RegularCredits":42,"MiscItems":[],"#;
+        let second_json = br#""DeathSquadable":false}"#;
+        let mut first = first_json.to_vec();
+        first.resize(64_000, b' ');
+        let mut second = vec![0; 64 * 1024 * 1024];
+        second[..second_json.len()].copy_from_slice(second_json);
         let regions = vec![
             LinuxRegion {
                 start: first.as_ptr() as usize,

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -1,5 +1,9 @@
 ﻿use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+#[cfg(target_os = "linux")]
+use std::fs::File;
+#[cfg(target_os = "linux")]
+use std::os::unix::fs::FileExt;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct ModCount {
@@ -298,8 +302,78 @@ pub fn scan_steam_id(data: &[u8]) -> Option<String> {
 #[cfg(target_os = "windows")]
 pub fn find_warframe_pid_pub() -> Option<u32> { find_warframe_pid() }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "linux")]
+pub fn find_warframe_pid_pub() -> Option<u32> { find_warframe_pid() }
+
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
 pub fn find_warframe_pid_pub() -> Option<u32> { None }
+
+#[cfg(target_os = "linux")]
+#[derive(Debug, PartialEq, Eq)]
+struct LinuxRegion {
+    start: usize,
+    len: usize,
+    executable: bool,
+}
+
+#[cfg(target_os = "linux")]
+fn parse_linux_maps(maps: &str) -> Vec<LinuxRegion> {
+    maps.lines()
+        .filter_map(|line| {
+            let mut fields = line.split_whitespace();
+            let (start, end) = fields.next()?.split_once('-')?;
+            let permissions = fields.next()?;
+            if !permissions.starts_with('r') {
+                return None;
+            }
+            let start = usize::from_str_radix(start, 16).ok()?;
+            let end = usize::from_str_radix(end, 16).ok()?;
+            Some(LinuxRegion {
+                start,
+                len: end.checked_sub(start)?,
+                executable: permissions.as_bytes().get(2) == Some(&b'x'),
+            })
+        })
+        .collect()
+}
+
+#[cfg(target_os = "linux")]
+#[allow(dead_code)]
+fn linux_process_regions(pid: u32) -> Result<Vec<LinuxRegion>, String> {
+    let path = format!("/proc/{pid}/maps");
+    std::fs::read_to_string(&path)
+        .map(|maps| parse_linux_maps(&maps))
+        .map_err(|error| format!("Failed to read {path}: {error}"))
+}
+
+#[cfg(target_os = "linux")]
+#[allow(dead_code)]
+fn open_linux_process_memory(pid: u32) -> Result<File, String> {
+    let path = format!("/proc/{pid}/mem");
+    File::open(&path).map_err(|error| {
+        format!(
+            "Failed to open {path}: {error}. Ensure kernel.yama.ptrace_scope permits same-user process access"
+        )
+    })
+}
+
+#[cfg(target_os = "linux")]
+#[allow(dead_code)]
+fn read_linux_process_memory(
+    memory: &File,
+    address: usize,
+    buffer: &mut [u8],
+) -> std::io::Result<usize> {
+    memory.read_at(buffer, address as u64)
+}
+
+#[cfg(target_os = "linux")]
+fn is_warframe_command(command: &str) -> bool {
+    let command = command.to_ascii_lowercase();
+    command.contains("warframe.x64.exe")
+        && !command.contains("launcher.exe")
+        && !command.contains("warframe-companion")
+}
 
 // ─── Raw memory format probe ──────────────────────────────────────────────────
 //
@@ -1469,6 +1543,18 @@ pub fn find_riven_validity_va(pid: u32) -> Option<usize> {
 #[cfg(not(target_os = "windows"))]
 pub fn find_riven_validity_va(_pid: u32) -> Option<usize> { None }
 
+#[cfg(target_os = "linux")]
+fn find_warframe_pid() -> Option<u32> {
+    std::fs::read_dir("/proc")
+        .ok()?
+        .filter_map(Result::ok)
+        .find_map(|entry| {
+            let pid = entry.file_name().to_str()?.parse().ok()?;
+            let command = std::fs::read(entry.path().join("cmdline")).ok()?;
+            is_warframe_command(&String::from_utf8_lossy(&command)).then_some(pid)
+        })
+}
+
 #[cfg(target_os = "windows")]
 fn find_warframe_pid() -> Option<u32> {
     use std::mem;
@@ -1555,5 +1641,41 @@ mod seed_tests {
         let buf = b"x\"SubscribedToEmails\":1}";
         let (marker_off, json_open) = blob_seed_offsets(buf);
         assert_eq!(json_open, marker_off);
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod linux_tests {
+    use super::*;
+
+    #[test]
+    fn parses_only_readable_linux_mappings() {
+        let maps = "1000-2000 r--p 0 00:00 0\n2000-2800 --xp 0 00:00 0\n3000-5000 rw-p 0 00:00 0\n";
+        assert_eq!(
+            parse_linux_maps(maps),
+            vec![
+                LinuxRegion {
+                    start: 0x1000,
+                    len: 0x1000,
+                    executable: false,
+                },
+                LinuxRegion {
+                    start: 0x3000,
+                    len: 0x2000,
+                    executable: false,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn recognizes_warframe_but_not_launcher_processes() {
+        assert!(is_warframe_command(
+            "Z:\\Warframe\\Warframe.x64.exe -cluster:public"
+        ));
+        assert!(!is_warframe_command(
+            "Z:\\Warframe\\Tools\\Launcher.exe"
+        ));
+        assert!(!is_warframe_command("warframe-companion"));
     }
 }

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -2153,7 +2153,7 @@ pub fn raw_scan_pass(_out: &mut impl std::io::Write) -> Result<usize, String> {
 //   The CMP instruction is 7 bytes. RIP at execution = match_va + 7.
 //   flag_va = (match_va + 7) + i32::from_le_bytes(bytes[2..6])
 
-#[cfg(any(target_os = "windows", target_os = "linux"))]
+#[cfg(target_os = "windows")]
 fn find_pattern_d2(data: &[u8], base_va: usize) -> Option<usize> {
     let len = data.len();
     if len < 13 { return None; }
@@ -2233,63 +2233,23 @@ pub fn find_riven_validity_va(pid: u32) -> Option<usize> {
 /// pattern sits in the game's executable mappings. Those are exactly the
 /// mappings the inventory scan skips, so this is the one caller that asks the
 /// walk for executable memory.
-/// Address span of the game's own module, from the mappings procfs attributes
-/// to `Warframe.x64.exe`.
-///
-/// Wine does not leave the executable's code file-backed — only the PE headers
-/// and one data section keep the pathname, while `.text` becomes a large
-/// anonymous executable mapping wedged between them. So the module is
-/// identified by the span its named mappings bracket, not by file backing.
+// Pattern D-2 does not locate a usable riven flag under Proton. Measured against
+// the running game: the game module contains exactly one matching site, and the
+// byte it points at reads 1 both with a riven reroll screen open and with the
+// player back in the orbiter, so it cannot tell the two apart. Reporting it
+// anyway would leave `read_riven_flag_byte` permanently fail-open and fire a
+// riven-screen-open event that never closes.
+//
+// Finding the flag on Linux needs a fresh differential search rather than a port
+// of the Windows pattern. Note for whoever does that: Wine does not leave the
+// executable's code file-backed — only the PE headers and one data section keep
+// the pathname in `/proc/<pid>/maps`, while `.text` is a large anonymous
+// executable mapping between them — so the module has to be identified by the
+// span its named mappings bracket, not by file backing.
+//
+// ponytail: riven screen detection on Linux still comes from EE.log only.
 #[cfg(target_os = "linux")]
-fn linux_game_image_span(pid: u32) -> Option<std::ops::Range<usize>> {
-    let maps = std::fs::read_to_string(format!("/proc/{pid}/maps")).ok()?;
-    let mut span: Option<std::ops::Range<usize>> = None;
-    for line in maps.lines() {
-        if !line.to_ascii_lowercase().ends_with("warframe.x64.exe") {
-            continue;
-        }
-        let mut fields = line.split_whitespace();
-        let (start, end) = fields.next()?.split_once('-')?;
-        let (start, end) = (
-            usize::from_str_radix(start, 16).ok()?,
-            usize::from_str_radix(end, 16).ok()?,
-        );
-        span = Some(match span {
-            Some(current) => current.start.min(start)..current.end.max(end),
-            None => start..end,
-        });
-    }
-    span
-}
-
-// ponytail: the Proton match is unverified — the byte reads non-zero with no
-// riven screen open, so confirm against an actual reroll screen before wiring
-// `start_riven_memory_watcher` up to anything on Linux.
-#[cfg(target_os = "linux")]
-pub fn find_riven_validity_va(pid: u32) -> Option<usize> {
-    const MIN_PATTERN: usize = 13;
-    const MAX_IMAGE: usize = 64 * 1024 * 1024;
-
-    let span = linux_game_image_span(pid)?;
-
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
-    let mut result = None;
-    let walk = walk_linux_regions(
-        pid,
-        |region| {
-            region.executable
-                && span.contains(&region.start)
-                && (MIN_PATTERN..=MAX_IMAGE).contains(&region.len)
-        },
-        deadline,
-        |address, data| {
-            result = find_pattern_d2(data, address);
-            result.is_none()
-        },
-    );
-    walk.ok()?;
-    result
-}
+pub fn find_riven_validity_va(_pid: u32) -> Option<usize> { None }
 
 #[cfg(not(any(target_os = "windows", target_os = "linux")))]
 pub fn find_riven_validity_va(_pid: u32) -> Option<usize> { None }

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -317,6 +317,22 @@ struct LinuxRegion {
 }
 
 #[cfg(target_os = "linux")]
+struct LinuxProcess {
+    memory: File,
+}
+
+#[cfg(target_os = "linux")]
+impl LinuxProcess {
+    fn open(pid: u32) -> Result<Self, String> {
+        open_linux_process_memory(pid).map(|memory| Self { memory })
+    }
+
+    fn read(&self, address: usize, buffer: &mut [u8]) -> std::io::Result<usize> {
+        read_linux_process_memory(&self.memory, address, buffer)
+    }
+}
+
+#[cfg(target_os = "linux")]
 fn parse_linux_maps(maps: &str) -> Vec<LinuxRegion> {
     maps.lines()
         .filter_map(|line| {
@@ -338,16 +354,18 @@ fn parse_linux_maps(maps: &str) -> Vec<LinuxRegion> {
 }
 
 #[cfg(target_os = "linux")]
-#[allow(dead_code)]
 fn linux_process_regions(pid: u32) -> Result<Vec<LinuxRegion>, String> {
     let path = format!("/proc/{pid}/maps");
     std::fs::read_to_string(&path)
         .map(|maps| parse_linux_maps(&maps))
-        .map_err(|error| format!("Failed to read {path}: {error}"))
+        .map_err(|error| {
+            format!(
+                "Failed to read {path}: {error}. Ensure kernel.yama.ptrace_scope permits same-user process access"
+            )
+        })
 }
 
 #[cfg(target_os = "linux")]
-#[allow(dead_code)]
 fn open_linux_process_memory(pid: u32) -> Result<File, String> {
     let path = format!("/proc/{pid}/mem");
     File::open(&path).map_err(|error| {
@@ -358,13 +376,75 @@ fn open_linux_process_memory(pid: u32) -> Result<File, String> {
 }
 
 #[cfg(target_os = "linux")]
-#[allow(dead_code)]
 fn read_linux_process_memory(
     memory: &File,
     address: usize,
     buffer: &mut [u8],
 ) -> std::io::Result<usize> {
     memory.read_at(buffer, address as u64)
+}
+
+#[cfg(target_os = "windows")]
+pub fn scan_warframe_credentials_process() -> Result<(String, String, String), String> {
+    use std::ffi::c_void;
+    use std::mem;
+    use windows_sys::Win32::{
+        Foundation::CloseHandle,
+        System::{
+            Diagnostics::Debug::ReadProcessMemory,
+            Memory::{VirtualQueryEx, MEMORY_BASIC_INFORMATION, MEM_COMMIT, PAGE_GUARD, PAGE_NOACCESS},
+            Threading::{OpenProcess, PROCESS_QUERY_INFORMATION, PROCESS_VM_READ},
+        },
+    };
+
+    let pid = find_warframe_pid_pub().ok_or("Warframe is not running")?;
+
+    unsafe {
+        let process = OpenProcess(PROCESS_VM_READ | PROCESS_QUERY_INFORMATION, 0, pid);
+        if process == 0 { return Err("Cannot open Warframe process".into()); }
+
+        let mut address: usize = 0x10000;
+        let mbi_size = mem::size_of::<MEMORY_BASIC_INFORMATION>();
+
+        loop {
+            let mut mbi: MEMORY_BASIC_INFORMATION = mem::zeroed();
+            if VirtualQueryEx(process, address as *const c_void, &mut mbi, mbi_size) == 0 { break; }
+            let region_end = (mbi.BaseAddress as usize).saturating_add(mbi.RegionSize);
+            if region_end <= address { break; }
+            address = region_end;
+
+            if mbi.State != MEM_COMMIT { continue; }
+            let protection = mbi.Protect;
+            if protection & PAGE_NOACCESS != 0 || protection & PAGE_GUARD != 0 { continue; }
+            if protection == 0x10 || protection == 0x20 { continue; }
+            if mbi.RegionSize > 128 * 1024 * 1024 { continue; }
+
+            let mut buffer = vec![0u8; mbi.RegionSize];
+            let mut bytes_read: usize = 0;
+            let ok = ReadProcessMemory(
+                process,
+                mbi.BaseAddress as *const c_void,
+                buffer.as_mut_ptr() as *mut c_void,
+                mbi.RegionSize,
+                &mut bytes_read,
+            );
+            if ok == 0 || bytes_read == 0 { continue; }
+
+            let data = &buffer[..bytes_read];
+            if let Some((id, nonce)) = scan_auth_credentials(data) {
+                let steam_id = scan_steam_id(data).unwrap_or_default();
+                CloseHandle(process);
+                return Ok((id, nonce, steam_id));
+            }
+        }
+        CloseHandle(process);
+    }
+    Err("Credentials not found in memory. Make sure you are in the orbiter (not loading screen) and Warframe has been running for a few minutes.".into())
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn scan_warframe_credentials_process() -> Result<(String, String, String), String> {
+    Err("Only supported on Windows".into())
 }
 
 #[cfg(target_os = "linux")]
@@ -1341,7 +1421,223 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
     saved
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "linux")]
+fn scan_linux_inventory_regions(
+    process: &LinuxProcess,
+    regions: impl IntoIterator<Item = LinuxRegion>,
+    mut on_blob: impl FnMut(usize, &[u8], BlobInventory) -> bool,
+) {
+    const MIN_REGION: usize = 64_000;
+    const MAX_READ: usize = 64 * 1024 * 1024;
+    const MAX_SCAN: usize = 20 * 1024 * 1024;
+    const START_MARKER: &[u8] = b"\"SubscribedToEmails\"";
+    const END_MARKER: &[u8] = b"\"DeathSquadable\":";
+    const MISSION_DELTA: &[u8] = b"\"InventoryChanges\":";
+    const PREFIX_MARKERS: &[&[u8]] = &[
+        b"/Lotus/",
+        b"\"MiscItems\":[",
+        b"\"Suits\":[",
+        b"\"LongGuns\":[",
+        b"\"Melee\":[",
+        b"\"Pistols\":[",
+    ];
+    const PREFIX_BYTES: usize = 8 * 1024 * 1024;
+
+    struct ActiveScan {
+        data: Vec<u8>,
+        start_address: usize,
+        search_from: usize,
+    }
+
+    struct PrefixChunk {
+        start: usize,
+        end: usize,
+        data: Vec<u8>,
+    }
+
+    let mut scans: Vec<ActiveScan> = Vec::new();
+    let mut prefix = std::collections::VecDeque::<PrefixChunk>::new();
+    for region in regions {
+        if region.executable || region.len < MIN_REGION {
+            continue;
+        }
+
+        let mut buffer = vec![0; region.len.min(MAX_READ)];
+        let read = match process.read(region.start, &mut buffer) {
+            Ok(read) if read >= 8 => read,
+            Ok(_) | Err(_) => continue,
+        };
+        let chunk = &buffer[..read];
+
+        let mut index = 0;
+        while index < scans.len() {
+            let search_from = scans[index].search_from;
+            scans[index].search_from = scans[index].data.len().saturating_sub(END_MARKER.len() - 1);
+            scans[index].data.extend_from_slice(chunk);
+
+            if scans[index].data.len() > MAX_SCAN {
+                scans.swap_remove(index);
+                continue;
+            }
+
+            let complete = scans[index].data[search_from..]
+                .windows(END_MARKER.len())
+                .any(|window| window == END_MARKER)
+                && find_blob_end(&scans[index].data).is_some();
+            if !complete {
+                index += 1;
+                continue;
+            }
+
+            let scan = scans.swap_remove(index);
+            if let Some(inventory) = parse_full_account_blob(&scan.data) {
+                if !on_blob(scan.start_address, &scan.data, inventory) {
+                    return;
+                }
+            }
+        }
+
+        let is_mission = chunk
+            .windows(MISSION_DELTA.len())
+            .any(|window| window == MISSION_DELTA);
+        let start_offset = chunk
+            .windows(START_MARKER.len())
+            .position(|window| window == START_MARKER);
+        let has_prefix = PREFIX_MARKERS
+            .iter()
+            .any(|marker| chunk.windows(marker.len()).any(|window| window == *marker));
+        if start_offset.is_none() && !is_mission && has_prefix {
+            while prefix.iter().map(|item| item.data.len()).sum::<usize>() + read > PREFIX_BYTES
+                && !prefix.is_empty()
+            {
+                prefix.pop_front();
+            }
+            prefix.push_back(PrefixChunk {
+                start: region.start,
+                end: region.start + read,
+                data: chunk.to_vec(),
+            });
+        }
+        if is_mission {
+            continue;
+        }
+        let Some(_) = start_offset else {
+            continue;
+        };
+
+        let mut combined = Vec::new();
+        let mut combined_start = region.start;
+        let mut expected_end = region.start;
+        let mut chain = Vec::new();
+        for (index, item) in prefix.iter().enumerate().rev() {
+            if item.end <= expected_end && item.end + 4096 >= expected_end {
+                chain.push(index);
+                expected_end = item.start;
+            } else if item.end < expected_end.saturating_sub(4096) {
+                break;
+            }
+        }
+        chain.reverse();
+        for index in chain {
+            let item = &prefix[index];
+            if combined.is_empty() {
+                combined_start = item.start;
+            }
+            combined.extend_from_slice(&item.data);
+        }
+        combined.extend_from_slice(chunk);
+
+        let start_offset = combined
+            .windows(START_MARKER.len())
+            .position(|window| window == START_MARKER)
+            .expect("combined data retains the start marker");
+        let json_open = combined[..start_offset + 1]
+            .windows(2)
+            .position(|window| window == b"{\"")
+            .unwrap_or(start_offset);
+        let start_address = combined_start + json_open;
+        let seed = combined[json_open..].to_vec();
+
+        if find_blob_end(&seed).is_some() {
+            if let Some(inventory) = parse_full_account_blob(&seed) {
+                if !on_blob(start_address, &seed, inventory) {
+                    return;
+                }
+            }
+        } else {
+            scans.push(ActiveScan {
+                data: seed,
+                start_address,
+                search_from: 0,
+            });
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub fn capture_all_blobs(
+    blob_dir: &std::path::Path,
+    ts: &str,
+    blob_tx: std::sync::mpsc::Sender<BlobInventory>,
+    save: bool,
+) -> usize {
+    const MAX_BLOBS: usize = 25;
+
+    let Some(pid) = find_warframe_pid_pub() else {
+        eprintln!("[blob-capture] Warframe is not running");
+        return 0;
+    };
+    let process = match LinuxProcess::open(pid) {
+        Ok(process) => process,
+        Err(error) => {
+            eprintln!("[blob-capture] {error}");
+            return 0;
+        }
+    };
+    let regions = match linux_process_regions(pid) {
+        Ok(regions) => regions,
+        Err(error) => {
+            eprintln!("[blob-capture] {error}");
+            return 0;
+        }
+    };
+
+    let mut found = 0;
+    let mut saved = 0;
+    scan_linux_inventory_regions(&process, regions, |address, raw, inventory| {
+        found += 1;
+        eprintln!(
+            "[blob] Linux scan SUCCESS at 0x{address:012x}: {} unique, {} stackable, {} mods",
+            inventory.unique_items.len(),
+            inventory.stackable_items.len(),
+            inventory.mods.len()
+        );
+        if save {
+            let path = blob_dir.join(format!(
+                "Actual_inventory_FULL_ACCOUNT_{}_{:02}.txt",
+                ts,
+                saved + 1
+            ));
+            match std::fs::write(&path, raw) {
+                Ok(()) => saved += 1,
+                Err(error) => {
+                    eprintln!("[blob-capture] Failed to write {}: {error}", path.display())
+                }
+            }
+        }
+        blob_tx.send(inventory).ok();
+        save && found < MAX_BLOBS
+    });
+
+    if found == 0 {
+        eprintln!(
+            "[blob-capture] WARNING: no FULL_ACCOUNT blob found (open Arsenal or Inventory and try again)"
+        );
+    }
+    saved
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
 pub fn capture_all_blobs(_blob_dir: &std::path::Path, _ts: &str, _blob_tx: std::sync::mpsc::Sender<BlobInventory>, _save: bool) -> usize { 0 }
 
 // ─── Continuous raw memory string dump ───────────────────────────────────────
@@ -1647,6 +1943,90 @@ mod seed_tests {
 #[cfg(all(test, target_os = "linux"))]
 mod linux_tests {
     use super::*;
+
+    #[test]
+    fn credential_process_scan_is_unsupported() {
+        assert_eq!(
+            scan_warframe_credentials_process(),
+            Err("Only supported on Windows".to_string())
+        );
+    }
+
+    #[test]
+    fn linux_reader_reads_its_own_mapping() {
+        let marker = b"frameforge-linux-reader";
+        let process = LinuxProcess::open(std::process::id()).expect("current process is readable");
+        let mut actual = vec![0; marker.len()];
+        let read = process
+            .read(marker.as_ptr() as usize, &mut actual)
+            .expect("marker address is mapped");
+        assert_eq!(read, marker.len());
+        assert_eq!(actual, marker);
+    }
+
+    #[test]
+    fn linux_inventory_scan_stitches_and_parses_regions() {
+        let first_json = br#"{"SubscribedToEmails":true,"RegularCredits":42,"MiscItems":[],"#;
+        let second_json = br#""DeathSquadable":false}"#;
+        let mut first = first_json.to_vec();
+        first.resize(64_000, b' ');
+        let mut second = second_json.to_vec();
+        second.resize(64_000, 0);
+        let regions = vec![
+            LinuxRegion {
+                start: first.as_ptr() as usize,
+                len: first.len(),
+                executable: false,
+            },
+            LinuxRegion {
+                start: second.as_ptr() as usize,
+                len: second.len(),
+                executable: false,
+            },
+        ];
+        let process = LinuxProcess::open(std::process::id()).expect("current process is readable");
+        let mut inventory = None;
+
+        scan_linux_inventory_regions(&process, regions, |_, _, parsed| {
+            inventory = Some(parsed);
+            false
+        });
+
+        assert_eq!(inventory.expect("inventory blob is found").credits, 42);
+    }
+
+    #[test]
+    fn linux_inventory_scan_recovers_fields_before_start_marker() {
+        let prefix =
+            br#"{"RegularCredits":42,"MiscItems":[{"ItemType":"/Lotus/Test","ItemCount":1}],"#;
+        let suffix = br#""SubscribedToEmails":true,"DeathSquadable":false}"#;
+        let mut mapping = vec![b' '; 128_000];
+        mapping[..prefix.len()].copy_from_slice(prefix);
+        mapping[64_000..64_000 + suffix.len()].copy_from_slice(suffix);
+        let regions = vec![
+            LinuxRegion {
+                start: mapping.as_ptr() as usize,
+                len: 64_000,
+                executable: false,
+            },
+            LinuxRegion {
+                start: mapping.as_ptr() as usize + 64_000,
+                len: 64_000,
+                executable: false,
+            },
+        ];
+        let process = LinuxProcess::open(std::process::id()).expect("current process is readable");
+        let mut inventory = None;
+
+        scan_linux_inventory_regions(&process, regions, |_, _, parsed| {
+            inventory = Some(parsed);
+            false
+        });
+
+        let inventory = inventory.expect("inventory blob is found");
+        assert_eq!(inventory.credits, 42);
+        assert_eq!(inventory.stackable_items.len(), 1);
+    }
 
     #[test]
     fn parses_only_readable_linux_mappings() {

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -2233,23 +2233,102 @@ pub fn find_riven_validity_va(pid: u32) -> Option<usize> {
 /// pattern sits in the game's executable mappings. Those are exactly the
 /// mappings the inventory scan skips, so this is the one caller that asks the
 /// walk for executable memory.
-// Pattern D-2 does not locate a usable riven flag under Proton. Measured against
-// the running game: the game module contains exactly one matching site, and the
-// byte it points at reads 1 both with a riven reroll screen open and with the
-// player back in the orbiter, so it cannot tell the two apart. Reporting it
-// anyway would leave `read_riven_flag_byte` permanently fail-open and fire a
-// riven-screen-open event that never closes.
-//
-// Finding the flag on Linux needs a fresh differential search rather than a port
-// of the Windows pattern. Note for whoever does that: Wine does not leave the
-// executable's code file-backed — only the PE headers and one data section keep
-// the pathname in `/proc/<pid>/maps`, while `.text` is a large anonymous
-// executable mapping between them — so the module has to be identified by the
-// span its named mappings bracket, not by file backing.
-//
-// ponytail: riven screen detection on Linux still comes from EE.log only.
+/// Address span of the game's own module, from the mappings procfs attributes
+/// to `Warframe.x64.exe`.
+///
+/// Wine does not leave the executable's code file-backed — only the PE headers
+/// and one data section keep the pathname, while `.text` becomes a large
+/// anonymous executable mapping wedged between them. So the module is
+/// identified by the span its named mappings bracket, not by file backing.
 #[cfg(target_os = "linux")]
-pub fn find_riven_validity_va(_pid: u32) -> Option<usize> { None }
+fn linux_game_image_span(pid: u32) -> Option<std::ops::Range<usize>> {
+    let maps = std::fs::read_to_string(format!("/proc/{pid}/maps")).ok()?;
+    let mut span: Option<std::ops::Range<usize>> = None;
+    for line in maps.lines() {
+        if !line.to_ascii_lowercase().ends_with("warframe.x64.exe") {
+            continue;
+        }
+        let mut fields = line.split_whitespace();
+        let (start, end) = fields.next()?.split_once('-')?;
+        let (start, end) = (
+            usize::from_str_radix(start, 16).ok()?,
+            usize::from_str_radix(end, 16).ok()?,
+        );
+        span = Some(match span {
+            Some(current) => current.start.min(start)..current.end.max(end),
+            None => start..end,
+        });
+    }
+    span
+}
+
+/// Locate the byte the game sets while a riven reroll's A/B selection screen is
+/// up. Non-zero = selection pending, which is the same event the EE.log
+/// `omegarerollselection.swf` line reports.
+///
+/// This is not the Windows Pattern D-2 scan. That pattern matches exactly one
+/// site under Proton, and the byte it resolves to reads 1 in the orbiter, in
+/// the mod segment and on the reroll screen alike, so it cannot drive the
+/// watcher. The signature below was found by diffing the game's writable
+/// statics across those states against the live game, and the surviving byte
+/// was confirmed to be 0 everywhere except while the A/B screen is up.
+///
+/// It matches the store the game publishes the state with:
+///
+/// ```text
+/// 44 87 35 <disp32>    xchg dword ptr [rip+disp], r14d
+/// 41 83 fe 01          cmp  r14d, 1
+/// ```
+///
+/// Only the displacement varies, and it appeared exactly once in the whole
+/// process, so the first match is taken.
+///
+/// ponytail: a byte signature tracks one game build; if riven detection stops
+/// working after an update, re-run `examples/riven_flag_hunt.rs` to find the
+/// flag again rather than guessing at the pattern.
+#[cfg(target_os = "linux")]
+pub fn find_riven_validity_va(pid: u32) -> Option<usize> {
+    const STORE: [u8; 3] = [0x44, 0x87, 0x35];
+    const COMPARE: [u8; 4] = [0x41, 0x83, 0xfe, 0x01];
+    // Bytes from the start of the store up to the end of its displacement,
+    // which is where the RIP-relative address is measured from.
+    const STORE_LEN: usize = 7;
+
+    let span = linux_game_image_span(pid)?;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+    let mut result = None;
+
+    // The game's code is one mapping well under the walk's chunk size, so a
+    // signature cannot be split across two chunks here.
+    let walk = walk_linux_regions(
+        pid,
+        |region| region.executable && span.contains(&region.start),
+        deadline,
+        |address, data| {
+            for index in 0..data.len().saturating_sub(STORE_LEN + COMPARE.len()) {
+                if data[index..index + STORE.len()] != STORE {
+                    continue;
+                }
+                if data[index + STORE_LEN..index + STORE_LEN + COMPARE.len()] != COMPARE {
+                    continue;
+                }
+                let displacement = i32::from_le_bytes(
+                    data[index + STORE.len()..index + STORE_LEN]
+                        .try_into()
+                        .expect("displacement is four bytes"),
+                ) as i64;
+                let flag = (address + index + STORE_LEN) as i64 + displacement;
+                if flag > 0x10000 && flag < 0x7fff_ffff_ffff {
+                    result = Some(flag as usize);
+                    return false;
+                }
+            }
+            true
+        },
+    );
+    walk.ok()?;
+    result
+}
 
 #[cfg(not(any(target_os = "windows", target_os = "linux")))]
 pub fn find_riven_validity_va(_pid: u32) -> Option<usize> { None }

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -492,6 +492,108 @@ pub fn scan_warframe_credentials_process() -> Result<(String, String, String), S
     Err("Only supported on Windows and Linux".into())
 }
 
+// ==============================================================================
+// Shared Linux region walk
+// ==============================================================================
+//
+// The diagnostic tools below each want the same thing: every readable mapping,
+// in bounded pieces, with the address the bytes came from. On Windows each of
+// them open-codes its own `VirtualQueryEx` loop; on Linux they share this one
+// so the read caps, the deadline, and the procfs error text stay in one place.
+//
+// `visit` returning false stops the walk early — used by the callers that cap
+// their output.
+
+/// Hand every mapping `accept` selects to `visit` in chunks, lowest address
+/// first. Callers differ in what they want — inventory data, code, or both —
+/// so the filter is theirs to supply rather than a flag this has to interpret.
+#[cfg(target_os = "linux")]
+fn walk_linux_regions(
+    pid: u32,
+    accept: impl Fn(&LinuxRegion) -> bool,
+    deadline: std::time::Instant,
+    mut visit: impl FnMut(usize, &[u8]) -> bool,
+) -> Result<(), String> {
+    // Matches the Windows tools: large mappings are read in 64 MiB pieces so a
+    // multi-gigabyte arena cannot blow up the heap.
+    const CHUNK: usize = 64 * 1024 * 1024;
+    const MIN_USEFUL: usize = 8;
+
+    let process = LinuxProcess::open(pid)?;
+    let regions = linux_process_regions(pid)?;
+
+    let mut buffer = Vec::new();
+    for region in regions {
+        if !accept(&region) {
+            continue;
+        }
+        let mut offset = 0;
+        while offset < region.len {
+            if std::time::Instant::now() >= deadline {
+                return Ok(());
+            }
+            let size = CHUNK.min(region.len - offset);
+            let address = region.start + offset;
+            offset += size;
+
+            buffer.resize(size, 0);
+            let read = match process.read(address, &mut buffer[..size]) {
+                Ok(read) if read >= MIN_USEFUL => read,
+                Ok(_) | Err(_) => continue,
+            };
+            if !visit(address, &buffer[..read]) {
+                return Ok(());
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Read a single byte from the game process, used for the riven validity flag.
+/// `None` means the process or the address is not readable.
+#[cfg(target_os = "windows")]
+pub fn read_process_byte(pid: u32, address: usize) -> Option<u8> {
+    use std::ffi::c_void;
+    use windows_sys::Win32::{
+        Foundation::CloseHandle,
+        System::{
+            Diagnostics::Debug::ReadProcessMemory,
+            Threading::{OpenProcess, PROCESS_QUERY_INFORMATION, PROCESS_VM_READ},
+        },
+    };
+
+    unsafe {
+        let process = OpenProcess(PROCESS_VM_READ | PROCESS_QUERY_INFORMATION, 0, pid);
+        if process == 0 {
+            return None;
+        }
+        let mut byte: u8 = 0;
+        let mut read = 0usize;
+        let ok = ReadProcessMemory(
+            process,
+            address as *const c_void,
+            &mut byte as *mut u8 as *mut c_void,
+            1,
+            &mut read,
+        );
+        CloseHandle(process);
+        (ok != 0 && read == 1).then_some(byte)
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub fn read_process_byte(pid: u32, address: usize) -> Option<u8> {
+    let process = LinuxProcess::open(pid).ok()?;
+    let mut byte = [0u8; 1];
+    match process.read(address, &mut byte) {
+        Ok(1) => Some(byte[0]),
+        _ => None,
+    }
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
+pub fn read_process_byte(_pid: u32, _address: usize) -> Option<u8> { None }
+
 #[cfg(target_os = "linux")]
 fn is_warframe_command(command: &str) -> bool {
     let command = command.to_ascii_lowercase();
@@ -626,9 +728,123 @@ pub fn dump_inventory_regions(max_hits: usize) -> Vec<String> {
     results
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "linux")]
+pub fn dump_inventory_regions(max_hits: usize) -> Vec<String> {
+    // Same needles and context window as the Windows probe so saved output from
+    // either platform reads the same way.
+    const NEEDLES: &[&[u8]] = &[
+        b"\"MiscItems\":[{",
+        b"\"ItemCount\":",
+        b"MiscItems",
+        b"AlloyPlate",
+        b"Circuits\"",
+        b"/Lotus/Types/Items/MiscItems/",
+    ];
+    const HITS_PER_NEEDLE: usize = 3;
+
+    let Some(pid) = find_warframe_pid_pub() else {
+        return vec!["Warframe is not running".to_string()];
+    };
+
+    let mut results: Vec<String> = Vec::new();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    let walk = walk_linux_regions(pid, |region| !region.executable, deadline, |address, data| {
+        for needle in NEEDLES {
+            let mut search = 0;
+            for _ in 0..HITS_PER_NEEDLE {
+                if results.len() >= max_hits {
+                    return false;
+                }
+                let Some(relative) = data[search..]
+                    .windows(needle.len())
+                    .position(|window| window == *needle)
+                else {
+                    break;
+                };
+                let position = search + relative;
+                let context_start = position.saturating_sub(80);
+                let context_end = data.len().min(position + 200);
+                let snippet: String = data[context_start..context_end]
+                    .iter()
+                    .map(|&byte| if (0x20..0x7f).contains(&byte) { byte as char } else { '·' })
+                    .collect();
+                results.push(format!(
+                    "0x{:012x}  needle=\"{}\"  ctx: {}",
+                    address + context_start,
+                    String::from_utf8_lossy(needle),
+                    snippet
+                ));
+                search = position + needle.len();
+            }
+        }
+        true
+    });
+
+    if let Err(error) = walk {
+        return vec![error];
+    }
+    if results.is_empty() {
+        results.push("No matches found".to_string());
+    }
+    results
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
 pub fn dump_inventory_regions(_max_hits: usize) -> Vec<String> {
-    vec!["Only supported on Windows".to_string()]
+    vec!["Only supported on Windows and Linux".to_string()]
+}
+
+/// Collect context around the request strings the game builds its API calls
+/// from. The Windows equivalent is inlined in the command in `lib.rs`; on Linux
+/// it lives here so it can share the region walk with the other probes.
+#[cfg(target_os = "linux")]
+pub fn scan_api_url_strings() -> Result<Vec<String>, String> {
+    const NEEDLES: &[&[u8]] = &[
+        b"/API/PHP/",
+        b"inventory.php",
+        b"login.php",
+        b"warframe.com/A",
+        b"Nonce",
+        b"accountId",
+    ];
+    const MAX_RESULTS: usize = 40;
+
+    let pid = find_warframe_pid_pub().ok_or("Warframe not running")?;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    let mut found: Vec<String> = Vec::new();
+
+    walk_linux_regions(pid, |region| !region.executable, deadline, |_, data| {
+        for needle in NEEDLES {
+            let mut search = 0;
+            while let Some(relative) = data[search..]
+                .windows(needle.len())
+                .position(|window| window == *needle)
+            {
+                let position = search + relative;
+                search = position + needle.len();
+
+                let start = position.saturating_sub(30);
+                let end = (position + 100).min(data.len());
+                let context: String = data[start..end]
+                    .iter()
+                    .map(|&byte| if (0x20..0x7f).contains(&byte) { byte as char } else { ' ' })
+                    .collect();
+                let trimmed = context.split_whitespace().collect::<Vec<_>>().join(" ");
+                // Near-identical strings appear in thousands of copies, so the
+                // first 30 characters act as the deduplication key.
+                let key = &trimmed[..trimmed.len().min(30)];
+                if !found.iter().any(|seen| seen.contains(key)) {
+                    found.push(format!("[{}] {}", String::from_utf8_lossy(needle), trimmed));
+                }
+                if found.len() >= MAX_RESULTS {
+                    return false;
+                }
+            }
+        }
+        true
+    })?;
+
+    Ok(found)
 }
 
 // ─── One-shot inventory blob capture ─────────────────────────────────────────
@@ -1878,9 +2094,49 @@ pub fn raw_scan_pass(out: &mut impl std::io::Write) -> Result<usize, String> {
     Ok(count)
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "linux")]
+pub fn raw_scan_pass(out: &mut impl std::io::Write) -> Result<usize, String> {
+    const MIN_LEN: usize = 8;
+    const TIMEOUT: u64 = 600; // 10 minutes — full coverage over a full scan
+
+    let pid = find_warframe_pid_pub().ok_or("Warframe not running")?;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(TIMEOUT);
+    let mut count = 0usize;
+
+    // Executable mappings are included: the game's constant string tables live
+    // in read-execute sections, and they are half the point of a raw dump.
+    walk_linux_regions(pid, |_| true, deadline, |address, data| {
+        let mut run_start = None;
+        for (index, &byte) in data.iter().enumerate() {
+            if (0x20..0x7f).contains(&byte) {
+                run_start.get_or_insert(index);
+                continue;
+            }
+            if let Some(start) = run_start.take() {
+                if index - start >= MIN_LEN {
+                    let text = std::str::from_utf8(&data[start..index]).unwrap_or("?");
+                    let _ = writeln!(out, "0x{:012x}  {}", address + start, text);
+                    count += 1;
+                }
+            }
+        }
+        // A run that reaches the end of the chunk is still worth reporting.
+        if let Some(start) = run_start {
+            if data.len() - start >= MIN_LEN {
+                let text = std::str::from_utf8(&data[start..]).unwrap_or("?");
+                let _ = writeln!(out, "0x{:012x}  {}", address + start, text);
+                count += 1;
+            }
+        }
+        true
+    })?;
+
+    Ok(count)
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
 pub fn raw_scan_pass(_out: &mut impl std::io::Write) -> Result<usize, String> {
-    Err("Only supported on Windows".into())
+    Err("Only supported on Windows and Linux".into())
 }
 
 // ─── Riven validity flag scanner ──────────────────────────────────────────────
@@ -1897,7 +2153,7 @@ pub fn raw_scan_pass(_out: &mut impl std::io::Write) -> Result<usize, String> {
 //   The CMP instruction is 7 bytes. RIP at execution = match_va + 7.
 //   flag_va = (match_va + 7) + i32::from_le_bytes(bytes[2..6])
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "linux"))]
 fn find_pattern_d2(data: &[u8], base_va: usize) -> Option<usize> {
     let len = data.len();
     if len < 13 { return None; }
@@ -1973,7 +2229,69 @@ pub fn find_riven_validity_va(pid: u32) -> Option<usize> {
     result
 }
 
-#[cfg(not(target_os = "windows"))]
+/// Linux counterpart: Proton maps the same PE image, so the same instruction
+/// pattern sits in the game's executable mappings. Those are exactly the
+/// mappings the inventory scan skips, so this is the one caller that asks the
+/// walk for executable memory.
+/// Address span of the game's own module, from the mappings procfs attributes
+/// to `Warframe.x64.exe`.
+///
+/// Wine does not leave the executable's code file-backed — only the PE headers
+/// and one data section keep the pathname, while `.text` becomes a large
+/// anonymous executable mapping wedged between them. So the module is
+/// identified by the span its named mappings bracket, not by file backing.
+#[cfg(target_os = "linux")]
+fn linux_game_image_span(pid: u32) -> Option<std::ops::Range<usize>> {
+    let maps = std::fs::read_to_string(format!("/proc/{pid}/maps")).ok()?;
+    let mut span: Option<std::ops::Range<usize>> = None;
+    for line in maps.lines() {
+        if !line.to_ascii_lowercase().ends_with("warframe.x64.exe") {
+            continue;
+        }
+        let mut fields = line.split_whitespace();
+        let (start, end) = fields.next()?.split_once('-')?;
+        let (start, end) = (
+            usize::from_str_radix(start, 16).ok()?,
+            usize::from_str_radix(end, 16).ok()?,
+        );
+        span = Some(match span {
+            Some(current) => current.start.min(start)..current.end.max(end),
+            None => start..end,
+        });
+    }
+    span
+}
+
+// ponytail: the Proton match is unverified — the byte reads non-zero with no
+// riven screen open, so confirm against an actual reroll screen before wiring
+// `start_riven_memory_watcher` up to anything on Linux.
+#[cfg(target_os = "linux")]
+pub fn find_riven_validity_va(pid: u32) -> Option<usize> {
+    const MIN_PATTERN: usize = 13;
+    const MAX_IMAGE: usize = 64 * 1024 * 1024;
+
+    let span = linux_game_image_span(pid)?;
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+    let mut result = None;
+    let walk = walk_linux_regions(
+        pid,
+        |region| {
+            region.executable
+                && span.contains(&region.start)
+                && (MIN_PATTERN..=MAX_IMAGE).contains(&region.len)
+        },
+        deadline,
+        |address, data| {
+            result = find_pattern_d2(data, address);
+            result.is_none()
+        },
+    );
+    walk.ok()?;
+    result
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
 pub fn find_riven_validity_va(_pid: u32) -> Option<usize> { None }
 
 #[cfg(target_os = "linux")]

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -975,18 +975,46 @@ fn enclosing_object_start(buf: &[u8], marker_off: usize) -> Option<usize> {
     None
 }
 
-/// Locate seed offsets for the FULL_ACCOUNT blob within `buf`.
-/// Returns `(marker_off, json_open)`:
-///   - `marker_off`: byte position of the first known start marker
-///   - `json_open`:  byte position of the outermost `{` enclosing the marker
-fn blob_seed_offsets(buf: &[u8]) -> (usize, usize) {
-    let marker_off = buf.windows(START_MARKER.len())
+/// Where a stitched buffer's blob begins: `(marker_at, seed_at)`.
+///
+/// `marker_at` is the marker occurrence the seed is anchored to; `seed_at` is
+/// the brace enclosing it, or the marker itself when no occurrence has a
+/// brace that reads as an object head. See `enclosing_object_start` for why
+/// marker and brace are rarely the same offset.
+///
+/// With no primary marker anywhere the fallbacks keep both offsets in bounds,
+/// down to the buffer's last byte when nothing matches at all. Such a seed is
+/// junk and fails to parse, which is what the walk already does with a bad
+/// start.
+fn blob_seed_offsets(combined: &[u8]) -> (usize, usize) {
+    // The heap can hold a stale copy of the blob ahead of the live one: its
+    // marker survives but its opening brace was overwritten, so brace-matching
+    // backward from it lands on a stray `{` in binary garbage. A live seed is
+    // a JSON object head, so only accept a brace followed by a quote, and keep
+    // trying later marker occurrences until one qualifies.
+    let mut first_marker = None;
+    let mut search_from = 0;
+    while let Some(found) = combined[search_from..]
+        .windows(START_MARKER.len())
         .position(|w| w == START_MARKER)
+    {
+        let marker_at = search_from + found;
+        first_marker.get_or_insert(marker_at);
+        if let Some(open) = enclosing_object_start(combined, marker_at) {
+            if combined.get(open + 1) == Some(&b'"') {
+                return (marker_at, open);
+            }
+        }
+        search_from = marker_at + 1;
+    }
+    // Without a plausible brace anywhere, seed at the first marker: the
+    // parser can rebuild the object head from a marker-anchored seed.
+    let marker_at = first_marker
         .or_else(|| ALT_STARTS.iter().find_map(|a|
-            buf.windows(a.len()).position(|w| w == *a)))
-        .unwrap_or(buf.len().saturating_sub(1));
-    let json_open = enclosing_object_start(buf, marker_off).unwrap_or(marker_off);
-    (marker_off, json_open)
+            combined.windows(a.len()).position(|w| w == *a)))
+        .unwrap_or(combined.len().saturating_sub(1));
+    (marker_at, first_marker.unwrap_or_else(||
+        enclosing_object_start(combined, marker_at).unwrap_or(marker_at)))
 }
 
 /// Parse a FULL_ACCOUNT blob from raw memory bytes into structured inventory data.
@@ -2431,6 +2459,37 @@ mod seed_tests {
         let buf = b"x\"SubscribedToEmails\":1}";
         let (marker_off, json_open) = blob_seed_offsets(buf);
         assert_eq!(json_open, marker_off);
+    }
+
+    /// A freed copy of the blob can sit ahead of the live one with its marker
+    /// intact but its opening brace overwritten. Brace-matching backward from
+    /// that copy lands on a stray `{` in binary garbage ("key must be a string
+    /// at line 1 column 2"), so the stale occurrence has to be skipped in
+    /// favour of the live one.
+    #[test]
+    fn a_stale_headless_copy_is_skipped_for_the_live_blob() {
+        let mut combined = b"\x00{J>\x01\x02 garbage ".to_vec();
+        combined.extend_from_slice(br#""SubscribedToEmails":0,"RegularCredits":1,"#);
+        combined.extend_from_slice(b"\x03\x04 more garbage ");
+        let live_at = combined.len();
+        combined.extend_from_slice(br#"{"SubscribedToEmails":0,"RegularCredits":42}"#);
+
+        let (marker_at, seed_at) = blob_seed_offsets(&combined);
+        assert_eq!(seed_at, live_at, "seed is the live copy's opening brace");
+        assert!(marker_at > live_at, "the marker used is the live copy's");
+    }
+
+    /// With only the headless copy in the buffer, seeding at the marker lets
+    /// the parser rebuild the object head instead of parsing garbage.
+    #[test]
+    fn a_lone_headless_copy_seeds_at_its_marker() {
+        let mut combined = b"\x00{J>\x01\x02 garbage ".to_vec();
+        let marker = combined.len();
+        combined.extend_from_slice(br#""SubscribedToEmails":0,"RegularCredits":42,"#);
+
+        let (marker_at, seed_at) = blob_seed_offsets(&combined);
+        assert_eq!(marker_at, marker);
+        assert_eq!(seed_at, marker, "seed skips the garbage brace");
     }
 }
 

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -1629,6 +1629,76 @@ fn scan_linux_inventory_regions(
     }
 }
 
+/// Re-read the blob straight from the address the last successful scan found it
+/// at, stitching forward through following mappings until the JSON closes.
+///
+/// The full walk reads several gigabytes to reach a blob that, in practice,
+/// sits near the very top of the address space — the last few percent of the
+/// mappings. Because the monitor rescans every 10 seconds and the game rarely
+/// moves the allocation between them, probing the remembered address first
+/// turns the common case into a few megabytes of reads.
+///
+/// Returns `None` whenever anything looks different from last time, which puts
+/// the caller back on the full walk rather than reporting a stale inventory.
+#[cfg(target_os = "linux")]
+fn scan_linux_cached_blob(
+    process: &LinuxProcess,
+    regions: &[LinuxRegion],
+) -> Option<(usize, Vec<u8>, BlobInventory)> {
+    const MAX_SCAN: usize = 20 * 1024 * 1024;
+    const START_MARKER: &[u8] = b"\"SubscribedToEmails\"";
+    const MISSION_DELTA: &[u8] = b"\"InventoryChanges\":";
+
+    let cached = LAST_BLOB_REGION.load(std::sync::atomic::Ordering::Relaxed) as usize;
+    if cached == 0 {
+        return None;
+    }
+    let index = regions
+        .iter()
+        .position(|region| cached >= region.start && cached < region.start + region.len)?;
+
+    // The cached address is the blob's opening brace, so the seed starts there
+    // and runs to the end of its mapping.
+    let region = &regions[index];
+    let mut data = vec![0; region.start + region.len - cached];
+    let read = process.read(cached, &mut data).ok()?;
+    data.truncate(read);
+    // The walk seeds either from the blob's opening brace or, when the brace
+    // sits in an earlier mapping it could not stitch, from the start marker
+    // itself. Accept both shapes and reject anything else as a stale address.
+    if !data.starts_with(b"{\"") && !data.starts_with(START_MARKER) {
+        return None;
+    }
+    // A mission reward delta shares most of the blob's field names but describes
+    // a single mission, so treating one as the inventory would wipe the cache.
+    if AhoCorasick::new([MISSION_DELTA])
+        .expect("mission marker is a valid literal")
+        .is_match(&data[..])
+    {
+        return None;
+    }
+
+    // Continue through the following mappings exactly as the full walk does:
+    // the blob regularly spans several of them, and gaps between mappings do
+    // not interrupt the JSON.
+    let mut next = index + 1;
+    while find_blob_end(&data).is_none() {
+        if data.len() >= MAX_SCAN {
+            return None;
+        }
+        let region = regions.get(next)?;
+        next += 1;
+        if region.executable {
+            continue;
+        }
+        let mut buffer = vec![0; region.len.min(MAX_SCAN - data.len())];
+        let read = process.read(region.start, &mut buffer).ok()?;
+        data.extend_from_slice(&buffer[..read]);
+    }
+
+    parse_full_account_blob(&data).map(|inventory| (cached, data, inventory))
+}
+
 #[cfg(target_os = "linux")]
 pub fn capture_all_blobs(
     blob_dir: &std::path::Path,
@@ -1657,6 +1727,16 @@ pub fn capture_all_blobs(
         }
     };
 
+    // Saving blobs is a debugging path that wants every copy in memory, so it
+    // always takes the full walk.
+    if !save {
+        if let Some((address, _, inventory)) = scan_linux_cached_blob(&process, &regions) {
+            eprintln!("[blob] Linux cached-region hit at 0x{address:012x}");
+            blob_tx.send(inventory).ok();
+            return 0;
+        }
+    }
+
     let mut found = 0;
     let mut saved = 0;
     scan_linux_inventory_regions(&process, regions, |address, raw, inventory| {
@@ -1680,6 +1760,8 @@ pub fn capture_all_blobs(
                 }
             }
         }
+        // Remember where this blob started so the next cycle can skip the walk.
+        LAST_BLOB_REGION.store(address as u64, std::sync::atomic::Ordering::Relaxed);
         blob_tx.send(inventory).ok();
         save && found < MAX_BLOBS
     });
@@ -2009,6 +2091,33 @@ mod linux_tests {
             .expect("marker address is mapped");
         assert_eq!(read, marker.len());
         assert_eq!(actual, marker);
+    }
+
+    #[test]
+    fn linux_cached_blob_is_reread_and_rejected_when_stale() {
+        // Blobs under 50 KB are rejected as coincidental fragments, so the
+        // fixture pads the object out to a realistic size.
+        let mut data = br#"{"SubscribedToEmails":true,"RegularCredits":42,"MiscItems":[],"#.to_vec();
+        data.resize(64_000, b' ');
+        data.extend_from_slice(br#""DeathSquadable":false}"#);
+        data.resize(128_000, 0);
+        let regions = vec![LinuxRegion {
+            start: data.as_ptr() as usize,
+            len: data.len(),
+            executable: false,
+        }];
+        let process = LinuxProcess::open(std::process::id()).expect("current process is readable");
+
+        LAST_BLOB_REGION.store(data.as_ptr() as u64, std::sync::atomic::Ordering::Relaxed);
+        let hit = scan_linux_cached_blob(&process, &regions);
+        assert_eq!(hit.expect("cached blob is re-read").2.credits, 42);
+
+        // An address that no longer starts a blob must fall back to the walk
+        // rather than reporting whatever happens to live there now.
+        LAST_BLOB_REGION.store(data.as_ptr() as u64 + 8, std::sync::atomic::Ordering::Relaxed);
+        assert!(scan_linux_cached_blob(&process, &regions).is_none());
+
+        reset_last_blob_region();
     }
 
     #[test]

--- a/src-tauri/src/ocr.rs
+++ b/src-tauri/src/ocr.rs
@@ -215,14 +215,10 @@ fn preprocess_for_ocr(pixels: &[u8], width: u32, height: u32) -> (Vec<u8>, u32, 
 
 /// OCR a rectangle from a pre-captured pixel buffer. All coordinates are 0.0–1.0 fractions.
 /// Applies a mild contrast stretch before OCR (no upscaling — upscaling distorts numerals).
-///
-/// `layout` describes what the rectangle contains: callers that crop down to one
-/// panel pass `Block`, callers that pass the whole frame pass `Scattered`. The
-/// distinction is invisible to Windows OCR and decisive for Tesseract.
+#[cfg(target_os = "windows")]
 pub fn ocr_pixels_rect(
     pixels: &[u8], full_w: u32, full_h: u32,
     x_start: f32, x_end: f32, y_start: f32, y_end: f32,
-    layout: OcrLayout,
 ) -> Result<String, String> {
     let col_s = (full_w as f32 * x_start.clamp(0.0, 1.0)) as usize;
     let col_e = ((full_w as f32 * x_end.clamp(0.0, 1.0)) as usize).min(full_w as usize);
@@ -242,15 +238,15 @@ pub fn ocr_pixels_rect(
     }
 
     let (enhanced, ew, eh) = preprocess_for_ocr(&cropped, rect_w, rect_h);
-    run_ocr(&enhanced, ew, eh, layout).map(|(text, _)| text)
+    let bmp = to_bmp(&enhanced, ew, eh);
+    run_windows_ocr(bmp, ew, eh).map(|(text, _)| text)
 }
 
 /// OCR a rectangle WITHOUT preprocessing — for white-on-dark text that OCRs fine raw.
-/// See `ocr_pixels_rect` for what `layout` selects.
+#[cfg(target_os = "windows")]
 pub fn ocr_pixels_rect_raw(
     pixels: &[u8], full_w: u32, full_h: u32,
     x_start: f32, x_end: f32, y_start: f32, y_end: f32,
-    layout: OcrLayout,
 ) -> Result<String, String> {
     let col_s = (full_w as f32 * x_start.clamp(0.0, 1.0)) as usize;
     let col_e = ((full_w as f32 * x_end.clamp(0.0, 1.0)) as usize).min(full_w as usize);
@@ -267,21 +263,108 @@ pub fn ocr_pixels_rect_raw(
         let dst = row * dst_stride;
         cropped[dst..dst + dst_stride].copy_from_slice(&pixels[src..src + dst_stride]);
     }
-    run_ocr(&cropped, rect_w, rect_h, layout).map(|(text, _)| text)
+    let bmp = to_bmp(&cropped, rect_w, rect_h);
+    run_windows_ocr(bmp, rect_w, rect_h).map(|(text, _)| text)
+}
+
+// ==============================================================================
+// Linux entry points — the same contract, a different engine
+// ==============================================================================
+//
+// These mirror the two functions above rather than sharing them. Sharing would
+// mean rewriting a function upstream actively develops, and `ocr.rs` is one of
+// the files upstream churns hardest; a duplicated crop loop costs us nothing on
+// a sync, while an edit to upstream's version costs a conflict on every one.
+// The signatures are deliberately identical to upstream's so that call sites in
+// `lib.rs` stay platform-agnostic and keep speaking upstream's 7-argument form.
+
+/// Crop a BGRA rectangle out of a full frame. Fractions, as above.
+///
+/// Returns `None` when the rectangle is under four pixels on a side, matching
+/// the "Region too small" rejection the Windows path applies.
+#[cfg(target_os = "linux")]
+fn crop_bgra(
+    pixels: &[u8], full_w: u32, full_h: u32,
+    x_start: f32, x_end: f32, y_start: f32, y_end: f32,
+) -> Option<(Vec<u8>, u32, u32)> {
+    let col_s = (full_w as f32 * x_start.clamp(0.0, 1.0)) as usize;
+    let col_e = ((full_w as f32 * x_end.clamp(0.0, 1.0)) as usize).min(full_w as usize);
+    let row_s = (full_h as f32 * y_start.clamp(0.0, 1.0)) as usize;
+    let row_e = ((full_h as f32 * y_end.clamp(0.0, 1.0)) as usize).min(full_h as usize);
+    let rect_w = (col_e - col_s) as u32;
+    let rect_h = (row_e - row_s) as u32;
+    if rect_w < 4 || rect_h < 4 {
+        return None;
+    }
+    let src_stride = full_w as usize * 4;
+    let dst_stride = rect_w as usize * 4;
+    let mut cropped = vec![0u8; dst_stride * rect_h as usize];
+    for row in 0..rect_h as usize {
+        let src = (row_s + row) * src_stride + col_s * 4;
+        let dst = row * dst_stride;
+        cropped[dst..dst + dst_stride].copy_from_slice(&pixels[src..src + dst_stride]);
+    }
+    Some((cropped, rect_w, rect_h))
+}
+
+/// Which page-segmentation mode a rectangle wants from Tesseract.
+///
+/// The hint is derived from the rectangle rather than passed in, because passing
+/// it in means adding an argument to a signature upstream owns, at every call
+/// site in `lib.rs`. Full width means the caller handed us a whole game frame —
+/// the only case that wants sparse mode. Every cropped region is a panel.
+///
+/// ponytail: heuristic stands in for an explicit parameter. It holds while
+/// "full width" and "whole frame" mean the same thing. A future caller that
+/// crops vertically but keeps the full width would read as `Scattered` and get
+/// nothing back; if that case appears, thread the layout through a Linux-only
+/// entry point rather than widening upstream's signature.
+#[cfg(target_os = "linux")]
+fn layout_for(x_start: f32, x_end: f32) -> OcrLayout {
+    if x_end - x_start >= 0.99 {
+        OcrLayout::Scattered
+    } else {
+        OcrLayout::Block
+    }
+}
+
+/// Linux twin of the Windows `ocr_pixels_rect`. Same contract, Tesseract behind it.
+#[cfg(target_os = "linux")]
+pub fn ocr_pixels_rect(
+    pixels: &[u8], full_w: u32, full_h: u32,
+    x_start: f32, x_end: f32, y_start: f32, y_end: f32,
+) -> Result<String, String> {
+    let (cropped, rect_w, rect_h) =
+        crop_bgra(pixels, full_w, full_h, x_start, x_end, y_start, y_end)
+            .ok_or_else(|| "Region too small".to_string())?;
+    let (enhanced, ew, eh) = preprocess_for_ocr(&cropped, rect_w, rect_h);
+    run_ocr(&enhanced, ew, eh, layout_for(x_start, x_end)).map(|(text, _)| text)
+}
+
+/// Linux twin of the Windows `ocr_pixels_rect_raw`.
+#[cfg(target_os = "linux")]
+pub fn ocr_pixels_rect_raw(
+    pixels: &[u8], full_w: u32, full_h: u32,
+    x_start: f32, x_end: f32, y_start: f32, y_end: f32,
+) -> Result<String, String> {
+    let (cropped, rect_w, rect_h) =
+        crop_bgra(pixels, full_w, full_h, x_start, x_end, y_start, y_end)
+            .ok_or_else(|| "Region too small".to_string())?;
+    run_ocr(&cropped, rect_w, rect_h, layout_for(x_start, x_end)).map(|(text, _)| text)
 }
 
 /// Convenience: capture + OCR a vertical strip of the window (full width).
 #[allow(dead_code)]
 pub fn capture_and_ocr_region(y_start: f32, y_end: f32) -> Result<String, String> {
     let (pixels, w, h) = capture_warframe_pixels()?;
-    ocr_pixels_rect(&pixels, w, h, 0.0, 1.0, y_start, y_end, OcrLayout::Scattered)
+    ocr_pixels_rect(&pixels, w, h, 0.0, 1.0, y_start, y_end)
 }
 
 /// Convenience: capture + OCR a specific rectangle.
 #[allow(dead_code)]
 pub fn capture_rect_and_ocr(x_start: f32, x_end: f32, y_start: f32, y_end: f32) -> Result<String, String> {
     let (pixels, w, h) = capture_warframe_pixels()?;
-    ocr_pixels_rect(&pixels, w, h, x_start, x_end, y_start, y_end, OcrLayout::Block)
+    ocr_pixels_rect(&pixels, w, h, x_start, x_end, y_start, y_end)
 }
 
 /// Captures the full Warframe window region from the desktop using GDI BitBlt.
@@ -570,96 +653,12 @@ pub fn to_bmp(pixels_bgra: &[u8], width: u32, height: u32) -> Vec<u8> {
     bmp
 }
 
-// ─── OCR line assembly (engine-independent) ───────────────────────────────────
-
-/// One recognised word, with its horizontal extent and vertical centre already
-/// expressed as fractions of the source image. Both OCR engines (WinRT on
-/// Windows, Tesseract on Linux) report pixel bounding boxes; normalising at the
-/// engine boundary lets the card-column logic downstream stay resolution- and
-/// engine-agnostic.
-pub struct OcrWord {
-    pub text: String,
-    pub x_left: f32,
-    pub x_right: f32,
-    pub cy: f32,
-}
-
-/// How much page structure the OCR engine should assume.
-///
-/// Windows OCR does its own layout analysis and ignores this; Tesseract does not,
-/// and picks up nothing at all on the wrong setting — a cropped riven card reads
-/// perfectly as one block and returns empty as scattered text, and a full reward
-/// frame does the opposite.
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub enum OcrLayout {
-    /// Text scattered anywhere in a full game frame.
-    Scattered,
-    /// A single block of text filling a cropped region.
-    Block,
-}
-
-/// Inter-card gap: reward cards are separated by ~10–12% of image width.
-/// Word gaps within a single item name are ≤ 3%. Splitting at 7% cleanly
-/// divides "Daikyu Prime Upper Limb Nautilus Prime Systems" (which both OCR
-/// engines merge into one line when the two names share a baseline Y) into the
-/// two separate card entries the column-assignment logic expects.
-const WORD_GAP: f32 = 0.07;
-
-/// Turn engine lines into the `(full_text, positions)` pair the reward pipeline
-/// consumes, splitting any line whose internal word gap exceeds `WORD_GAP`.
-///
-/// Each returned entry is `(text, x_centre, y_centre)`, averaged over the words
-/// that make up that sub-line.
-fn assemble_ocr_lines(engine_lines: &[Vec<OcrWord>]) -> (String, Vec<(String, f32, f32)>) {
-    let mut full = String::new();
-    let mut lines_out: Vec<(String, f32, f32)> = Vec::new();
-
-    for words in engine_lines {
-        // Walk words left-to-right; flush a sub-line whenever the horizontal
-        // gap to the next word exceeds WORD_GAP.
-        let mut seg_texts: Vec<&str> = Vec::new();
-        let mut seg_sx = 0.0f32;
-        let mut seg_sy = 0.0f32;
-        let mut seg_n = 0u32;
-        let mut prev_right = -1.0f32;
-        for w in words {
-            if prev_right >= 0.0 && (w.x_left - prev_right) > WORD_GAP && !seg_texts.is_empty() {
-                let sub = seg_texts.join(" ");
-                full.push_str(&sub);
-                full.push('\n');
-                lines_out.push((sub, seg_sx / seg_n as f32, seg_sy / seg_n as f32));
-                seg_texts.clear();
-                seg_sx = 0.0;
-                seg_sy = 0.0;
-                seg_n = 0;
-            }
-            seg_texts.push(&w.text);
-            seg_sx += (w.x_left + w.x_right) / 2.0;
-            seg_sy += w.cy;
-            seg_n += 1;
-            prev_right = w.x_right;
-        }
-        if !seg_texts.is_empty() {
-            let sub = seg_texts.join(" ");
-            full.push_str(&sub);
-            full.push('\n');
-            lines_out.push((sub, seg_sx / seg_n as f32, seg_sy / seg_n as f32));
-        }
-    }
-
-    (full, lines_out)
-}
-
 // ─── Windows OCR ──────────────────────────────────────────────────────────────
 
-/// Run Windows.Media.Ocr on a BGRA buffer. Returns (full_text, line_positions).
-/// line_positions: Vec<(line_text, x_frac, y_frac)> — centre per line from word
-/// bounding rects. `BitmapDecoder` wants an encoded image, so the buffer is
-/// wrapped in a BMP here; the Linux backend takes the same buffer and hands
-/// Tesseract raw samples instead.
+/// Run Windows.Media.Ocr on a BMP. Returns (full_text, line_positions).
+/// line_positions: Vec<(line_text, x_frac)> — X centre per line from word bounding rects.
 #[cfg(target_os = "windows")]
-pub fn run_ocr(pixels_bgra: &[u8], img_w: u32, img_h: u32, _layout: OcrLayout) -> Result<(String, Vec<(String, f32, f32)>), String> {
-    let bmp = to_bmp(pixels_bgra, img_w, img_h);
+pub fn run_windows_ocr(bmp: Vec<u8>, img_w: u32, img_h: u32) -> Result<(String, Vec<(String, f32, f32)>), String> {
     // Ensure COM is initialized for this thread. Tokio spawn_blocking threads
     // start without a COM apartment; WinRT calls fail or return empty silently.
     // CoInitializeEx returns S_OK (first init), S_FALSE (already MTA), or
@@ -699,39 +698,57 @@ pub fn run_ocr(pixels_bgra: &[u8], img_w: u32, img_h: u32, _layout: OcrLayout) -
             .or_else(|_| OcrEngine::TryCreateFromUserProfileLanguages())?;
         let result = engine.RecognizeAsync(&bitmap)?.get()?;
 
+        let mut full = String::new();
+        let mut lines_out: Vec<(String, f32, f32)> = Vec::new();
         let lines: IVectorView<OcrLine> = result.Lines()?;
         let count = lines.Size()?;
-        let mut engine_lines: Vec<Vec<OcrWord>> = Vec::with_capacity(count as usize);
+        // Inter-card gap: reward cards are separated by ~10–12% of image width.
+        // Word gaps within a single item name are ≤ 3%. Splitting at 7% cleanly
+        // divides "Daikyu Prime Upper Limb Nautilus Prime Systems" (which WinRT
+        // merges into one line when both names share the same baseline Y) into the
+        // two separate card entries the column-assignment logic expects.
+        const WORD_GAP: f32 = 0.07;
         for i in 0..count {
             let line = lines.GetAt(i)?;
             let words = line.Words()?;
             let wc = words.Size()?;
             if wc == 0 {
-                // A line with text but no word boxes carries no position — centre
-                // it so the column assignment treats it as ambiguous rather than
-                // pinning it to the left edge.
-                engine_lines.push(vec![OcrWord {
-                    text: line.Text()?.to_string(),
-                    x_left: 0.5,
-                    x_right: 0.5,
-                    cy: 0.5,
-                }]);
+                let text = line.Text()?.to_string();
+                full.push_str(&text); full.push('\n');
+                lines_out.push((text, 0.5, 0.5));
                 continue;
             }
-            let mut words_out = Vec::with_capacity(wc as usize);
+            // Walk words left-to-right; flush a sub-line whenever the horizontal
+            // gap to the next word exceeds WORD_GAP.
+            let mut seg_texts: Vec<String> = Vec::new();
+            let mut seg_sx = 0.0f32;
+            let mut seg_sy = 0.0f32;
+            let mut seg_n  = 0u32;
+            let mut prev_right = -1.0f32;
             for j in 0..wc {
-                let w = words.GetAt(j)?;
-                let r = w.BoundingRect()?;
-                words_out.push(OcrWord {
-                    text: w.Text()?.to_string(),
-                    x_left: if img_w > 0 { r.X / img_w as f32 } else { 0.0 },
-                    x_right: if img_w > 0 { (r.X + r.Width) / img_w as f32 } else { 1.0 },
-                    cy: if img_h > 0 { (r.Y + r.Height / 2.0) / img_h as f32 } else { 0.5 },
-                });
+                let w  = words.GetAt(j)?;
+                let r  = w.BoundingRect()?;
+                let cx = if img_w > 0 { (r.X + r.Width  / 2.0) / img_w as f32 } else { 0.5 };
+                let cy = if img_h > 0 { (r.Y + r.Height / 2.0) / img_h as f32 } else { 0.5 };
+                let xl = if img_w > 0 { r.X / img_w as f32 } else { 0.0 };
+                let xr = if img_w > 0 { (r.X + r.Width) / img_w as f32 } else { 1.0 };
+                if prev_right >= 0.0 && (xl - prev_right) > WORD_GAP && !seg_texts.is_empty() {
+                    let sub = seg_texts.join(" ");
+                    full.push_str(&sub); full.push('\n');
+                    lines_out.push((sub, seg_sx / seg_n as f32, seg_sy / seg_n as f32));
+                    seg_texts.clear(); seg_sx = 0.0; seg_sy = 0.0; seg_n = 0;
+                }
+                seg_texts.push(w.Text()?.to_string());
+                seg_sx += cx; seg_sy += cy; seg_n += 1;
+                prev_right = xr;
             }
-            engine_lines.push(words_out);
+            if !seg_texts.is_empty() {
+                let sub = seg_texts.join(" ");
+                full.push_str(&sub); full.push('\n');
+                lines_out.push((sub, seg_sx / seg_n as f32, seg_sy / seg_n as f32));
+            }
         }
-        Ok(assemble_ocr_lines(&engine_lines))
+        Ok((full, lines_out))
     })().map_err(|e| e.to_string())
 }
 
@@ -867,6 +884,7 @@ fn normalise(s: &str) -> String {
 /// band have bar-coloured pixels. Columns that are consistently orange or teal
 /// across many rows score high. This is far more robust than row-by-row detection
 /// because it tolerates thin bars, color gradients, and single-row noise.
+#[cfg(any(target_os = "windows", target_os = "linux"))]
 /// Returns `(Some((centers, bar_y_frac)), diagnostic_string)`.
 /// `centers` are fractions of image width — the diamond icon X per card.
 /// The diagnostic string is always populated for session log inclusion.
@@ -1042,6 +1060,11 @@ fn find_rarity_bars(pixels: &[u8], pix_w: u32, pix_h: u32) -> (Option<(Vec<f32>,
     (Some((centers, bar_y)), diag)
 }
 
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
+fn find_rarity_bars(_: &[u8], _: u32, _: u32) -> (Option<(Vec<f32>, f32)>, String) {
+    (None, "not supported on non-Windows".into())
+}
+
 // ─── Icon component classifier ────────────────────────────────────────────────
 
 /// What the card icon looks like, used to constrain catalog matching.
@@ -1084,6 +1107,7 @@ pub enum IconType {
 ///   ⑧ blade        — low symmetry, moderate aspect (flat asymmetric part)
 ///   ⑨ upper/lower limb — low fill, arc-shaped (bow components)
 ///   Unknown        — ambiguous; fall back to text-only matching
+#[cfg(any(target_os = "windows", target_os = "linux"))]
 fn classify_card_icon(
     pixels: &[u8], pix_w: u32, pix_h: u32,
     x_left: f32, x_right: f32, bar_y: f32,
@@ -1217,6 +1241,11 @@ fn classify_card_icon(
         };
     }
 
+    IconType::Unknown
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
+fn classify_card_icon(_: &[u8], _: u32, _: u32, _: f32, _: f32, _: f32) -> IconType {
     IconType::Unknown
 }
 
@@ -1357,6 +1386,7 @@ fn score_item(display_name: &str, words: &std::collections::HashSet<String>) -> 
 /// 3. Assign each OCR line to the nearest card (by X).
 /// 4. Per-card word set → prefix + fuzzy match against relic catalog.
 /// 5. Full-frame fallback if bar detection fails.
+#[cfg(any(target_os = "windows", target_os = "linux"))]
 pub fn extract_reward_items_twophase(
     pixels: &[u8], pix_w: u32, pix_h: u32, _game_h: u32,
     catalog: &[(String, String)],
@@ -1366,8 +1396,16 @@ pub fn extract_reward_items_twophase(
 ) -> (bool, bool, Vec<String>, Vec<f32>, String) {
 
     // ── 1. Raw OCR ────────────────────────────────────────────────────────────
+    // Each platform calls its own engine directly rather than going through a
+    // shared wrapper. Upstream's line is kept verbatim so this hunk stays a pure
+    // addition on their side of the file; the Linux arm sits beside it.
+    #[cfg(target_os = "windows")]
+    let engine_output = run_windows_ocr(to_bmp(pixels, pix_w, pix_h), pix_w, pix_h);
+    #[cfg(target_os = "linux")]
+    let engine_output = run_ocr(pixels, pix_w, pix_h, OcrLayout::Scattered);
+
     let (raw_full, ocr_lines) =
-        match run_ocr(pixels, pix_w, pix_h, OcrLayout::Scattered) {
+        match engine_output {
             Ok(r) => r,
             Err(e) => return (false, false, vec![], vec![],
                 format!("├─ Capture  : {}\n└─ OCR error: {}", capture_info, e)),
@@ -2215,6 +2253,95 @@ pub fn capture_desktop_for_diag() -> Option<(Vec<u8>, u32, u32)> {
     None
 }
 
+// ─── OCR line assembly (Linux/Tesseract) ─────────────────────────────────────
+//
+// Upstream assembles its lines inline inside `run_windows_ocr`, and that is
+// left exactly as upstream wrote it. This is the same logic re-expressed for
+// Tesseract, which reports geometry per word in TSV rather than per line.
+
+/// One recognised word, with its horizontal extent and vertical centre already
+/// expressed as fractions of the source image. Both OCR engines (WinRT on
+/// Windows, Tesseract on Linux) report pixel bounding boxes; normalising at the
+/// engine boundary lets the card-column logic downstream stay resolution- and
+/// engine-agnostic.
+#[cfg(target_os = "linux")]
+pub struct OcrWord {
+    pub text: String,
+    pub x_left: f32,
+    pub x_right: f32,
+    pub cy: f32,
+}
+
+/// How much page structure the OCR engine should assume.
+///
+/// Windows OCR does its own layout analysis and ignores this; Tesseract does not,
+/// and picks up nothing at all on the wrong setting — a cropped riven card reads
+/// perfectly as one block and returns empty as scattered text, and a full reward
+/// frame does the opposite.
+#[cfg(target_os = "linux")]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum OcrLayout {
+    /// Text scattered anywhere in a full game frame.
+    Scattered,
+    /// A single block of text filling a cropped region.
+    Block,
+}
+
+/// Inter-card gap: reward cards are separated by ~10–12% of image width.
+/// Word gaps within a single item name are ≤ 3%. Splitting at 7% cleanly
+/// divides "Daikyu Prime Upper Limb Nautilus Prime Systems" (which both OCR
+/// engines merge into one line when the two names share a baseline Y) into the
+/// two separate card entries the column-assignment logic expects.
+#[cfg(target_os = "linux")]
+const WORD_GAP: f32 = 0.07;
+
+/// Turn engine lines into the `(full_text, positions)` pair the reward pipeline
+/// consumes, splitting any line whose internal word gap exceeds `WORD_GAP`.
+///
+/// Each returned entry is `(text, x_centre, y_centre)`, averaged over the words
+/// that make up that sub-line.
+#[cfg(target_os = "linux")]
+fn assemble_ocr_lines(engine_lines: &[Vec<OcrWord>]) -> (String, Vec<(String, f32, f32)>) {
+    let mut full = String::new();
+    let mut lines_out: Vec<(String, f32, f32)> = Vec::new();
+
+    for words in engine_lines {
+        // Walk words left-to-right; flush a sub-line whenever the horizontal
+        // gap to the next word exceeds WORD_GAP.
+        let mut seg_texts: Vec<&str> = Vec::new();
+        let mut seg_sx = 0.0f32;
+        let mut seg_sy = 0.0f32;
+        let mut seg_n = 0u32;
+        let mut prev_right = -1.0f32;
+        for w in words {
+            if prev_right >= 0.0 && (w.x_left - prev_right) > WORD_GAP && !seg_texts.is_empty() {
+                let sub = seg_texts.join(" ");
+                full.push_str(&sub);
+                full.push('\n');
+                lines_out.push((sub, seg_sx / seg_n as f32, seg_sy / seg_n as f32));
+                seg_texts.clear();
+                seg_sx = 0.0;
+                seg_sy = 0.0;
+                seg_n = 0;
+            }
+            seg_texts.push(&w.text);
+            seg_sx += (w.x_left + w.x_right) / 2.0;
+            seg_sy += w.cy;
+            seg_n += 1;
+            prev_right = w.x_right;
+        }
+        if !seg_texts.is_empty() {
+            let sub = seg_texts.join(" ");
+            full.push_str(&sub);
+            full.push('\n');
+            lines_out.push((sub, seg_sx / seg_n as f32, seg_sy / seg_n as f32));
+        }
+    }
+
+    (full, lines_out)
+}
+
+
 /// Tesseract stand-in for `Windows.Media.Ocr`. Same contract: a BGRA buffer in,
 /// `(full_text, per-line (text, x_centre, y_centre))` out.
 ///
@@ -2482,14 +2609,21 @@ pub fn capture_desktop_for_diag() -> Option<(Vec<u8>, u32, u32)> {
     None
 }
 
+// Upstream's own non-Windows stubs, narrowed to exclude Linux now that Linux has
+// real implementations. Kept in upstream's wording and shape so the only delta
+// on these lines is the widened `cfg`.
 #[cfg(not(any(target_os = "windows", target_os = "linux")))]
-pub fn run_ocr(
-    _pixels_bgra: &[u8],
-    _w: u32,
-    _h: u32,
-    _layout: OcrLayout,
-) -> Result<(String, Vec<(String, f32, f32)>), String> {
+pub fn run_windows_ocr(_bmp: Vec<u8>, _w: u32, _h: u32) -> Result<(String, Vec<(String, f32, f32)>), String> {
     Err(OCR_UNSUPPORTED.into())
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
+pub fn extract_reward_items_twophase(
+    _pixels: &[u8], _w: u32, _cap_h: u32, _full_h: u32,
+    _catalog: &[(String, String)], _capture_info: &str,
+    _hint_squad_size: Option<usize>, _player_names: &[String],
+) -> (bool, bool, Vec<String>, Vec<f32>, String) {
+    (false, false, vec![], vec![], String::new())
 }
 
 #[cfg(test)]

--- a/src-tauri/src/ocr.rs
+++ b/src-tauri/src/ocr.rs
@@ -2273,6 +2273,31 @@ fn reads_as_words(text: &str) -> bool {
         .any(|token| token.len() >= 3)
 }
 
+/// Directory holding the language model shipped with the app, when there is one.
+///
+/// Empty for a `cargo run` build, which falls back to whatever model the system
+/// has installed. Every bundle carries its own copy, so this is only unset when
+/// the app is run straight out of the build directory.
+#[cfg(target_os = "linux")]
+static BUNDLED_TESSDATA: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
+/// Point Tesseract at the app's own copy of the language model.
+///
+/// Without this, OCR fails to initialise on any host that has not installed
+/// Tesseract's English data separately, which no Linux bundle can guarantee.
+/// Called once at startup with the bundle's resource directory; a
+/// directory without the model in it is ignored, so a build that skipped the
+/// fetch still runs against the system copy rather than failing outright.
+#[cfg(target_os = "linux")]
+pub fn use_bundled_tessdata(resource_dir: &std::path::Path) {
+    let dir = resource_dir.join("tessdata");
+    if dir.join("eng.traineddata").is_file() {
+        if let Some(dir) = dir.to_str() {
+            let _ = BUNDLED_TESSDATA.set(dir.to_string());
+        }
+    }
+}
+
 /// Run Tesseract over one 8-bit sample per pixel.
 #[cfg(target_os = "linux")]
 fn recognize_samples(
@@ -2283,16 +2308,9 @@ fn recognize_samples(
 ) -> Result<(String, Vec<(String, f32, f32)>), String> {
     use tesseract::{PageSegMode, Tesseract};
 
-    let mut engine = Tesseract::new(None, Some("eng"))
+    let mut engine = Tesseract::new(BUNDLED_TESSDATA.get().map(String::as_str), Some("eng"))
         .map_err(|e| format!("Cannot initialise Tesseract (is eng.traineddata installed?): {e}"))?;
 
-    // A full game frame is not a document page: Tesseract's default layout
-    // analysis looks for columns and a reading order in scattered HUD text and
-    // drops most of it, whereas sparse mode reports every text region it finds —
-    // which is what the position-based card assignment downstream wants. A
-    // cropped region is the opposite case: it holds one block of lines, and
-    // sparse mode reads nothing at all from a riven card that single-block mode
-    // transcribes exactly.
     engine.set_page_seg_mode(match layout {
         OcrLayout::Scattered => PageSegMode::PsmSparseText,
         OcrLayout::Block => PageSegMode::PsmSingleBlock,

--- a/src-tauri/src/ocr.rs
+++ b/src-tauri/src/ocr.rs
@@ -2003,7 +2003,7 @@ const WARFRAME_WINDOW_TITLE: &str = "Warframe";
 /// connection would have to be re-established anyway whenever the X server or
 /// XWayland restarts.
 #[cfg(target_os = "linux")]
-fn x11_connect() -> Result<xcb::Connection, String> {
+pub(crate) fn x11_connect() -> Result<xcb::Connection, String> {
     xcb::Connection::connect(None)
         .map(|(conn, _screen)| conn)
         .map_err(|e| format!("Cannot connect to the X server: {e}"))

--- a/src-tauri/src/ocr.rs
+++ b/src-tauri/src/ocr.rs
@@ -2537,6 +2537,124 @@ mod tesseract_tests {
         assert!(reads_as_words("| Gauss Prime Chassis"));
         assert!(reads_as_words("MR11"));
     }
+
+    // ==========================================================================
+    // Reward extraction corpus
+    // ==========================================================================
+    //
+    // Everything above this line pins one component in isolation. This runs the
+    // whole reward pipeline — capture-shaped pixels in, item names out — over
+    // labelled screenshots of real reward screens, which is the only way to tell
+    // whether a change to bar detection or catalog scoring actually helps.
+
+    /// Images the pipeline currently gets wrong, with the reason. Listed rather
+    /// than ignored so the test fails in BOTH directions: a regression adds an
+    /// entry, and fixing a bug without deleting its entry is also a failure.
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    const KNOWN_MISSES: &[(&str, &str)] = &[];
+
+    /// End-to-end reward extraction against the labelled corpus.
+    ///
+    /// The corpus is not vendored: it is megabytes of real reward screens that
+    /// already live in the sibling `wfinfo-ng` checkout, so the test skips when
+    /// it is missing rather than failing. `WFINFO_TEST_IMAGES` overrides the
+    /// location. Expect roughly one OCR pass per image — this is the slow test.
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[test]
+    fn reward_extraction_matches_the_labelled_corpus() {
+        let dir = std::path::PathBuf::from(
+            std::env::var("WFINFO_TEST_IMAGES").unwrap_or_else(|_| {
+                format!("{}/../../wfinfo-ng/test-images", env!("CARGO_MANIFEST_DIR"))
+            }),
+        );
+        let manifest = match std::fs::read_to_string(dir.join("manifest.json")) {
+            Ok(m) => m,
+            Err(_) => {
+                eprintln!(
+                    "skipping: no reward corpus at {} (set WFINFO_TEST_IMAGES)",
+                    dir.display()
+                );
+                return;
+            }
+        };
+        let manifest: serde_json::Value =
+            serde_json::from_str(&manifest).expect("corpus manifest is JSON we generated");
+        let images = manifest["images"]
+            .as_object()
+            .expect("corpus manifest always has an images object");
+
+        // Nothing in the pipeline reads a unique name — it is only the key it
+        // looks the display name back up by — so each name doubles as its key.
+        let catalog: Vec<(String, String)> =
+            include_str!("../tests/fixtures/relic_rewards.txt")
+                .lines()
+                .filter(|l| !l.is_empty() && !l.starts_with('#'))
+                .map(|n| (n.to_string(), n.to_string()))
+                .collect();
+
+        // The corpus labels a 2× Forma card "Forma Blueprint" while the catalog
+        // carries a distinct "2X Forma Blueprint" entry that the pipeline
+        // correctly prefers. Fold the two together instead of recording a miss
+        // for an answer that is more precise than the label.
+        let fold = |n: &str| n.trim_start_matches("2X ").to_string();
+
+        let mut misses: Vec<(String, String)> = Vec::new();
+        for (file, spec) in images {
+            let image = match tauri::image::Image::from_path(dir.join(file)) {
+                Ok(i) => i,
+                Err(e) => panic!("corpus image {file} does not decode: {e}"),
+            };
+            let (width, full_h) = (image.width(), image.height());
+
+            // Match what the live capture hands the pipeline: BGRA for the top
+            // 80% of the game window. Bar detection reads absolute proportions,
+            // so a full-height frame would not exercise the real geometry.
+            let mut bgra = image.rgba().to_vec();
+            for px in bgra.chunks_exact_mut(4) {
+                px.swap(0, 2);
+            }
+            let cap_h = ((full_h as f32 * 0.80) as u32).max(1);
+            bgra.truncate((width * cap_h * 4) as usize);
+
+            // The squad size is what the live path gets from EE.log; the corpus
+            // has no player names to filter out.
+            let hint_squad = spec["reward_count"].as_u64().map(|n| n as usize);
+            let (_, _, items, _, diag) = extract_reward_items_twophase(
+                &bgra, width, cap_h, full_h, &catalog, file, hint_squad, &[],
+            );
+
+            let mut got: Vec<String> = items.iter().map(|n| fold(n)).collect();
+            let mut want: Vec<String> = spec["items"]
+                .as_array()
+                .expect("every corpus entry lists its items")
+                .iter()
+                .map(|v| fold(v.as_str().expect("item names are strings")))
+                .collect();
+            // Compare as a multiset: which column a name landed in is a separate
+            // concern, and a crossed pair still changes the names themselves.
+            got.sort();
+            want.sort();
+            if got != want {
+                misses.push((
+                    file.clone(),
+                    format!("wanted {want:?}, got {got:?}\n{diag}"),
+                ));
+            }
+        }
+
+        let mut missed: Vec<&str> = misses.iter().map(|(f, _)| f.as_str()).collect();
+        let mut known: Vec<&str> = KNOWN_MISSES.iter().map(|(f, _)| *f).collect();
+        missed.sort();
+        known.sort();
+        for (file, detail) in &misses {
+            eprintln!("── {file}\n{detail}");
+        }
+        assert_eq!(
+            missed, known,
+            "corpus results moved; see the per-image detail above. \
+             Known misses and their causes: {KNOWN_MISSES:?}"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/ocr.rs
+++ b/src-tauri/src/ocr.rs
@@ -1876,6 +1876,49 @@ pub fn capture_desktop_for_diag() -> Option<(Vec<u8>, u32, u32)> {
 #[cfg(not(target_os = "windows"))]
 pub fn capture_desktop_for_diag() -> Option<(Vec<u8>, u32, u32)> { None }
 
+// ==============================================================================
+// Non-Windows capture and OCR stubs
+// ==============================================================================
+//
+// Screen capture and text recognition both go through Windows-only APIs (GDI,
+// DXGI, WinRT OCR). Linux has no equivalent wired up, so every entry point
+// returns the same explicit error instead of silently producing empty text —
+// callers surface it to the user as "unavailable" rather than "found nothing".
+
+#[cfg(not(target_os = "windows"))]
+const OCR_UNSUPPORTED: &str = "OCR is not supported on Linux";
+
+#[cfg(not(target_os = "windows"))]
+pub fn capture_warframe_pixels() -> Result<(Vec<u8>, u32, u32), String> {
+    Err(OCR_UNSUPPORTED.into())
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn capture_screen_for_diagnostics() -> Result<(Vec<u8>, u32, u32), String> {
+    Err(OCR_UNSUPPORTED.into())
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn capture_screen_for_diagnostics_half() -> Result<(Vec<u8>, u32, u32), String> {
+    Err(OCR_UNSUPPORTED.into())
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn ocr_pixels_rect(
+    _pixels: &[u8], _full_w: u32, _full_h: u32,
+    _x_start: f32, _x_end: f32, _y_start: f32, _y_end: f32,
+) -> Result<String, String> {
+    Err(OCR_UNSUPPORTED.into())
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn ocr_pixels_rect_raw(
+    _pixels: &[u8], _full_w: u32, _full_h: u32,
+    _x_start: f32, _x_end: f32, _y_start: f32, _y_end: f32,
+) -> Result<String, String> {
+    Err(OCR_UNSUPPORTED.into())
+}
+
 #[cfg(not(target_os = "windows"))]
 pub fn capture_warframe_reward_area() -> Option<(Vec<u8>, u32, u32, u32, String)> { None }
 

--- a/src-tauri/src/ocr.rs
+++ b/src-tauri/src/ocr.rs
@@ -215,10 +215,14 @@ fn preprocess_for_ocr(pixels: &[u8], width: u32, height: u32) -> (Vec<u8>, u32, 
 
 /// OCR a rectangle from a pre-captured pixel buffer. All coordinates are 0.0–1.0 fractions.
 /// Applies a mild contrast stretch before OCR (no upscaling — upscaling distorts numerals).
-#[cfg(target_os = "windows")]
+///
+/// `layout` describes what the rectangle contains: callers that crop down to one
+/// panel pass `Block`, callers that pass the whole frame pass `Scattered`. The
+/// distinction is invisible to Windows OCR and decisive for Tesseract.
 pub fn ocr_pixels_rect(
     pixels: &[u8], full_w: u32, full_h: u32,
     x_start: f32, x_end: f32, y_start: f32, y_end: f32,
+    layout: OcrLayout,
 ) -> Result<String, String> {
     let col_s = (full_w as f32 * x_start.clamp(0.0, 1.0)) as usize;
     let col_e = ((full_w as f32 * x_end.clamp(0.0, 1.0)) as usize).min(full_w as usize);
@@ -238,15 +242,15 @@ pub fn ocr_pixels_rect(
     }
 
     let (enhanced, ew, eh) = preprocess_for_ocr(&cropped, rect_w, rect_h);
-    let bmp = to_bmp(&enhanced, ew, eh);
-    run_windows_ocr(bmp, ew, eh).map(|(text, _)| text)
+    run_ocr(&enhanced, ew, eh, layout).map(|(text, _)| text)
 }
 
 /// OCR a rectangle WITHOUT preprocessing — for white-on-dark text that OCRs fine raw.
-#[cfg(target_os = "windows")]
+/// See `ocr_pixels_rect` for what `layout` selects.
 pub fn ocr_pixels_rect_raw(
     pixels: &[u8], full_w: u32, full_h: u32,
     x_start: f32, x_end: f32, y_start: f32, y_end: f32,
+    layout: OcrLayout,
 ) -> Result<String, String> {
     let col_s = (full_w as f32 * x_start.clamp(0.0, 1.0)) as usize;
     let col_e = ((full_w as f32 * x_end.clamp(0.0, 1.0)) as usize).min(full_w as usize);
@@ -263,22 +267,21 @@ pub fn ocr_pixels_rect_raw(
         let dst = row * dst_stride;
         cropped[dst..dst + dst_stride].copy_from_slice(&pixels[src..src + dst_stride]);
     }
-    let bmp = to_bmp(&cropped, rect_w, rect_h);
-    run_windows_ocr(bmp, rect_w, rect_h).map(|(text, _)| text)
+    run_ocr(&cropped, rect_w, rect_h, layout).map(|(text, _)| text)
 }
 
 /// Convenience: capture + OCR a vertical strip of the window (full width).
 #[allow(dead_code)]
 pub fn capture_and_ocr_region(y_start: f32, y_end: f32) -> Result<String, String> {
     let (pixels, w, h) = capture_warframe_pixels()?;
-    ocr_pixels_rect(&pixels, w, h, 0.0, 1.0, y_start, y_end)
+    ocr_pixels_rect(&pixels, w, h, 0.0, 1.0, y_start, y_end, OcrLayout::Scattered)
 }
 
 /// Convenience: capture + OCR a specific rectangle.
 #[allow(dead_code)]
 pub fn capture_rect_and_ocr(x_start: f32, x_end: f32, y_start: f32, y_end: f32) -> Result<String, String> {
     let (pixels, w, h) = capture_warframe_pixels()?;
-    ocr_pixels_rect(&pixels, w, h, x_start, x_end, y_start, y_end)
+    ocr_pixels_rect(&pixels, w, h, x_start, x_end, y_start, y_end, OcrLayout::Block)
 }
 
 /// Captures the full Warframe window region from the desktop using GDI BitBlt.
@@ -567,12 +570,96 @@ pub fn to_bmp(pixels_bgra: &[u8], width: u32, height: u32) -> Vec<u8> {
     bmp
 }
 
+// ─── OCR line assembly (engine-independent) ───────────────────────────────────
+
+/// One recognised word, with its horizontal extent and vertical centre already
+/// expressed as fractions of the source image. Both OCR engines (WinRT on
+/// Windows, Tesseract on Linux) report pixel bounding boxes; normalising at the
+/// engine boundary lets the card-column logic downstream stay resolution- and
+/// engine-agnostic.
+pub struct OcrWord {
+    pub text: String,
+    pub x_left: f32,
+    pub x_right: f32,
+    pub cy: f32,
+}
+
+/// How much page structure the OCR engine should assume.
+///
+/// Windows OCR does its own layout analysis and ignores this; Tesseract does not,
+/// and picks up nothing at all on the wrong setting — a cropped riven card reads
+/// perfectly as one block and returns empty as scattered text, and a full reward
+/// frame does the opposite.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum OcrLayout {
+    /// Text scattered anywhere in a full game frame.
+    Scattered,
+    /// A single block of text filling a cropped region.
+    Block,
+}
+
+/// Inter-card gap: reward cards are separated by ~10–12% of image width.
+/// Word gaps within a single item name are ≤ 3%. Splitting at 7% cleanly
+/// divides "Daikyu Prime Upper Limb Nautilus Prime Systems" (which both OCR
+/// engines merge into one line when the two names share a baseline Y) into the
+/// two separate card entries the column-assignment logic expects.
+const WORD_GAP: f32 = 0.07;
+
+/// Turn engine lines into the `(full_text, positions)` pair the reward pipeline
+/// consumes, splitting any line whose internal word gap exceeds `WORD_GAP`.
+///
+/// Each returned entry is `(text, x_centre, y_centre)`, averaged over the words
+/// that make up that sub-line.
+fn assemble_ocr_lines(engine_lines: &[Vec<OcrWord>]) -> (String, Vec<(String, f32, f32)>) {
+    let mut full = String::new();
+    let mut lines_out: Vec<(String, f32, f32)> = Vec::new();
+
+    for words in engine_lines {
+        // Walk words left-to-right; flush a sub-line whenever the horizontal
+        // gap to the next word exceeds WORD_GAP.
+        let mut seg_texts: Vec<&str> = Vec::new();
+        let mut seg_sx = 0.0f32;
+        let mut seg_sy = 0.0f32;
+        let mut seg_n = 0u32;
+        let mut prev_right = -1.0f32;
+        for w in words {
+            if prev_right >= 0.0 && (w.x_left - prev_right) > WORD_GAP && !seg_texts.is_empty() {
+                let sub = seg_texts.join(" ");
+                full.push_str(&sub);
+                full.push('\n');
+                lines_out.push((sub, seg_sx / seg_n as f32, seg_sy / seg_n as f32));
+                seg_texts.clear();
+                seg_sx = 0.0;
+                seg_sy = 0.0;
+                seg_n = 0;
+            }
+            seg_texts.push(&w.text);
+            seg_sx += (w.x_left + w.x_right) / 2.0;
+            seg_sy += w.cy;
+            seg_n += 1;
+            prev_right = w.x_right;
+        }
+        if !seg_texts.is_empty() {
+            let sub = seg_texts.join(" ");
+            full.push_str(&sub);
+            full.push('\n');
+            lines_out.push((sub, seg_sx / seg_n as f32, seg_sy / seg_n as f32));
+        }
+    }
+
+    (full, lines_out)
+}
+
 // ─── Windows OCR ──────────────────────────────────────────────────────────────
 
-/// Run Windows.Media.Ocr on a BMP. Returns (full_text, line_positions).
-/// line_positions: Vec<(line_text, x_frac)> — X centre per line from word bounding rects.
+/// Run Windows.Media.Ocr on a BGRA buffer. Returns (full_text, line_positions).
+/// line_positions: Vec<(line_text, x_frac, y_frac)> — centre per line from word
+/// bounding rects. `BitmapDecoder` wants an encoded image, so the buffer is
+/// wrapped in a BMP here; the Linux backend takes the same buffer and hands
+/// Tesseract raw samples instead.
 #[cfg(target_os = "windows")]
-pub fn run_windows_ocr(bmp: Vec<u8>, img_w: u32, img_h: u32) -> Result<(String, Vec<(String, f32, f32)>), String> {
+pub fn run_ocr(pixels_bgra: &[u8], img_w: u32, img_h: u32, _layout: OcrLayout) -> Result<(String, Vec<(String, f32, f32)>), String> {
+    let bmp = to_bmp(pixels_bgra, img_w, img_h);
     // Ensure COM is initialized for this thread. Tokio spawn_blocking threads
     // start without a COM apartment; WinRT calls fail or return empty silently.
     // CoInitializeEx returns S_OK (first init), S_FALSE (already MTA), or
@@ -612,57 +699,39 @@ pub fn run_windows_ocr(bmp: Vec<u8>, img_w: u32, img_h: u32) -> Result<(String, 
             .or_else(|_| OcrEngine::TryCreateFromUserProfileLanguages())?;
         let result = engine.RecognizeAsync(&bitmap)?.get()?;
 
-        let mut full = String::new();
-        let mut lines_out: Vec<(String, f32, f32)> = Vec::new();
         let lines: IVectorView<OcrLine> = result.Lines()?;
         let count = lines.Size()?;
-        // Inter-card gap: reward cards are separated by ~10–12% of image width.
-        // Word gaps within a single item name are ≤ 3%. Splitting at 7% cleanly
-        // divides "Daikyu Prime Upper Limb Nautilus Prime Systems" (which WinRT
-        // merges into one line when both names share the same baseline Y) into the
-        // two separate card entries the column-assignment logic expects.
-        const WORD_GAP: f32 = 0.07;
+        let mut engine_lines: Vec<Vec<OcrWord>> = Vec::with_capacity(count as usize);
         for i in 0..count {
             let line = lines.GetAt(i)?;
             let words = line.Words()?;
             let wc = words.Size()?;
             if wc == 0 {
-                let text = line.Text()?.to_string();
-                full.push_str(&text); full.push('\n');
-                lines_out.push((text, 0.5, 0.5));
+                // A line with text but no word boxes carries no position — centre
+                // it so the column assignment treats it as ambiguous rather than
+                // pinning it to the left edge.
+                engine_lines.push(vec![OcrWord {
+                    text: line.Text()?.to_string(),
+                    x_left: 0.5,
+                    x_right: 0.5,
+                    cy: 0.5,
+                }]);
                 continue;
             }
-            // Walk words left-to-right; flush a sub-line whenever the horizontal
-            // gap to the next word exceeds WORD_GAP.
-            let mut seg_texts: Vec<String> = Vec::new();
-            let mut seg_sx = 0.0f32;
-            let mut seg_sy = 0.0f32;
-            let mut seg_n  = 0u32;
-            let mut prev_right = -1.0f32;
+            let mut words_out = Vec::with_capacity(wc as usize);
             for j in 0..wc {
-                let w  = words.GetAt(j)?;
-                let r  = w.BoundingRect()?;
-                let cx = if img_w > 0 { (r.X + r.Width  / 2.0) / img_w as f32 } else { 0.5 };
-                let cy = if img_h > 0 { (r.Y + r.Height / 2.0) / img_h as f32 } else { 0.5 };
-                let xl = if img_w > 0 { r.X / img_w as f32 } else { 0.0 };
-                let xr = if img_w > 0 { (r.X + r.Width) / img_w as f32 } else { 1.0 };
-                if prev_right >= 0.0 && (xl - prev_right) > WORD_GAP && !seg_texts.is_empty() {
-                    let sub = seg_texts.join(" ");
-                    full.push_str(&sub); full.push('\n');
-                    lines_out.push((sub, seg_sx / seg_n as f32, seg_sy / seg_n as f32));
-                    seg_texts.clear(); seg_sx = 0.0; seg_sy = 0.0; seg_n = 0;
-                }
-                seg_texts.push(w.Text()?.to_string());
-                seg_sx += cx; seg_sy += cy; seg_n += 1;
-                prev_right = xr;
+                let w = words.GetAt(j)?;
+                let r = w.BoundingRect()?;
+                words_out.push(OcrWord {
+                    text: w.Text()?.to_string(),
+                    x_left: if img_w > 0 { r.X / img_w as f32 } else { 0.0 },
+                    x_right: if img_w > 0 { (r.X + r.Width) / img_w as f32 } else { 1.0 },
+                    cy: if img_h > 0 { (r.Y + r.Height / 2.0) / img_h as f32 } else { 0.5 },
+                });
             }
-            if !seg_texts.is_empty() {
-                let sub = seg_texts.join(" ");
-                full.push_str(&sub); full.push('\n');
-                lines_out.push((sub, seg_sx / seg_n as f32, seg_sy / seg_n as f32));
-            }
+            engine_lines.push(words_out);
         }
-        Ok((full, lines_out))
+        Ok(assemble_ocr_lines(&engine_lines))
     })().map_err(|e| e.to_string())
 }
 
@@ -798,7 +867,6 @@ fn normalise(s: &str) -> String {
 /// band have bar-coloured pixels. Columns that are consistently orange or teal
 /// across many rows score high. This is far more robust than row-by-row detection
 /// because it tolerates thin bars, color gradients, and single-row noise.
-#[cfg(target_os = "windows")]
 /// Returns `(Some((centers, bar_y_frac)), diagnostic_string)`.
 /// `centers` are fractions of image width — the diamond icon X per card.
 /// The diagnostic string is always populated for session log inclusion.
@@ -974,11 +1042,6 @@ fn find_rarity_bars(pixels: &[u8], pix_w: u32, pix_h: u32) -> (Option<(Vec<f32>,
     (Some((centers, bar_y)), diag)
 }
 
-#[cfg(not(target_os = "windows"))]
-fn find_rarity_bars(_: &[u8], _: u32, _: u32) -> (Option<(Vec<f32>, f32)>, String) {
-    (None, "not supported on non-Windows".into())
-}
-
 // ─── Icon component classifier ────────────────────────────────────────────────
 
 /// What the card icon looks like, used to constrain catalog matching.
@@ -1021,7 +1084,6 @@ pub enum IconType {
 ///   ⑧ blade        — low symmetry, moderate aspect (flat asymmetric part)
 ///   ⑨ upper/lower limb — low fill, arc-shaped (bow components)
 ///   Unknown        — ambiguous; fall back to text-only matching
-#[cfg(target_os = "windows")]
 fn classify_card_icon(
     pixels: &[u8], pix_w: u32, pix_h: u32,
     x_left: f32, x_right: f32, bar_y: f32,
@@ -1155,11 +1217,6 @@ fn classify_card_icon(
         };
     }
 
-    IconType::Unknown
-}
-
-#[cfg(not(target_os = "windows"))]
-fn classify_card_icon(_: &[u8], _: u32, _: u32, _: f32, _: f32, _: f32) -> IconType {
     IconType::Unknown
 }
 
@@ -1300,7 +1357,6 @@ fn score_item(display_name: &str, words: &std::collections::HashSet<String>) -> 
 /// 3. Assign each OCR line to the nearest card (by X).
 /// 4. Per-card word set → prefix + fuzzy match against relic catalog.
 /// 5. Full-frame fallback if bar detection fails.
-#[cfg(target_os = "windows")]
 pub fn extract_reward_items_twophase(
     pixels: &[u8], pix_w: u32, pix_h: u32, _game_h: u32,
     catalog: &[(String, String)],
@@ -1311,7 +1367,7 @@ pub fn extract_reward_items_twophase(
 
     // ── 1. Raw OCR ────────────────────────────────────────────────────────────
     let (raw_full, ocr_lines) =
-        match run_windows_ocr(to_bmp(pixels, pix_w, pix_h), pix_w, pix_h) {
+        match run_ocr(pixels, pix_w, pix_h, OcrLayout::Scattered) {
             Ok(r) => r,
             Err(e) => return (false, false, vec![], vec![],
                 format!("├─ Capture  : {}\n└─ OCR error: {}", capture_info, e)),
@@ -1873,67 +1929,614 @@ pub fn capture_desktop_for_diag() -> Option<(Vec<u8>, u32, u32)> {
     None
 }
 
-#[cfg(not(target_os = "windows"))]
-pub fn capture_desktop_for_diag() -> Option<(Vec<u8>, u32, u32)> { None }
-
 // ==============================================================================
-// Non-Windows capture and OCR stubs
+// Linux capture and OCR
 // ==============================================================================
 //
-// Screen capture and text recognition both go through Windows-only APIs (GDI,
-// DXGI, WinRT OCR). Linux has no equivalent wired up, so every entry point
-// returns the same explicit error instead of silently producing empty text —
-// callers surface it to the user as "unavailable" rather than "found nothing".
+// Warframe runs under Proton, and on a Wayland session it is an XWayland client:
+// an ordinary X11 window titled exactly "Warframe". Capture therefore goes
+// through plain X11 (`xcb` GetImage on the window drawable) whether the session
+// is X11 or Wayland — no desktop portal, no permission prompt, no monitor-wide
+// grab, and no dependency on the compositor's screencast support.
+//
+// Deliberately not using a cross-platform capture crate (`xcap`) for this: its
+// Linux build pulls the whole Wayland/PipeWire stack in for a code path this app
+// never takes, and that stack does not currently compile against a recent
+// PipeWire. The three X11 requests below are all that is actually needed.
+//
+// Two platform primitives carry every Linux difference:
+//   • `capture_warframe_bgra` — the window grab, in the BGRA byte order the
+//     shared pipeline (`to_bmp`, `preprocess_for_ocr`, `find_rarity_bars`,
+//     `classify_card_icon`) assumes.
+//   • `run_windows_ocr`       — Tesseract in place of WinRT OCR, reporting the
+//     same (text, per-word position) shape.
+// Everything above them — cropping, preprocessing, rarity bars, icon
+// classification, catalog matching — is shared with Windows unchanged.
 
-#[cfg(not(target_os = "windows"))]
-const OCR_UNSUPPORTED: &str = "OCR is not supported on Linux";
+/// The game's X11 window title. Warframe uses this exact string under Proton,
+/// with no version suffix, which is why an equality test is safe here.
+#[cfg(target_os = "linux")]
+const WARFRAME_WINDOW_TITLE: &str = "Warframe";
 
-#[cfg(not(target_os = "windows"))]
+/// Connect to the X server named by `DISPLAY`.
+///
+/// A fresh connection per call rather than a cached one: capture happens at most
+/// a few times a second, the handshake is local-socket cheap, and a cached
+/// connection would have to be re-established anyway whenever the X server or
+/// XWayland restarts.
+#[cfg(target_os = "linux")]
+fn x11_connect() -> Result<xcb::Connection, String> {
+    xcb::Connection::connect(None)
+        .map(|(conn, _screen)| conn)
+        .map_err(|e| format!("Cannot connect to the X server: {e}"))
+}
+
+/// Look up an atom by name.
+#[cfg(target_os = "linux")]
+fn x11_atom(conn: &xcb::Connection, name: &str) -> Result<xcb::x::Atom, String> {
+    let cookie = conn.send_request(&xcb::x::InternAtom {
+        only_if_exists: true,
+        name: name.as_bytes(),
+    });
+    conn.wait_for_reply(cookie)
+        .map(|reply| reply.atom())
+        .map_err(|e| format!("Cannot intern the {name} atom: {e}"))
+}
+
+/// Read a window's title, preferring the EWMH `_NET_WM_NAME` (UTF-8) over the
+/// legacy `WM_NAME` (Latin-1). Wine sets both; other clients may set only one.
+#[cfg(target_os = "linux")]
+fn x11_window_title(conn: &xcb::Connection, window: xcb::x::Window) -> Option<String> {
+    let read = |property: xcb::x::Atom, r#type: xcb::x::Atom| -> Option<String> {
+        let cookie = conn.send_request(&xcb::x::GetProperty {
+            delete: false,
+            window,
+            property,
+            r#type,
+            long_offset: 0,
+            long_length: 256,
+        });
+        let reply = conn.wait_for_reply(cookie).ok()?;
+        let value: &[u8] = reply.value();
+        (!value.is_empty()).then(|| String::from_utf8_lossy(value).into_owned())
+    };
+
+    let net_wm_name = x11_atom(conn, "_NET_WM_NAME").ok();
+    let utf8_string = x11_atom(conn, "UTF8_STRING").ok();
+    net_wm_name
+        .zip(utf8_string)
+        .and_then(|(property, r#type)| read(property, r#type))
+        .or_else(|| read(xcb::x::ATOM_WM_NAME, xcb::x::ATOM_STRING))
+}
+
+/// Find the game's window. Errors when Warframe is not running, which the
+/// callers surface as "capture failed" rather than as an empty frame.
+///
+/// Managed top-level windows are enumerated from the window manager's
+/// `_NET_CLIENT_LIST_STACKING` rather than by walking the whole window tree:
+/// that list holds exactly the client windows, so it cannot return a decoration
+/// frame or an unmapped helper window whose title happens to match.
+#[cfg(target_os = "linux")]
+fn warframe_window(conn: &xcb::Connection) -> Result<xcb::x::Window, String> {
+    let client_list = x11_atom(conn, "_NET_CLIENT_LIST_STACKING")?;
+
+    for screen in conn.get_setup().roots() {
+        let cookie = conn.send_request(&xcb::x::GetProperty {
+            delete: false,
+            window: screen.root(),
+            property: client_list,
+            r#type: xcb::x::ATOM_WINDOW,
+            long_offset: 0,
+            long_length: 1024,
+        });
+        let Ok(reply) = conn.wait_for_reply(cookie) else {
+            continue;
+        };
+        for &window in reply.value::<xcb::x::Window>() {
+            if x11_window_title(conn, window).as_deref() == Some(WARFRAME_WINDOW_TITLE) {
+                return Ok(window);
+            }
+        }
+    }
+
+    Err("Warframe window not found".into())
+}
+
+/// A window's origin in root coordinates plus its size.
+///
+/// `GetGeometry` reports a position relative to the parent — which, for a
+/// reparenting window manager, is the decoration frame rather than the desktop.
+/// Translating the window's own `(x, y)` into root space and subtracting it back
+/// out yields the origin of the window content itself.
+#[cfg(target_os = "linux")]
+fn x11_window_rect(
+    conn: &xcb::Connection,
+    window: xcb::x::Window,
+) -> Result<(i32, i32, u32, u32), String> {
+    let geometry_cookie = conn.send_request(&xcb::x::GetGeometry {
+        drawable: xcb::x::Drawable::Window(window),
+    });
+    let geometry = conn
+        .wait_for_reply(geometry_cookie)
+        .map_err(|e| format!("Cannot read the Warframe window geometry: {e}"))?;
+
+    let translate_cookie = conn.send_request(&xcb::x::TranslateCoordinates {
+        src_window: window,
+        dst_window: geometry.root(),
+        src_x: geometry.x(),
+        src_y: geometry.y(),
+    });
+    let translated = conn
+        .wait_for_reply(translate_cookie)
+        .map_err(|e| format!("Cannot translate the Warframe window position: {e}"))?;
+
+    Ok((
+        (translated.dst_x() - geometry.x()) as i32,
+        (translated.dst_y() - geometry.y()) as i32,
+        geometry.width() as u32,
+        geometry.height() as u32,
+    ))
+}
+
+/// Capture the whole game window as BGRA.
+///
+/// X11 `ZPixmap` data at depth 24/32 is already 4 bytes per pixel in the
+/// server's byte order: B, G, R, unused on the little-endian servers this runs
+/// on, which is exactly the layout the shared pipeline expects. Only the unused
+/// byte needs filling, because `to_bmp` ignores it but `avg_brightness` and the
+/// bar detector read whole pixels and an undefined alpha makes captures
+/// non-reproducible.
+#[cfg(target_os = "linux")]
+fn capture_warframe_bgra() -> Result<(Vec<u8>, u32, u32), String> {
+    let conn = x11_connect()?;
+    let window = warframe_window(&conn)?;
+    let (_x, _y, width, height) = x11_window_rect(&conn, window)?;
+    // Same floor the Windows path uses: a window this small is either minimised
+    // or mid-creation, and OCR on it would only waste a frame.
+    if width < 100 || height < 100 {
+        return Err(format!("Window too small ({width}×{height})"));
+    }
+
+    let cookie = conn.send_request(&xcb::x::GetImage {
+        format: xcb::x::ImageFormat::ZPixmap,
+        drawable: xcb::x::Drawable::Window(window),
+        x: 0,
+        y: 0,
+        width: width as u16,
+        height: height as u16,
+        plane_mask: u32::MAX,
+    });
+    let reply = conn
+        .wait_for_reply(cookie)
+        .map_err(|e| format!("Cannot capture the Warframe window: {e}"))?;
+
+    let depth = reply.depth();
+    if depth != 24 && depth != 32 {
+        return Err(format!("Unsupported window depth {depth} (expected 24 or 32)"));
+    }
+    let expected = (width as usize) * (height as usize) * 4;
+    let data = reply.data();
+    if data.len() < expected {
+        return Err(format!(
+            "Short capture: got {} bytes for {width}×{height} (expected {expected})",
+            data.len()
+        ));
+    }
+
+    let mut pixels = data[..expected].to_vec();
+    // MSB-first servers hand back R, G, B — rare, but a wrong guess would make
+    // the rarity-bar colour tests match the wrong hues, so handle both orders.
+    if conn.get_setup().image_byte_order() == xcb::x::ImageOrder::MsbFirst {
+        for px in pixels.chunks_exact_mut(4) {
+            px.swap(0, 2);
+        }
+    }
+    for px in pixels.chunks_exact_mut(4) {
+        px[3] = 255;
+    }
+    Ok((pixels, width, height))
+}
+
+/// The game's window geometry in desktop coordinates, as `[x, y, w, h]`.
+/// The overlay is positioned from this, so it must describe the same area the
+/// capture covers — for an X11 window the capture is the whole window, and
+/// Warframe under Proton is borderless, so window rect == client rect.
+#[cfg(target_os = "linux")]
+pub fn warframe_window_rect() -> Result<[i32; 4], String> {
+    let conn = x11_connect()?;
+    let window = warframe_window(&conn)?;
+    let (x, y, width, height) = x11_window_rect(&conn, window)?;
+    Ok([x, y, width as i32, height as i32])
+}
+
+#[cfg(target_os = "linux")]
+pub fn capture_warframe_pixels() -> Result<(Vec<u8>, u32, u32), String> {
+    capture_warframe_bgra()
+}
+
+/// Full-resolution capture for manual diagnostics; kept to match the Windows
+/// entry point, which the manual capture button no longer calls.
+#[allow(dead_code)]
+#[cfg(target_os = "linux")]
+pub fn capture_screen_for_diagnostics() -> Result<(Vec<u8>, u32, u32), String> {
+    capture_warframe_bgra()
+}
+
+/// Half-resolution capture for automatic diagnostics: a 2×2 box average, which
+/// keeps small UI text legible in the saved BMP where dropping every other pixel
+/// would alias it away. Windows gets the equivalent from StretchBlt/HALFTONE.
+#[cfg(target_os = "linux")]
+pub fn capture_screen_for_diagnostics_half() -> Result<(Vec<u8>, u32, u32), String> {
+    let (pixels, width, height) = capture_warframe_bgra()?;
+    let (half_w, half_h) = ((width / 2).max(1), (height / 2).max(1));
+    let mut out = Vec::with_capacity((half_w * half_h * 4) as usize);
+    for y in 0..half_h {
+        for x in 0..half_w {
+            for channel in 0..4 {
+                let sample = |dy: u32, dx: u32| {
+                    let i = (((y * 2 + dy) * width + x * 2 + dx) * 4 + channel) as usize;
+                    pixels[i] as u32
+                };
+                let sum = sample(0, 0) + sample(0, 1) + sample(1, 0) + sample(1, 1);
+                out.push((sum / 4) as u8);
+            }
+        }
+    }
+    Ok((out, half_w, half_h))
+}
+
+/// Reward-strip capture. The top 80% of the window is kept for the same reason
+/// as on Windows: reward cards never reach the lower fifth of the screen, and
+/// cropping there removes the squad list and chat box from the OCR input.
+#[cfg(target_os = "linux")]
+pub fn capture_warframe_reward_area() -> Option<(Vec<u8>, u32, u32, u32, String)> {
+    let (mut pixels, width, full_h) = capture_warframe_bgra().ok()?;
+    let cap_h = ((full_h as f32 * 0.80) as u32).max(1);
+    pixels.truncate((width * cap_h * 4) as usize);
+    let avg = avg_brightness(&pixels);
+    let info =
+        format!("xcap/X11  {width}×{full_h}px (top 80%, cap {cap_h}px)  avg_brightness={avg}");
+    Some((pixels, width, cap_h, full_h, info))
+}
+
+/// The composited desktop is not reachable on this platform.
+///
+/// Under XWayland the X11 root window has no backing content — a root grab comes
+/// back uniformly black (measured) because every X11 client is an independent
+/// Wayland surface. Grabbing the game window instead would defeat the purpose of
+/// this capture, which exists to prove the FrameForge overlay is being drawn on
+/// top of the game, so it reports failure rather than a picture that can never
+/// contain the overlay.
+///
+/// ponytail: no Linux desktop grab; wire up xdg-desktop-portal ScreenCast if
+/// overlay-on-game diagnostics are wanted (it prompts for permission per run).
+#[cfg(target_os = "linux")]
+pub fn capture_desktop_for_diag() -> Option<(Vec<u8>, u32, u32)> {
+    None
+}
+
+/// Tesseract stand-in for `Windows.Media.Ocr`. Same contract: a BGRA buffer in,
+/// `(full_text, per-line (text, x_centre, y_centre))` out.
+///
+/// Two reductions to one byte per pixel are available and the better one is
+/// chosen by result, not by guesswork: the UI-colour mask is tried first and
+/// plain luminance is used when it comes back empty. See `ui_text_mask`.
+///
+/// Word boxes come from Tesseract's TSV output, the only one of its report
+/// formats that carries both per-word geometry and the block/paragraph/line
+/// grouping the gap-splitting logic needs.
+#[cfg(target_os = "linux")]
+pub fn run_ocr(
+    pixels_bgra: &[u8],
+    img_w: u32,
+    img_h: u32,
+    layout: OcrLayout,
+) -> Result<(String, Vec<(String, f32, f32)>), String> {
+    let expected = (img_w as usize) * (img_h as usize);
+    if pixels_bgra.len() < expected * 4 {
+        return Err(format!(
+            "OCR buffer is {} bytes, short of the {img_w}×{img_h} BGRA claimed",
+            pixels_bgra.len()
+        ));
+    }
+
+    // The mask is right for interface text and blind to everything else — riven
+    // card stats are drawn in an item colour no theme table can list, and callers
+    // that pre-convert to greyscale (`ocr_pixels_rect`) have no colour left to
+    // match. Rather than guess which case a buffer is from, read it masked and
+    // keep that only if it produced text.
+    if let Some(mask) = ui_text_mask(&pixels_bgra[..expected * 4]) {
+        let masked = recognize_samples(&mask, img_w, img_h, layout)?;
+        if reads_as_words(&masked.0) {
+            return Ok(masked);
+        }
+    }
+
+    let luminance: Vec<u8> = pixels_bgra[..expected * 4]
+        .chunks_exact(4)
+        .map(|px| {
+            ((px[2] as u32 * 299 + px[1] as u32 * 587 + px[0] as u32 * 114) / 1000).min(255) as u8
+        })
+        .collect();
+    recognize_samples(&luminance, img_w, img_h, layout)
+}
+
+/// Whether OCR output looks like it read text rather than shapes.
+///
+/// A mask that isolated nothing still leaves stray marks — panel borders, an icon
+/// edge — and Tesseract reports those as one- and two-character fragments. Real
+/// interface text always yields at least one run of three or more letters or
+/// digits, which is also the shortest token the catalog matcher will consider.
+#[cfg(target_os = "linux")]
+fn reads_as_words(text: &str) -> bool {
+    text.split(|c: char| !c.is_ascii_alphanumeric())
+        .any(|token| token.len() >= 3)
+}
+
+/// Run Tesseract over one 8-bit sample per pixel.
+#[cfg(target_os = "linux")]
+fn recognize_samples(
+    samples: &[u8],
+    img_w: u32,
+    img_h: u32,
+    layout: OcrLayout,
+) -> Result<(String, Vec<(String, f32, f32)>), String> {
+    use tesseract::{PageSegMode, Tesseract};
+
+    let mut engine = Tesseract::new(None, Some("eng"))
+        .map_err(|e| format!("Cannot initialise Tesseract (is eng.traineddata installed?): {e}"))?;
+
+    // A full game frame is not a document page: Tesseract's default layout
+    // analysis looks for columns and a reading order in scattered HUD text and
+    // drops most of it, whereas sparse mode reports every text region it finds —
+    // which is what the position-based card assignment downstream wants. A
+    // cropped region is the opposite case: it holds one block of lines, and
+    // sparse mode reads nothing at all from a riven card that single-block mode
+    // transcribes exactly.
+    engine.set_page_seg_mode(match layout {
+        OcrLayout::Scattered => PageSegMode::PsmSparseText,
+        OcrLayout::Block => PageSegMode::PsmSingleBlock,
+    });
+
+    let mut engine = engine
+        .set_frame(samples, img_w as i32, img_h as i32, 1, img_w as i32)
+        .map_err(|e| format!("Tesseract rejected the captured frame: {e}"))?
+        .recognize()
+        .map_err(|e| format!("Tesseract recognition failed: {e}"))?;
+    let tsv = engine
+        .get_tsv_text(0)
+        .map_err(|e| format!("Cannot read Tesseract TSV output: {e}"))?;
+
+    Ok(assemble_ocr_lines(&parse_tesseract_tsv(&tsv, img_w, img_h)))
+}
+
+/// Warframe's UI text colours: the `primary` and `secondary` of every built-in
+/// interface theme, as RGB. Ported from wfinfo-ng's theme table.
+///
+/// The game draws interface text in exactly one of these colours, unblended, so
+/// an equality test against the whole set isolates text without having to know
+/// which theme the player has selected.
+#[cfg(target_os = "linux")]
+const UI_TEXT_COLOURS: &[(u8, u8, u8)] = &[
+    (190, 169, 102), (245, 227, 173), // Vitruvian
+    (153, 31, 35),   (255, 61, 51),   // Stalker
+    (238, 193, 105), (236, 211, 162), // Baruuk
+    (35, 201, 245),  (111, 229, 253), // Corpus
+    (57, 105, 192),  (255, 115, 230), // Fortuna
+    (255, 189, 102), (255, 224, 153), // Grineer
+    (36, 184, 242),  (255, 241, 191), // Lotus
+    (140, 38, 92),   (245, 73, 93),   // Nidus
+    (20, 41, 29),    (178, 125, 5),   // Orokin
+    (9, 78, 106),    (6, 106, 74),    // Tenno
+    (2, 127, 217),   (255, 255, 0),   // High Contrast
+    (255, 255, 255), (232, 213, 93),  // Legacy
+    (158, 159, 167), (232, 227, 227), // Equinox
+    (140, 119, 147), (189, 169, 237), // Dark Lotus
+    (253, 132, 2),   (255, 53, 0),    // Zephyr
+];
+
+/// Isolate interface text: pixels that exactly match a theme text colour become
+/// black, everything else white. `None` when no pixel matched, so the caller can
+/// skip an OCR pass it knows will come back blank.
+///
+/// Tesseract is a document OCR engine — handed a raw game frame it tries to read
+/// the artwork too, and on a 4K reward screen that buries four item names in
+/// ~200 lines of noise. Deleting everything that is not interface text is the
+/// difference between mostly-garbage and near-perfect names on real captures.
+#[cfg(target_os = "linux")]
+fn ui_text_mask(pixels_bgra: &[u8]) -> Option<Vec<u8>> {
+    let mut matched = false;
+    let mask: Vec<u8> = pixels_bgra
+        .chunks_exact(4)
+        .map(|px| {
+            let is_ui_text = UI_TEXT_COLOURS
+                .iter()
+                .any(|&(r, g, b)| px[2] == r && px[1] == g && px[0] == b);
+            matched |= is_ui_text;
+            if is_ui_text { 0 } else { 255 }
+        })
+        .collect();
+    matched.then_some(mask)
+}
+
+/// Group Tesseract's TSV rows into per-line word lists.
+///
+/// Columns are `level page block paragraph line word left top width height conf
+/// text`; level 5 is a word and every coarser level repeats the same geometry
+/// with `conf` = -1, so filtering on level keeps each word exactly once.
+///
+/// Lines are emitted in top-to-bottom, left-to-right order and their words in
+/// left-to-right order. WinRT OCR already reports them that way, and the
+/// full-frame fallback in `extract_reward_items_twophase` uses line index as a
+/// stand-in for screen position — sparse-text mode makes no ordering promise, so
+/// the order is imposed here instead.
+#[cfg(target_os = "linux")]
+fn parse_tesseract_tsv(tsv: &str, img_w: u32, img_h: u32) -> Vec<Vec<OcrWord>> {
+    // Zero dimensions would make every fraction a division by zero; the callers
+    // reject sub-4-pixel rects, so this only guards against a degenerate BMP.
+    if img_w == 0 || img_h == 0 {
+        return Vec::new();
+    }
+
+    // Keyed by (block, paragraph, line) so words from two different text regions
+    // that happen to share a baseline stay in separate lines.
+    let mut lines: std::collections::BTreeMap<(i32, i32, i32), Vec<(i32, i32, OcrWord)>> =
+        std::collections::BTreeMap::new();
+
+    for row in tsv.lines() {
+        let fields: Vec<&str> = row.split('\t').collect();
+        if fields.len() < 12 || fields[0] != "5" {
+            continue;
+        }
+        let num = |i: usize| fields[i].parse::<i32>().ok();
+        let (Some(block), Some(par), Some(line)) = (num(2), num(3), num(4)) else {
+            continue;
+        };
+        let (Some(left), Some(top), Some(width), Some(height)) =
+            (num(6), num(7), num(8), num(9))
+        else {
+            continue;
+        };
+        // Tesseract emits empty words for regions it segmented but could not
+        // read; they carry no text for matching and would only widen word gaps.
+        let text = fields[11].trim();
+        if text.is_empty() {
+            continue;
+        }
+        lines.entry((block, par, line)).or_default().push((
+            top,
+            left,
+            OcrWord {
+                text: text.to_owned(),
+                x_left: left as f32 / img_w as f32,
+                x_right: (left + width) as f32 / img_w as f32,
+                cy: (top as f32 + height as f32 / 2.0) / img_h as f32,
+            },
+        ));
+    }
+
+    let mut ordered: Vec<(i32, i32, Vec<OcrWord>)> = lines
+        .into_values()
+        .filter_map(|mut words| {
+            words.sort_by_key(|(_, left, _)| *left);
+            let top = words.iter().map(|(top, _, _)| *top).min()?;
+            let left = words.first().map(|(_, left, _)| *left)?;
+            Some((top, left, words.into_iter().map(|(_, _, w)| w).collect()))
+        })
+        .collect();
+    ordered.sort_by_key(|(top, left, _)| (*top, *left));
+    ordered.into_iter().map(|(_, _, words)| words).collect()
+}
+
+// ==============================================================================
+// Unsupported platforms
+// ==============================================================================
+//
+// Capture and OCR are implemented for Windows and Linux only. Everywhere else
+// each entry point returns the same explicit error instead of silently producing
+// empty text — callers surface it as "unavailable" rather than "found nothing".
+
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
+const OCR_UNSUPPORTED: &str = "OCR is not supported on this platform";
+
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
 pub fn capture_warframe_pixels() -> Result<(Vec<u8>, u32, u32), String> {
     Err(OCR_UNSUPPORTED.into())
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
 pub fn capture_screen_for_diagnostics() -> Result<(Vec<u8>, u32, u32), String> {
     Err(OCR_UNSUPPORTED.into())
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
 pub fn capture_screen_for_diagnostics_half() -> Result<(Vec<u8>, u32, u32), String> {
     Err(OCR_UNSUPPORTED.into())
 }
 
-#[cfg(not(target_os = "windows"))]
-pub fn ocr_pixels_rect(
-    _pixels: &[u8], _full_w: u32, _full_h: u32,
-    _x_start: f32, _x_end: f32, _y_start: f32, _y_end: f32,
-) -> Result<String, String> {
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
+pub fn capture_warframe_reward_area() -> Option<(Vec<u8>, u32, u32, u32, String)> {
+    None
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
+pub fn capture_desktop_for_diag() -> Option<(Vec<u8>, u32, u32)> {
+    None
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
+pub fn run_ocr(
+    _pixels_bgra: &[u8],
+    _w: u32,
+    _h: u32,
+    _layout: OcrLayout,
+) -> Result<(String, Vec<(String, f32, f32)>), String> {
     Err(OCR_UNSUPPORTED.into())
 }
 
-#[cfg(not(target_os = "windows"))]
-pub fn ocr_pixels_rect_raw(
-    _pixels: &[u8], _full_w: u32, _full_h: u32,
-    _x_start: f32, _x_end: f32, _y_start: f32, _y_end: f32,
-) -> Result<String, String> {
-    Err(OCR_UNSUPPORTED.into())
-}
+#[cfg(test)]
+mod tesseract_tests {
+    use super::*;
 
-#[cfg(not(target_os = "windows"))]
-pub fn capture_warframe_reward_area() -> Option<(Vec<u8>, u32, u32, u32, String)> { None }
+    /// Two reward cards whose names share a baseline land in one Tesseract line.
+    /// The pipeline downstream assigns text to cards by X position, so the
+    /// gap-splitting in `assemble_ocr_lines` is what keeps the two names from
+    /// being scored as a single item — and the TSV parser is what gives it the
+    /// geometry to split on.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn tsv_words_split_into_one_sub_line_per_card() {
+        // level page block par line word left top width height conf text
+        // 1000 px wide: "Daikyu Prime" sits at x 100–300, "Nautilus Prime" at
+        // 700–950 — a 40% gap, far beyond the 7% inter-card threshold.
+        let tsv = "\
+1\t1\t0\t0\t0\t0\t0\t0\t1000\t500\t-1\t\n\
+5\t1\t1\t1\t1\t1\t100\t200\t80\t20\t92\tDaikyu\n\
+5\t1\t1\t1\t1\t2\t200\t200\t100\t20\t90\tPrime\n\
+5\t1\t1\t1\t1\t3\t700\t200\t110\t20\t88\tNautilus\n\
+5\t1\t1\t1\t1\t4\t830\t200\t120\t20\t91\tPrime\n";
 
-#[cfg(not(target_os = "windows"))]
-pub fn run_windows_ocr(_bmp: Vec<u8>, _w: u32, _h: u32) -> Result<(String, Vec<(String, f32, f32)>), String> {
-    Err("Windows only".into())
-}
+        let lines = parse_tesseract_tsv(tsv, 1000, 500);
+        assert_eq!(lines.len(), 1, "all four words share one TSV line");
 
-#[cfg(not(target_os = "windows"))]
-pub fn extract_reward_items_twophase(
-    _pixels: &[u8], _w: u32, _cap_h: u32, _full_h: u32,
-    _catalog: &[(String, String)], _capture_info: &str,
-    _hint_squad_size: Option<usize>, _player_names: &[String],
-) -> (bool, bool, Vec<String>, Vec<f32>, String) {
-    (false, false, vec![], vec![], String::new())
+        let (full, positions) = assemble_ocr_lines(&lines);
+        assert_eq!(full, "Daikyu Prime\nNautilus Prime\n");
+        assert_eq!(positions.len(), 2);
+        assert_eq!(positions[0].0, "Daikyu Prime");
+        assert_eq!(positions[1].0, "Nautilus Prime");
+        // Left card centres in the left half, right card in the right half.
+        assert!(positions[0].1 < 0.4, "left centre was {}", positions[0].1);
+        assert!(positions[1].1 > 0.6, "right centre was {}", positions[1].1);
+        // Both baselines are at y 200–220 of 500 → ~0.42.
+        assert!((positions[0].2 - 0.42).abs() < 0.01);
+    }
+
+    /// The mask is what makes Tesseract usable on a game frame, and the word
+    /// check is what stops a mask that isolated nothing from being trusted over
+    /// the greyscale fallback. Both directions matter, so both are pinned here.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn the_ui_colour_mask_keeps_interface_text_and_drops_artwork() {
+        // Two pixels of Zephyr-theme text, one of artwork that is merely close to
+        // it, and one unrelated. BGRA order, so the tuples read blue-first.
+        let pixels: Vec<u8> = [
+            [2u8, 132, 253, 255],  // Zephyr primary  (253,132,2) → text
+            [0, 53, 255, 255],     // Zephyr secondary (255,53,0) → text
+            [3, 133, 252, 255],    // one off in every channel → artwork
+            [40, 30, 20, 255],     // dark background → artwork
+        ]
+        .concat();
+        assert_eq!(ui_text_mask(&pixels), Some(vec![0, 0, 255, 255]));
+
+        // Nothing to isolate: the caller must not waste an OCR pass on a blank.
+        assert_eq!(ui_text_mask(&[40, 30, 20, 255, 41, 31, 21, 255]), None);
+
+        // Stray marks from a mask that caught only a panel border read as
+        // one- and two-character fragments; real interface text does not.
+        assert!(!reads_as_words("| - \n{ ,\n1,"));
+        assert!(reads_as_words("| Gauss Prime Chassis"));
+        assert!(reads_as_words("MR11"));
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/overlay_linux.rs
+++ b/src-tauri/src/overlay_linux.rs
@@ -166,6 +166,42 @@ fn apply_hints(xid: u32, window_type: &'static str) -> Result<(), String> {
     Ok(())
 }
 
+/// Put an overlay window where the caller asked, through X rather than through
+/// GTK.
+///
+/// Tauri's `set_position` on a window that is not yet mapped is a request the
+/// window manager answers with its own placement, and the client's value is only
+/// applied on a later turn of the GTK main loop. The overlay is shown at the
+/// moment the app is busiest, with OCR running on the reward screen, so that
+/// turn can be a long time coming, and until it arrives the band sits wherever
+/// KWin put it. On a two-monitor desktop that is routinely the wrong monitor.
+///
+/// A `ConfigureWindow` on our own connection does not queue behind any of that.
+///
+/// The size rides along because `set_size` defers the same way, and the band is
+/// a strip as wide as the game's monitor, so a late size is as visible as a late
+/// position.
+pub(crate) fn place(window: &WebviewWindow, x: i32, y: i32, width: u32, height: u32) {
+    let Some(xid) = xid(window) else { return };
+    if let Err(e) = configure(xid, x, y, width, height) {
+        eprintln!("[overlay] {}: {e}", window.label());
+    }
+}
+
+fn configure(xid: u32, x: i32, y: i32, width: u32, height: u32) -> Result<(), String> {
+    let conn = x11_connect()?;
+    conn.send_and_check_request(&x::ConfigureWindow {
+        window: x::Window::new(xid),
+        value_list: &[
+            x::ConfigWindow::X(x),
+            x::ConfigWindow::Y(y),
+            x::ConfigWindow::Width(width),
+            x::ConfigWindow::Height(height),
+        ],
+    })
+    .map_err(|e| format!("Cannot place the overlay window: {e}"))
+}
+
 /// The window's X11 id. `None` means the window is not an X11 window at all,
 /// which under `GDK_BACKEND=x11` means it has never been realised.
 fn xid(window: &WebviewWindow) -> Option<u32> {

--- a/src-tauri/src/overlay_linux.rs
+++ b/src-tauri/src/overlay_linux.rs
@@ -1,0 +1,335 @@
+// ==============================================================================
+// Linux overlay placement
+// ==============================================================================
+//
+// The relic band and the riven panel are ordinary Tauri windows that have to
+// behave like game overlays: above a fullscreen client, undecorated, never
+// stealing focus, and — for the band — invisible to the pointer. On Linux none
+// of that comes from Tauri's window options alone. It comes from EWMH
+// properties set on the X11 window, which this module writes.
+//
+// Two facts drive the whole design.
+//
+// The first is ordering. KWin reads `_NET_WM_WINDOW_TYPE` when it takes a
+// window under management and never looks again, so a property written to a
+// window that is already on screen changes nothing: the overlay sits under the
+// game while `xprop` reports the property present. The window has to be
+// unmapped when the properties are written and mapped afterwards. Since the X11
+// id only exists once the window has been realised, that makes the full
+// sequence show, unmap, write, map.
+//
+// The second is that a window type is enough on its own. `_NET_WM_STATE_ABOVE`
+// cannot win against a fullscreen client, because KWin promotes the focused
+// fullscreen window above every keep-above window. `_NET_WM_WINDOW_TYPE_DOCK`
+// loses for the same reason. KDE's critical-notification type lands in a layer
+// above both, which is why it is worth a KDE-specific atom.
+
+use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+use tauri::WebviewWindow;
+use xcb::{x, Xid, XidNew};
+
+use crate::ocr::x11_connect;
+
+// ==============================================================================
+// The window type
+// ==============================================================================
+
+fn window_type_atom() -> &'static str {
+    window_type_atom_from(|key| std::env::var(key).ok())
+}
+
+/// The window type that reaches a layer above a fullscreen game.
+///
+/// Only KDE needs a type of its own. Everything else this module writes is
+/// standard EWMH and needs no per-compositor branch.
+///
+/// Written over an environment reader rather than the real environment so it can
+/// be exercised without `set_var` racing other tests.
+///
+/// TODO: a compositor that refuses `_NET_WM_WINDOW_TYPE_DOCK` above a fullscreen
+/// client needs a branch of its own here, and enough detection to tell it apart.
+/// Nothing outside KDE has been run against a game yet.
+fn window_type_atom_from(env: impl Fn(&str) -> Option<String>) -> &'static str {
+    // The desktop name survives in a user's environment long after they stop
+    // running that desktop, and handing Hyprland an atom only KWin knows would
+    // leave the overlay an ordinary window under the game.
+    let names_itself = env("HYPRLAND_INSTANCE_SIGNATURE").is_some() || env("SWAYSOCK").is_some();
+
+    // Distributions disagree on case, on KDE versus plasma, and some publish
+    // several names joined by colons, so this is a substring test rather than an
+    // equality one.
+    let desktop = env("XDG_CURRENT_DESKTOP").unwrap_or_default().to_lowercase();
+    if !names_itself && (desktop.contains("kde") || desktop.contains("plasma")) {
+        "_KDE_NET_WM_WINDOW_TYPE_CRITICAL_NOTIFICATION"
+    } else {
+        "_NET_WM_WINDOW_TYPE_DOCK"
+    }
+}
+
+// ==============================================================================
+// The hints
+// ==============================================================================
+
+/// Properties whose values are themselves atoms, paired with the atom names to
+/// resolve into them.
+fn atom_hints(window_type: &'static str) -> Vec<(&'static str, Vec<&'static str>)> {
+    vec![
+        ("_NET_WM_WINDOW_TYPE", vec![window_type]),
+        (
+            "_NET_WM_STATE",
+            vec![
+                "_NET_WM_STATE_ABOVE",
+                "_NET_WM_STATE_STAYS_ON_TOP",
+                "_NET_WM_STATE_SKIP_TASKBAR",
+                "_NET_WM_STATE_SKIP_PAGER",
+            ],
+        ),
+    ]
+}
+
+/// Properties carrying plain numbers.
+///
+/// `_NET_WM_USER_TIME` of zero marks the map as not user-initiated, which is
+/// what stops the freshly mapped overlay from pulling focus off the game.
+///
+/// TODO: GTK points every toplevel at a second window through
+/// `_NET_WM_USER_TIME_WINDOW`, and a window manager honouring that redirection
+/// reads user time from there rather than from the window written below. KWin
+/// does not advertise it in `_NET_SUPPORTED`, so the zero lands; elsewhere the
+/// write has to follow the property.
+const CARDINAL_HINTS: &[(&str, &[u32])] = &[
+    ("_NET_WM_BYPASS_COMPOSITOR", &[2]),
+    ("_NET_WM_USER_TIME", &[0]),
+];
+
+/// The five-word Motif structure, with only the decorations field flagged as
+/// present and set to none. Belt and braces against a window manager that draws
+/// a frame despite Tauri's `decorations: false`.
+///
+/// Motif hints are typed with the `_MOTIF_WM_HINTS` atom rather than with
+/// `CARDINAL`, which is why this is not in the list above. A reader asks for
+/// the property by type, so the wrong type does not fail: it returns nothing,
+/// and the hint is quietly ignored.
+const MOTIF_HINTS: (&str, &[u32]) = ("_MOTIF_WM_HINTS", &[2, 0, 0, 0, 0]);
+
+/// Resolve an atom, creating it if the server has never seen it.
+///
+/// Not `ocr`'s `x11_atom`, which asks the server for existing atoms only. That
+/// is the right question when reading a property — a missing
+/// `_NET_CLIENT_LIST_STACKING` means there is no EWMH window manager — but the
+/// wrong one when writing. `_NET_WM_STATE_STAYS_ON_TOP` in particular is not
+/// part of EWMH and may well be unknown to the server until we name it, and an
+/// existence check would silently hand back the null atom.
+fn intern(conn: &xcb::Connection, name: &str) -> Result<x::Atom, String> {
+    let cookie = conn.send_request(&x::InternAtom {
+        only_if_exists: false,
+        name: name.as_bytes(),
+    });
+    conn.wait_for_reply(cookie)
+        .map(|reply| reply.atom())
+        .map_err(|e| format!("Cannot intern the {name} atom: {e}"))
+}
+
+/// Write every hint onto an X11 window.
+///
+/// Each request is checked rather than fired and forgotten, which also makes
+/// the call a round trip: by the time this returns, the properties are on the
+/// server and any subsequent map will be managed with them in place.
+fn apply_hints(xid: u32, window_type: &'static str) -> Result<(), String> {
+    let conn = x11_connect()?;
+    let window = x::Window::new(xid);
+
+    let write = |property: &str, r#type: x::Atom, data: &[u32]| -> Result<(), String> {
+        let property = intern(&conn, property)?;
+        conn.send_and_check_request(&x::ChangeProperty {
+            mode: x::PropMode::Replace,
+            window,
+            property,
+            r#type,
+            data,
+        })
+        .map_err(|e| format!("Cannot write an overlay window hint: {e}"))
+    };
+
+    for (property, atoms) in atom_hints(window_type) {
+        let values = atoms
+            .iter()
+            .map(|name| intern(&conn, name).map(|atom| atom.resource_id()))
+            .collect::<Result<Vec<u32>, String>>()?;
+        write(property, x::ATOM_ATOM, &values)?;
+    }
+    for (property, values) in CARDINAL_HINTS {
+        write(property, x::ATOM_CARDINAL, values)?;
+    }
+    let (motif, structure) = MOTIF_HINTS;
+    write(motif, intern(&conn, motif)?, structure)?;
+    Ok(())
+}
+
+/// The window's X11 id. `None` means the window is not an X11 window at all,
+/// which under `GDK_BACKEND=x11` means it has never been realised.
+fn xid(window: &WebviewWindow) -> Option<u32> {
+    match window.window_handle().ok()?.as_raw() {
+        RawWindowHandle::Xlib(handle) => Some(handle.window as u32),
+        RawWindowHandle::Xcb(handle) => Some(handle.window.into()),
+        _ => None,
+    }
+}
+
+/// What should happen to the window once its hints are written.
+///
+/// The caller states this rather than the window being asked, because asking is
+/// what breaks. `tauri://window-created` fires once the window has been handed
+/// to GTK to show, so a freshly created panel may report itself either mapped or
+/// not depending on how far that has got — and the branch where it reports
+/// itself hidden is the one where nobody maps it again afterwards, leaving the
+/// hints on a window the compositor already took under management unhinted.
+pub(crate) enum AfterHinting {
+    /// Leave the window down. The relic band is parked off screen at startup and
+    /// the show that brings it up for a real fissure is the map that reads the
+    /// hints, so it needs no cycle of its own.
+    LeaveHidden,
+    /// Put the window back up. The riven panel is on screen from the moment it
+    /// exists, so the only map that can read its hints is one we perform.
+    ShowAgain,
+}
+
+/// Put an overlay window's hints in place so the next map is managed with them.
+///
+/// The window comes down first in both cases. That is free for a window that is
+/// already down, and it is what guarantees the ordering for one that is not: the
+/// unmap and the write both precede the map, whichever way the two X connections
+/// happen to interleave.
+///
+/// Every failure here is reported and then swallowed. An overlay that ends up
+/// behind the game is worth a line in the log; it is not worth refusing to
+/// start over. The one failure that must not pass quietly is a window taken
+/// down for hinting and never put back, so that path says so.
+pub(crate) fn hint_before_map(window: &WebviewWindow, after: AfterHinting) {
+    let Some(xid) = xid(window) else {
+        eprintln!("[overlay] {} has no X11 window id, hints skipped", window.label());
+        return;
+    };
+
+    let _ = window.hide();
+
+    // Off the main thread: the hint writes round-trip to the X server, and the
+    // unmap issued above needs the main loop back to reach the server at all.
+    let window = window.clone();
+    std::thread::spawn(move || {
+        if let Err(e) = apply_hints(xid, window_type_atom()) {
+            eprintln!("[overlay] {}: {e}", window.label());
+            return;
+        }
+        if matches!(after, AfterHinting::LeaveHidden) {
+            return;
+        }
+        // Position is left to GTK, which re-applies the geometry it was given at
+        // creation when the window maps again. Re-asserting it from here would
+        // mean reading a position back off a window that may never have been
+        // mapped, and a wrong origin puts the panel on the wrong monitor.
+        let restored = window.clone();
+        let put_back = window.run_on_main_thread(move || {
+            let _ = restored.show();
+        });
+        if let Err(e) = put_back {
+            eprintln!(
+                "[overlay] {} was hidden for hinting and cannot be shown again: {e}",
+                window.label()
+            );
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn env_of(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+        let map: HashMap<String, String> = pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        move |key: &str| map.get(key).cloned()
+    }
+
+    /// The distinction the whole module exists for: DOCK reaches KWin's
+    /// AboveLayer, which is below the layer a focused fullscreen window is
+    /// promoted into, so on KDE it would leave the overlay under the game.
+    #[test]
+    fn kde_gets_the_critical_notification_type() {
+        let env = env_of(&[("XDG_CURRENT_DESKTOP", "KDE"), ("XDG_SESSION_TYPE", "wayland")]);
+        assert_eq!(
+            window_type_atom_from(env),
+            "_KDE_NET_WM_WINDOW_TYPE_CRITICAL_NOTIFICATION"
+        );
+    }
+
+    /// Distributions disagree on the case and on whether the value reads KDE or
+    /// plasma, and some concatenate several names with colons.
+    #[test]
+    fn the_desktop_name_is_matched_loosely() {
+        let env = env_of(&[("XDG_CURRENT_DESKTOP", "plasmawayland:KDE")]);
+        assert_eq!(
+            window_type_atom_from(env),
+            "_KDE_NET_WM_WINDOW_TYPE_CRITICAL_NOTIFICATION"
+        );
+    }
+
+    /// Hyprland sets `XDG_CURRENT_DESKTOP=Hyprland`, but a session started from
+    /// a Plasma-configured user account can carry a stale KDE value, and neither
+    /// Hyprland nor Sway would know what to do with KDE's atom.
+    #[test]
+    fn a_compositor_that_names_itself_does_not_get_kdes_atom() {
+        for signature in ["HYPRLAND_INSTANCE_SIGNATURE", "SWAYSOCK"] {
+            let env = env_of(&[(signature, "abc123"), ("XDG_CURRENT_DESKTOP", "KDE")]);
+            assert_eq!(window_type_atom_from(env), "_NET_WM_WINDOW_TYPE_DOCK");
+        }
+    }
+
+    #[test]
+    fn anything_else_gets_dock() {
+        let env = env_of(&[]);
+        assert_eq!(window_type_atom_from(env), "_NET_WM_WINDOW_TYPE_DOCK");
+    }
+
+    #[test]
+    fn the_state_hint_keeps_the_overlay_above_and_out_of_the_task_switcher() {
+        let hints = atom_hints("_NET_WM_WINDOW_TYPE_DOCK");
+        let state = hints
+            .iter()
+            .find(|(property, _)| *property == "_NET_WM_STATE")
+            .expect("_NET_WM_STATE is written whatever the window type");
+        assert_eq!(
+            state.1,
+            vec![
+                "_NET_WM_STATE_ABOVE",
+                "_NET_WM_STATE_STAYS_ON_TOP",
+                "_NET_WM_STATE_SKIP_TASKBAR",
+                "_NET_WM_STATE_SKIP_PAGER",
+            ]
+        );
+    }
+
+    /// A non-zero user time would read as "the user just did this", which is
+    /// exactly the claim that makes a window manager hand over focus.
+    #[test]
+    fn the_user_time_hint_is_zero() {
+        let (_, values) = CARDINAL_HINTS
+            .iter()
+            .find(|(property, _)| *property == "_NET_WM_USER_TIME")
+            .expect("_NET_WM_USER_TIME is written");
+        assert_eq!(*values, &[0]);
+    }
+
+    /// Motif hints are typed with their own atom. Written as `CARDINAL` they
+    /// read back as nothing at all, so the property has to stay out of the list
+    /// that is written that way.
+    #[test]
+    fn the_motif_hint_is_not_written_as_a_cardinal() {
+        assert!(!CARDINAL_HINTS
+            .iter()
+            .any(|(property, _)| *property == MOTIF_HINTS.0));
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "FrameForge",
-  "version": "2.8.0+linux.1",
+  "version": "2.8.0+linux.2",
   "identifier": "com.jochem.frameforge",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -57,6 +57,10 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "publisher": "Lyrex",
+    "category": "Game",
+    "shortDescription": "Warframe companion — inventory, market prices and relic rewards.",
+    "longDescription": "A read-only desktop companion for Warframe. Reads the account inventory out of the running game's memory, prices items against warframe.market, tracks Foundry recipes and world-state timers, and shows relic reward values as an overlay while the fissure reward screen is open.",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "FrameForge",
-  "version": "2.8.0",
+  "version": "2.8.0+linux.1",
   "identifier": "com.jochem.frameforge",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -63,6 +63,20 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "linux": {
+      "deb": {
+        "depends": [
+          "libtesseract5",
+          "tesseract-ocr-eng"
+        ]
+      },
+      "rpm": {
+        "depends": [
+          "tesseract",
+          "tesseract-langpack-eng"
+        ]
+      }
+    }
   }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -67,14 +67,12 @@
     "linux": {
       "deb": {
         "depends": [
-          "libtesseract5",
-          "tesseract-ocr-eng"
+          "libtesseract5"
         ]
       },
       "rpm": {
         "depends": [
-          "tesseract",
-          "tesseract-langpack-eng"
+          "tesseract"
         ]
       }
     }

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "build": {
+    "beforeBundleCommand": "bash scripts/fetch-tessdata.sh"
+  },
+  "bundle": {
+    "resources": ["tessdata/eng.traineddata"]
+  }
+}

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -1,8 +1,5 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "build": {
-    "beforeBundleCommand": "bash scripts/fetch-tessdata.sh"
-  },
   "bundle": {
     "resources": ["tessdata/eng.traineddata"]
   }

--- a/src-tauri/tests/fixtures/relic_rewards.txt
+++ b/src-tauri/tests/fixtures/relic_rewards.txt
@@ -1,0 +1,602 @@
+# Every reward name a Void relic can drop, one per line.
+# Generated from WFCD warframe-items Relics.json (2026-07-27):
+#   jq -r '.[] | select(.uniqueName | contains("/Game/Projections/"))
+#          | .rewards[].item.name' Relics.json | sort -u
+# Committed rather than fetched so the OCR corpus test stays offline and
+# reproducible; refresh it when the game adds prime parts.
+1200X Kuva
+2X Forma Blueprint
+Acceltra Prime Barrel
+Acceltra Prime Blueprint
+Acceltra Prime Receiver
+Acceltra Prime Stock
+Afentis Prime Barrel
+Afentis Prime Blade
+Afentis Prime Blueprint
+Afentis Prime Handle
+Afuris Prime Barrel
+Afuris Prime Blueprint
+Afuris Prime Link
+Afuris Prime Receiver
+Akarius Prime Barrel
+Akarius Prime Blueprint
+Akarius Prime Link
+Akarius Prime Receiver
+Akbolto Prime Barrel
+Akbolto Prime Blueprint
+Akbolto Prime Link
+Akbolto Prime Receiver
+Akbronco Prime Blueprint
+Akbronco Prime Link
+Akjagara Prime Barrel
+Akjagara Prime Blueprint
+Akjagara Prime Link
+Akjagara Prime Receiver
+Aklex Prime Blueprint
+Aklex Prime Link
+Akmagnus Prime Blueprint
+Akmagnus Prime Link
+Aksomati Prime Barrel
+Aksomati Prime Blueprint
+Aksomati Prime Link
+Aksomati Prime Receiver
+Akstiletto Prime Barrel
+Akstiletto Prime Blueprint
+Akstiletto Prime Link
+Akstiletto Prime Receiver
+Akvasto Prime Blueprint
+Akvasto Prime Link
+Alternox Prime Barrel
+Alternox Prime Blueprint
+Alternox Prime Receiver
+Alternox Prime Stock
+Ankyros Prime Blade
+Ankyros Prime Blueprint
+Ankyros Prime Gauntlet
+Ash Prime Blueprint
+Ash Prime Chassis Blueprint
+Ash Prime Neuroptics Blueprint
+Ash Prime Systems Blueprint
+Astilla Prime Barrel
+Astilla Prime Blueprint
+Astilla Prime Receiver
+Astilla Prime Stock
+Athodai Prime Barrel
+Athodai Prime Blueprint
+Athodai Prime Receiver
+Atlas Prime Blueprint
+Atlas Prime Chassis Blueprint
+Atlas Prime Neuroptics Blueprint
+Atlas Prime Systems Blueprint
+Ayatan Amber Star
+Ballistica Prime Blueprint
+Ballistica Prime Lower Limb
+Ballistica Prime Receiver
+Ballistica Prime String
+Ballistica Prime Upper Limb
+Banshee Prime Blueprint
+Banshee Prime Chassis Blueprint
+Banshee Prime Neuroptics Blueprint
+Banshee Prime Systems Blueprint
+Baruuk Prime Blueprint
+Baruuk Prime Chassis Blueprint
+Baruuk Prime Neuroptics Blueprint
+Baruuk Prime Systems Blueprint
+Baza Prime Barrel
+Baza Prime Blueprint
+Baza Prime Receiver
+Baza Prime Stock
+Boar Prime Barrel
+Boar Prime Blueprint
+Boar Prime Receiver
+Boar Prime Stock
+Boltor Prime Barrel
+Boltor Prime Blueprint
+Boltor Prime Receiver
+Boltor Prime Stock
+Bo Prime Blueprint
+Bo Prime Handle
+Bo Prime Ornament
+Braton Prime Barrel
+Braton Prime Blueprint
+Braton Prime Receiver
+Braton Prime Stock
+Bronco Prime Barrel
+Bronco Prime Blueprint
+Bronco Prime Receiver
+Burston Prime Barrel
+Burston Prime Blueprint
+Burston Prime Receiver
+Burston Prime Stock
+Caliban Prime Blueprint
+Caliban Prime Chassis Blueprint
+Caliban Prime Neuroptics Blueprint
+Caliban Prime Systems Blueprint
+Carrier Prime Blueprint
+Carrier Prime Carapace
+Carrier Prime Cerebrum
+Carrier Prime Systems
+Cedo Prime Barrel
+Cedo Prime Blueprint
+Cedo Prime Receiver
+Cedo Prime Stock
+Cernos Prime Blueprint
+Cernos Prime Grip
+Cernos Prime Lower Limb
+Cernos Prime String
+Cernos Prime Upper Limb
+Chroma Prime Blueprint
+Chroma Prime Chassis Blueprint
+Chroma Prime Neuroptics Blueprint
+Chroma Prime Systems Blueprint
+Cobra & Crane Prime Blade
+Cobra & Crane Prime Blueprint
+Cobra & Crane Prime Guard
+Cobra & Crane Prime Hilt
+Corinth Prime Barrel
+Corinth Prime Blueprint
+Corinth Prime Receiver
+Corinth Prime Stock
+Corvas Prime Barrel
+Corvas Prime Blueprint
+Corvas Prime Receiver
+Corvas Prime Stock
+Daikyu Prime Blueprint
+Daikyu Prime Grip
+Daikyu Prime Lower Limb
+Daikyu Prime String
+Daikyu Prime Upper Limb
+Dakra Prime Blade
+Dakra Prime Blueprint
+Dakra Prime Handle
+Destreza Prime Blade
+Destreza Prime Blueprint
+Destreza Prime Handle
+Dethcube Prime Blueprint
+Dethcube Prime Carapace
+Dethcube Prime Cerebrum
+Dethcube Prime Systems
+Dual Kamas Prime Blade
+Dual Kamas Prime Blueprint
+Dual Kamas Prime Handle
+Dual Keres Prime Blade
+Dual Keres Prime Blueprint
+Dual Keres Prime Handle
+Dual Zoren Prime Blade
+Dual Zoren Prime Blueprint
+Dual Zoren Prime Handle
+Ember Prime Blueprint
+Ember Prime Chassis Blueprint
+Ember Prime Neuroptics Blueprint
+Ember Prime Systems Blueprint
+Epitaph Prime Barrel
+Epitaph Prime Blueprint
+Epitaph Prime Receiver
+Equinox Prime Blueprint
+Equinox Prime Chassis Blueprint
+Equinox Prime Neuroptics Blueprint
+Equinox Prime Systems Blueprint
+Euphona Prime Barrel
+Euphona Prime Blueprint
+Euphona Prime Receiver
+Exilus Weapon Adapter Blueprint
+Fang Prime Blade
+Fang Prime Blueprint
+Fang Prime Handle
+Fass
+Forma Blueprint
+Fragor Prime Blueprint
+Fragor Prime Handle
+Fragor Prime Head
+Frost Prime Blueprint
+Frost Prime Chassis Blueprint
+Frost Prime Neuroptics Blueprint
+Frost Prime Systems Blueprint
+Fulmin Prime Barrel
+Fulmin Prime Blueprint
+Fulmin Prime Receiver
+Fulmin Prime Stock
+Galatine Prime Blade
+Galatine Prime Blueprint
+Galatine Prime Handle
+Gara Prime Blueprint
+Gara Prime Chassis Blueprint
+Gara Prime Neuroptics Blueprint
+Gara Prime Systems Blueprint
+Garuda Prime Blueprint
+Garuda Prime Chassis Blueprint
+Garuda Prime Neuroptics Blueprint
+Garuda Prime Systems Blueprint
+Gauss Prime Blueprint
+Gauss Prime Chassis Blueprint
+Gauss Prime Neuroptics Blueprint
+Gauss Prime Systems Blueprint
+Glaive Prime Blade
+Glaive Prime Blueprint
+Glaive Prime Disc
+Gram Prime Blade
+Gram Prime Blueprint
+Gram Prime Handle
+Grendel Prime Blueprint
+Grendel Prime Chassis Blueprint
+Grendel Prime Neuroptics Blueprint
+Grendel Prime Systems Blueprint
+Guandao Prime Blade
+Guandao Prime Blueprint
+Guandao Prime Handle
+Gunsen Prime Blade
+Gunsen Prime Blueprint
+Gunsen Prime Handle
+Gyre Prime Blueprint
+Gyre Prime Chassis Blueprint
+Gyre Prime Neuroptics Blueprint
+Gyre Prime Systems Blueprint
+Harrow Prime Blueprint
+Harrow Prime Chassis Blueprint
+Harrow Prime Neuroptics Blueprint
+Harrow Prime Systems Blueprint
+Helios Prime Blueprint
+Helios Prime Carapace
+Helios Prime Cerebrum
+Helios Prime Systems
+Hikou Prime Blueprint
+Hikou Prime Pouch
+Hikou Prime Stars
+Hildryn Prime Blueprint
+Hildryn Prime Chassis Blueprint
+Hildryn Prime Neuroptics Blueprint
+Hildryn Prime Systems Blueprint
+Hydroid Prime Blueprint
+Hydroid Prime Chassis Blueprint
+Hydroid Prime Neuroptics Blueprint
+Hydroid Prime Systems Blueprint
+Hystrix Prime Barrel
+Hystrix Prime Blueprint
+Hystrix Prime Receiver
+Inaros Prime Blueprint
+Inaros Prime Chassis Blueprint
+Inaros Prime Neuroptics Blueprint
+Inaros Prime Systems Blueprint
+Ivara Prime Blueprint
+Ivara Prime Chassis Blueprint
+Ivara Prime Neuroptics Blueprint
+Ivara Prime Systems Blueprint
+Jahu
+Karyst Prime Blade
+Karyst Prime Blueprint
+Karyst Prime Handle
+Kavasa Prime Band
+Kavasa Prime Buckle
+Kavasa Prime Kubrow Collar Blueprint
+Kestrel Prime Blade
+Kestrel Prime Blueprint
+Kestrel Prime Grip
+Khora Prime Blueprint
+Khora Prime Chassis Blueprint
+Khora Prime Neuroptics Blueprint
+Khora Prime Systems Blueprint
+Khra
+Knell Prime Barrel
+Knell Prime Blueprint
+Knell Prime Receiver
+Kogake Prime Blueprint
+Kogake Prime Boot
+Kogake Prime Gauntlet
+Kompressa Prime Barrel
+Kompressa Prime Blueprint
+Kompressa Prime Receiver
+Kronen Prime Blade
+Kronen Prime Blueprint
+Kronen Prime Handle
+Larkspur Prime Barrel
+Larkspur Prime Blueprint
+Larkspur Prime Receiver
+Larkspur Prime Stock
+Latron Prime Barrel
+Latron Prime Blueprint
+Latron Prime Receiver
+Latron Prime Stock
+Lavos Prime Blueprint
+Lavos Prime Chassis Blueprint
+Lavos Prime Neuroptics Blueprint
+Lavos Prime Systems Blueprint
+Lex Prime Barrel
+Lex Prime Blueprint
+Lex Prime Receiver
+Limbo Prime Blueprint
+Limbo Prime Chassis Blueprint
+Limbo Prime Neuroptics Blueprint
+Limbo Prime Systems Blueprint
+Lohk
+Loki Prime Blueprint
+Loki Prime Chassis Blueprint
+Loki Prime Neuroptics Blueprint
+Loki Prime Systems Blueprint
+Magnus Prime Barrel
+Magnus Prime Blueprint
+Magnus Prime Receiver
+Mag Prime Blueprint
+Mag Prime Chassis Blueprint
+Mag Prime Neuroptics Blueprint
+Mag Prime Systems Blueprint
+Masseter Prime Blade
+Masseter Prime Blueprint
+Masseter Prime Handle
+Mesa Prime Blueprint
+Mesa Prime Chassis Blueprint
+Mesa Prime Neuroptics Blueprint
+Mesa Prime Systems Blueprint
+Mirage Prime Blueprint
+Mirage Prime Chassis Blueprint
+Mirage Prime Neuroptics Blueprint
+Mirage Prime Systems Blueprint
+Nagantaka Prime Barrel
+Nagantaka Prime Blueprint
+Nagantaka Prime Receiver
+Nagantaka Prime Stock
+Nami Skyla Prime Blade
+Nami Skyla Prime Blueprint
+Nami Skyla Prime Handle
+Nautilus Prime Blueprint
+Nautilus Prime Carapace
+Nautilus Prime Cerebrum
+Nautilus Prime Systems
+Nekros Prime Blueprint
+Nekros Prime Chassis Blueprint
+Nekros Prime Neuroptics Blueprint
+Nekros Prime Systems Blueprint
+Netra
+Nezha Prime Blueprint
+Nezha Prime Chassis Blueprint
+Nezha Prime Neuroptics Blueprint
+Nezha Prime Systems Blueprint
+Nidus Prime Blueprint
+Nidus Prime Chassis Blueprint
+Nidus Prime Neuroptics Blueprint
+Nidus Prime Systems Blueprint
+Nikana Prime Blade
+Nikana Prime Blueprint
+Nikana Prime Hilt
+Ninkondi Prime Blueprint
+Ninkondi Prime Chain
+Ninkondi Prime Handle
+Nova Prime Blueprint
+Nova Prime Chassis Blueprint
+Nova Prime Neuroptics Blueprint
+Nova Prime Systems Blueprint
+Nyx Prime Blueprint
+Nyx Prime Chassis Blueprint
+Nyx Prime Neuroptics Blueprint
+Nyx Prime Systems Blueprint
+Oberon Prime Blueprint
+Oberon Prime Chassis Blueprint
+Oberon Prime Neuroptics Blueprint
+Oberon Prime Systems Blueprint
+Octavia Prime Blueprint
+Octavia Prime Chassis Blueprint
+Octavia Prime Neuroptics Blueprint
+Octavia Prime Systems Blueprint
+Odonata Prime Blueprint
+Odonata Prime Harness Blueprint
+Odonata Prime Systems Blueprint
+Odonata Prime Wings Blueprint
+Okina Prime Blade
+Okina Prime Blueprint
+Okina Prime Handle
+Orthos Prime Blade
+Orthos Prime Blueprint
+Orthos Prime Handle
+Pandero Prime Barrel
+Pandero Prime Blueprint
+Pandero Prime Receiver
+Pangolin Prime Blade
+Pangolin Prime Blueprint
+Pangolin Prime Handle
+Panthera Prime Barrel
+Panthera Prime Blueprint
+Panthera Prime Receiver
+Panthera Prime Stock
+Paris Prime Blueprint
+Paris Prime Grip
+Paris Prime Lower Limb
+Paris Prime String
+Paris Prime Upper Limb
+Perigale Prime Barrel
+Perigale Prime Blueprint
+Perigale Prime Receiver
+Perigale Prime Stock
+Phantasma Prime Barrel
+Phantasma Prime Blueprint
+Phantasma Prime Receiver
+Phantasma Prime Stock
+Protea Prime Blueprint
+Protea Prime Chassis Blueprint
+Protea Prime Neuroptics Blueprint
+Protea Prime Systems Blueprint
+Pyrana Prime Barrel
+Pyrana Prime Blueprint
+Pyrana Prime Receiver
+Quassus Prime Blade
+Quassus Prime Blueprint
+Quassus Prime Handle
+Reaper Prime Blade
+Reaper Prime Blueprint
+Reaper Prime Handle
+Redeemer Prime Blade
+Redeemer Prime Blueprint
+Redeemer Prime Handle
+Revenant Prime Blueprint
+Revenant Prime Chassis Blueprint
+Revenant Prime Neuroptics Blueprint
+Revenant Prime Systems Blueprint
+Rhino Prime Blueprint
+Rhino Prime Chassis Blueprint
+Rhino Prime Neuroptics Blueprint
+Rhino Prime Systems Blueprint
+Ris
+Riven Sliver
+Rubico Prime Barrel
+Rubico Prime Blueprint
+Rubico Prime Receiver
+Rubico Prime Stock
+Sarofang Prime Blade
+Sarofang Prime Blueprint
+Sarofang Prime Handle
+Saryn Prime Blueprint
+Saryn Prime Chassis Blueprint
+Saryn Prime Neuroptics Blueprint
+Saryn Prime Systems Blueprint
+Scindo Prime Blade
+Scindo Prime Blueprint
+Scindo Prime Handle
+Scourge Prime Barrel
+Scourge Prime Blade
+Scourge Prime Blueprint
+Scourge Prime Handle
+Sevagoth Prime Blueprint
+Sevagoth Prime Chassis Blueprint
+Sevagoth Prime Neuroptics Blueprint
+Sevagoth Prime Systems Blueprint
+Shade Prime Blueprint
+Shade Prime Carapace
+Shade Prime Cerebrum
+Shade Prime Systems
+Sicarus Prime Barrel
+Sicarus Prime Blueprint
+Sicarus Prime Receiver
+Silva & Aegis Prime Blade
+Silva & Aegis Prime Blueprint
+Silva & Aegis Prime Guard
+Silva & Aegis Prime Hilt
+Soma Prime Barrel
+Soma Prime Blueprint
+Soma Prime Receiver
+Soma Prime Stock
+Spira Prime Blade
+Spira Prime Blueprint
+Spira Prime Pouch
+Stradavar Prime Barrel
+Stradavar Prime Blueprint
+Stradavar Prime Receiver
+Stradavar Prime Stock
+Strun Prime Barrel
+Strun Prime Blueprint
+Strun Prime Receiver
+Strun Prime Stock
+Styanax Prime Blueprint
+Styanax Prime Chassis Blueprint
+Styanax Prime Neuroptics Blueprint
+Styanax Prime Systems Blueprint
+Sybaris Prime Barrel
+Sybaris Prime Blueprint
+Sybaris Prime Receiver
+Sybaris Prime Stock
+Tatsu Prime Blade
+Tatsu Prime Blueprint
+Tatsu Prime Handle
+Tekko Prime Blade
+Tekko Prime Blueprint
+Tekko Prime Gauntlet
+Tenora Prime Barrel
+Tenora Prime Blueprint
+Tenora Prime Receiver
+Tenora Prime Stock
+Tiberon Prime Barrel
+Tiberon Prime Blueprint
+Tiberon Prime Receiver
+Tiberon Prime Stock
+Tigris Prime Barrel
+Tigris Prime Blueprint
+Tigris Prime Receiver
+Tigris Prime Stock
+Tipedo Prime Blueprint
+Tipedo Prime Handle
+Tipedo Prime Ornament
+Titania Prime Blueprint
+Titania Prime Chassis Blueprint
+Titania Prime Neuroptics Blueprint
+Titania Prime Systems Blueprint
+Trinity Prime Blueprint
+Trinity Prime Chassis Blueprint
+Trinity Prime Neuroptics Blueprint
+Trinity Prime Systems Blueprint
+Trumna Prime Barrel
+Trumna Prime Blueprint
+Trumna Prime Receiver
+Trumna Prime Stock
+Vadarya Prime Barrel
+Vadarya Prime Blueprint
+Vadarya Prime Receiver
+Vadarya Prime Stock
+Valkyr Prime Blueprint
+Valkyr Prime Chassis Blueprint
+Valkyr Prime Neuroptics Blueprint
+Valkyr Prime Systems Blueprint
+Vasto Prime Barrel
+Vasto Prime Blueprint
+Vasto Prime Receiver
+Vauban Prime Blueprint
+Vauban Prime Chassis Blueprint
+Vauban Prime Neuroptics Blueprint
+Vauban Prime Systems Blueprint
+Vectis Prime Barrel
+Vectis Prime Blueprint
+Vectis Prime Receiver
+Vectis Prime Stock
+Velox Prime Barrel
+Velox Prime Blueprint
+Velox Prime Receiver
+Venato Prime Blade
+Venato Prime Blueprint
+Venato Prime Handle
+Venka Prime Blades
+Venka Prime Blueprint
+Venka Prime Gauntlet
+Volnus Prime Blueprint
+Volnus Prime Handle
+Volnus Prime Head
+Volt Prime Blueprint
+Volt Prime Chassis Blueprint
+Volt Prime Neuroptics Blueprint
+Volt Prime Systems Blueprint
+Vome
+Voruna Prime Blueprint
+Voruna Prime Chassis Blueprint
+Voruna Prime Neuroptics Blueprint
+Voruna Prime Systems Blueprint
+Wisp Prime Blueprint
+Wisp Prime Chassis Blueprint
+Wisp Prime Neuroptics Blueprint
+Wisp Prime Systems Blueprint
+Wukong Prime Blueprint
+Wukong Prime Chassis Blueprint
+Wukong Prime Neuroptics Blueprint
+Wukong Prime Systems Blueprint
+Wyrm Prime Blueprint
+Wyrm Prime Carapace
+Wyrm Prime Cerebrum
+Wyrm Prime Systems
+Xaku Prime Blueprint
+Xaku Prime Chassis Blueprint
+Xaku Prime Neuroptics Blueprint
+Xaku Prime Systems Blueprint
+Xata
+Yareli Prime Blueprint
+Yareli Prime Chassis Blueprint
+Yareli Prime Neuroptics Blueprint
+Yareli Prime Systems Blueprint
+Zakti Prime Barrel
+Zakti Prime Blueprint
+Zakti Prime Receiver
+Zephyr Prime Blueprint
+Zephyr Prime Chassis Blueprint
+Zephyr Prime Neuroptics Blueprint
+Zephyr Prime Systems Blueprint
+Zhuge Prime Barrel
+Zhuge Prime Blueprint
+Zhuge Prime Grip
+Zhuge Prime Receiver
+Zhuge Prime String
+Zylok Prime Barrel
+Zylok Prime Blueprint
+Zylok Prime Receiver

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { getVersion } from "@tauri-apps/api/app";
 import { listen } from "@tauri-apps/api/event";
 import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
+import { usePlatformCapabilities } from "./platform";
 
 // ── Riven overlay — module-level window management ────────────────────────────
 // Stored OUTSIDE React so StrictMode remounts don't destroy/recreate the window.
@@ -578,7 +579,11 @@ const [blobLogEnabled, setBlobLogEnabled] = useState(false);
   const [wfmInvisibleOnClose,   setWfmInvisibleOnClose]   = useState(false);
   const [wfmAutoInvisible,      setWfmAutoInvisible]      = useState(false);
   const [wfmAutoInvisibleMins,  setWfmAutoInvisibleMins]  = useState(30);
+  const platform = usePlatformCapabilities();
   const [overlayStatus, setOverlayStatus] = useState("");
+  // Without OCR the overlay can never trigger, so treat it as off for this run.
+  // The stored preference is deliberately left untouched: the same settings file
+  // is used on Windows, where the overlay does work.
   const [subsummedWarframes, setSubsummedWarframes] = useState<Set<string>>(new Set());
   const [archonShards, setArchonShards] = useState<Record<string, {type: string; tauforged: boolean; color: string; boost?: string}[]>>({});
   const [lastApiRefresh, setLastApiRefresh] = useState<number | null>(null);
@@ -626,9 +631,10 @@ const [blobLogEnabled, setBlobLogEnabled] = useState(false);
   const [fetchMsg, setFetchMsg] = useState("");
   const [showSettings, setShowSettings] = useState(false);
   const [settingsTab, setSettingsTab] = useState<'general' | 'market' | 'accessibility' | 'data' | 'debugging'>('general');
-  const [overlayEnabled, setOverlayEnabled] = useState<boolean>(
+  const [overlayEnabledSetting, setOverlayEnabled] = useState<boolean>(
     () => localStorage.getItem("ff-overlay-enabled") !== "false"
   );
+  const overlayEnabled = overlayEnabledSetting && platform.ocr;
   const [overlayPriority, setOverlayPriority] = useState<string>(
     () => localStorage.getItem("ff-overlay-priority") ?? "completion"
   );
@@ -680,7 +686,7 @@ const [blobLogEnabled, setBlobLogEnabled] = useState(false);
     modularSectionOrder: ["tracking", "favorites", "timers"] as string[], modularPopout: false,
     wfmInvisibleOnStart: false, wfmInvisibleOnClose: false, wfmAutoInvisible: false, wfmAutoInvisibleMins: 30,
   });
-  settingsRef.current = { overlayEnabled, overlayPriority, textScale, colorblindMode, clockFormat, companionApiEnabled, memoryScannerEnabled, blobLogEnabled, apiLogEnabled, autoDiagEnabled, tracked, favorites, timerFavorites, fissureWatches, modularWidth, modularSectionOrder, modularPopout, wfmInvisibleOnStart, wfmInvisibleOnClose, wfmAutoInvisible, wfmAutoInvisibleMins };
+  settingsRef.current = { overlayEnabled: overlayEnabledSetting, overlayPriority, textScale, colorblindMode, clockFormat, companionApiEnabled, memoryScannerEnabled, blobLogEnabled, apiLogEnabled, autoDiagEnabled, tracked, favorites, timerFavorites, fissureWatches, modularWidth, modularSectionOrder, modularPopout, wfmInvisibleOnStart, wfmInvisibleOnClose, wfmAutoInvisible, wfmAutoInvisibleMins };
 
   const saveAllSettings = useCallback(() => {
     invoke("save_settings", { json: JSON.stringify(settingsRef.current) }).catch((e) => {
@@ -1951,7 +1957,17 @@ if (typeof s.autoDiagEnabled === "boolean") {
 
                   {/* Relic Overlay */}
                   <div className="settings-section">
-                    <div className="settings-section-title">Relic Overlay</div>
+                    {/* The overlay is driven by screen capture + OCR, neither of
+                        which the Linux backend provides, so the controls stay
+                        visible but inert rather than silently doing nothing. */}
+                    <div className="settings-section-title">
+                      Relic Overlay
+                      {!platform.ocr && (
+                        <span style={{ fontSize: 10, marginLeft: 8, color: "var(--muted)", fontWeight: 400 }}>
+                          Unavailable on Linux
+                        </span>
+                      )}
+                    </div>
                     {overlayStatus && (
                       <div style={{ fontSize: 12, padding: '4px 8px', marginBottom: 6,
                         background: 'rgba(255,255,255,0.05)', borderRadius: 4,
@@ -1966,9 +1982,10 @@ if (typeof s.autoDiagEnabled === "boolean") {
                       </div>
                       <button
                         className="btn-secondary"
+                        disabled={!platform.ocr}
                         style={{ minWidth: 64, background: overlayEnabled ? "rgba(56,139,253,.15)" : undefined, borderColor: overlayEnabled ? "var(--accent)" : undefined }}
                         onClick={() => {
-                          const next = !overlayEnabled;
+                          const next = !overlayEnabledSetting;
                           setOverlayEnabled(next);
                           localStorage.setItem("ff-overlay-enabled", String(next));
                           settingsRef.current = { ...settingsRef.current, overlayEnabled: next };
@@ -1989,7 +2006,7 @@ if (typeof s.autoDiagEnabled === "boolean") {
                       <select
                         className="settings-select"
                         value={overlayPriority}
-                        disabled={!overlayEnabled}
+                        disabled={!overlayEnabled || !platform.ocr}
                         onChange={e => {
                           const next = e.target.value;
                           setOverlayPriority(next);
@@ -2015,7 +2032,7 @@ if (typeof s.autoDiagEnabled === "boolean") {
                       </span>
                     </div>
                     <div style={{ fontSize: 11, color: "var(--muted)", marginBottom: 8, lineHeight: 1.5 }}>
-                      Reads live inventory, crafting jobs, and mod ranks from Warframe's process memory via <code style={{ fontSize: 10 }}>ReadProcessMemory</code>. DE has historically tolerated read-only tools, but has not given explicit permission. Enable at your own risk.
+                      Reads live inventory, crafting jobs, and mod ranks from Warframe's process memory via <code style={{ fontSize: 10 }}>{platform.linux ? "/proc/<pid>/mem" : "ReadProcessMemory"}</code>. DE has historically tolerated read-only tools, but has not given explicit permission. Enable at your own risk.
                     </div>
                     <div className="settings-row">
                       <div>

--- a/src/RivenOverlayWindow.css
+++ b/src/RivenOverlayWindow.css
@@ -89,6 +89,13 @@ body { background: transparent; overflow: hidden; }
 .rov-close-btn:hover { color: #f85149; background: rgba(248,81,73,.12); }
 
 /* ── Scanning / empty ── */
+.rov-grab-note {
+  font-size: 11px;
+  color: rgba(139,148,158,.7);
+  text-align: center;
+  padding: 2px 0 4px;
+}
+
 .rov-scanning {
   font-size: 12px;
   color: rgba(139,148,158,.8);

--- a/src/RivenOverlayWindow.tsx
+++ b/src/RivenOverlayWindow.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { listen, emit } from "@tauri-apps/api/event";
+import { usePlatformCapabilities } from "./platform";
 
 // Tells App.tsx to run OCR again (for "Check New Roll" / "Start Comparison")
 const triggerNewCheck = () => emit("riven-manual-check", {}).catch(() => {});
@@ -84,6 +85,7 @@ export default function RivenOverlayWindow() {
   const [scanning, setScanning]         = useState(true);
   const [saved, setSaved]               = useState(false);
   const scanTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const { linux } = usePlatformCapabilities();
 
   const resetToScanning = () => {
     setScanning(true);
@@ -203,6 +205,15 @@ export default function RivenOverlayWindow() {
           )}
           <button className="rov-close-btn" onClick={() => requestHide("x-button")} title="Dismiss">✕</button>
         </div>
+
+        {/* Warframe holds an X11 pointer grab for as long as it is the active
+            window, so nothing above it, this panel included, receives a click
+            until the player switches away. The buttons work normally then.
+
+            TODO: this line is the provisional answer to how the panel is meant
+            to be used at all while the game is focused. Driving it from the main
+            window and making it display-only are the alternatives. */}
+        {linux && <div className="rov-grab-note">Alt-Tab out of the game to use these buttons</div>}
 
         {/* Scanning */}
         {scanning && (

--- a/src/WfmTrading.tsx
+++ b/src/WfmTrading.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import ItemMarketPopup from "./ItemMarketPopup";
+import { usePlatformCapabilities } from "./platform";
 import "./WfmTrading.css";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -110,6 +111,10 @@ async function invokeWfm<T>(command: string, args?: Record<string, unknown>): Pr
 // ── Login panel ───────────────────────────────────────────────────────────────
 
 function LoginPanel({ onLogin }: { onLogin: (u: string) => void }) {
+  // Remembering the session needs the OS credential store, which only the
+  // Windows backend has. Where it is missing the option is hidden rather than
+  // offered and quietly ignored.
+  const { persistentCredentials } = usePlatformCapabilities();
   const [email, setEmail]       = useState("");
   const [password, setPassword] = useState("");
   const [remember, setRemember] = useState(true);
@@ -121,7 +126,7 @@ function LoginPanel({ onLogin }: { onLogin: (u: string) => void }) {
     setLoading(true); setError("");
     try {
       const username = await invoke<string>("wfm_login", { email, password });
-      if (remember) {
+      if (remember && persistentCredentials) {
         const tokenJson = await invoke<string | null>("wfm_get_jwt").catch(() => null);
         if (tokenJson) invoke("wfm_save_credentials", { email, password: tokenJson }).catch(() => {});
       }
@@ -146,10 +151,12 @@ function LoginPanel({ onLogin }: { onLogin: (u: string) => void }) {
             onKeyDown={e => e.key === "Enter" && submit()} />
         </div>
         {error && <div className="wfm-error">{error}</div>}
-        <label className="wfm-remember-row">
-          <input type="checkbox" checked={remember} onChange={e => setRemember(e.target.checked)} />
-          Remember credentials
-        </label>
+        {persistentCredentials && (
+          <label className="wfm-remember-row">
+            <input type="checkbox" checked={remember} onChange={e => setRemember(e.target.checked)} />
+            Remember credentials
+          </label>
+        )}
         <button className="wfm-btn-primary" onClick={submit} disabled={loading || !email || !password}>
           {loading ? "Logging in…" : "Log in"}
         </button>

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+// ==============================================================================
+// Platform capabilities
+// ==============================================================================
+//
+// Screen capture, OCR, and OS-encrypted credential storage only exist in the
+// Windows backend. The UI asks the backend what it can do instead of hiding
+// features behind a user-agent guess, so a control is only offered when the
+// command behind it can actually succeed.
+//
+// The query runs once per app load and every consumer shares that answer; a
+// component tree this wide would otherwise thread the same three booleans
+// through unrelated props.
+
+export type PlatformCapabilities = {
+  linux: boolean;
+  ocr: boolean;
+  persistentCredentials: boolean;
+};
+
+// Windows has been the only supported platform, so its capabilities are the
+// optimistic default for the brief moment before the backend answers.
+const WINDOWS: PlatformCapabilities = { linux: false, ocr: true, persistentCredentials: true };
+
+let current = WINDOWS;
+const ready = invoke<PlatformCapabilities>("get_platform_capabilities")
+  .then(capabilities => (current = capabilities))
+  .catch(() => current);
+
+export function usePlatformCapabilities(): PlatformCapabilities {
+  const [capabilities, setCapabilities] = useState(current);
+  useEffect(() => {
+    ready.then(setCapabilities);
+  }, []);
+  return capabilities;
+}

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -5,8 +5,9 @@ import { invoke } from "@tauri-apps/api/core";
 // Platform capabilities
 // ==============================================================================
 //
-// Screen capture, OCR, and OS-encrypted credential storage only exist in the
-// Windows backend. The UI asks the backend what it can do instead of hiding
+// Not every backend implements every feature: OS-encrypted credential storage
+// is Windows-only, and screen capture and OCR exist on Windows and Linux but
+// nowhere else. The UI asks the backend what it can do instead of hiding
 // features behind a user-agent guess, so a control is only offered when the
 // command behind it can actually succeed.
 //


### PR DESCRIPTION
## What

Adds a `dorny/paths-filter@v4.0.2` job that detects which paths changed and gates the four CI jobs on their relevant file sets.

| Job | Runs when… |
|---|---|
| **rust** | `src-tauri/**`, the composite action, `scripts/fetch-tessdata.sh`, or `ci.yml` change |
| **frontend** | `src/**`, `package.json`, lockfile, tsconfig, vite config, `index.html`, or `ci.yml` change |
| **scripts** | `scripts/**` or `ci.yml` change |
| **version** | `package.json`, `Cargo.toml`, `tauri.conf.json`, `scripts/check-version.sh`, or `ci.yml` change |

## Edge cases

- **`workflow_dispatch`** — all jobs run unconditionally so manual re-runs always work.
- **ci.yml edits** — all filters include it, so a workflow change never silently drops a required check.
- **README-only PR** — the `changes` job still runs, but all four downstream jobs skip (green).