### PR TITLE
fix(blob): trim saved inventory dumps at the end of the JSON

### DIFF
--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -631,9 +631,14 @@ pub fn compute_riven_mod_name(buffs: &[BlobRivenStat]) -> String {
     format!("{}{}", hi_p.to_lowercase(), lo_s.to_lowercase())
 }
 
-/// `raw` must span from the JSON opening `{` (or from `"SubscribedToEmails"`) through
-/// `"DeathSquadable":`. Returns `None` if neither start can be located or JSON is malformed.
-pub fn parse_full_account_blob(raw: &[u8]) -> Option<BlobInventory> {
+/// Cut the JSON object out of a stitched memory buffer.
+///
+/// `raw` must span from the JSON opening `{` (or from `"SubscribedToEmails"`)
+/// through `"DeathSquadable":`. A scan buffer is whole memory regions glued
+/// together, so the blob's last brace is followed by however much of the final
+/// region came after it. That tail is unrelated heap bytes rather than blob
+/// data, and it can run to tens of megabytes.
+pub fn extract_blob_json(raw: &[u8]) -> Option<Vec<u8>> {
     let end_pos = find_blob_end(raw)?;
 
     // Real FULL_ACCOUNT blobs are several hundred KB — anything smaller is a
@@ -647,16 +652,20 @@ pub fn parse_full_account_blob(raw: &[u8]) -> Option<BlobInventory> {
     // capture_all_blobs seeds from the JSON opening { so raw already forms a complete
     // JSON object — use it directly. Fall back to the old SubscribedToEmails approach
     // for any caller that still passes data starting inside the object.
-    let json_bytes: Vec<u8> = if raw.first() == Some(&b'{') {
-        raw[..end_pos].to_vec()
+    if raw.first() == Some(&b'{') {
+        Some(raw[..end_pos].to_vec())
     } else {
         const START: &[u8] = b"\"SubscribedToEmails\"";
         let start_pos = raw.windows(START.len()).position(|w| w == START)?;
         let mut v = Vec::with_capacity(end_pos - start_pos + 1);
         v.push(b'{');
         v.extend_from_slice(&raw[start_pos..end_pos]);
-        v
-    };
+        Some(v)
+    }
+}
+
+pub fn parse_full_account_blob(raw: &[u8]) -> Option<BlobInventory> {
+    let json_bytes = extract_blob_json(raw)?;
 
     let json: serde_json::Value = serde_json::from_slice(&json_bytes)
         .map_err(|e| {
@@ -1142,10 +1151,9 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
                         if save {
                             let name = format!("Actual_inventory_FULL_ACCOUNT_{}_{:02}.txt", ts, saved + 1);
                             let path = blob_dir.join(&name);
-                            let text: Vec<u8> = scan.data.iter()
-                                .map(|&b| if b >= 0x20 && b <= 0x7e || b == b'\n' || b == b'\t' { b } else { b'.' })
-                                .collect();
-                            if std::fs::write(&path, &text).is_ok() { saved += 1; }
+                            let json = extract_blob_json(&scan.data)
+                                .expect("parsing succeeded, so the blob bounds are known");
+                            if std::fs::write(&path, &json).is_ok() { saved += 1; }
                         }
                         blob_tx.send(inv).ok();
                         found_result = true;
@@ -1236,7 +1244,9 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
                         LAST_BLOB_REGION.store(seed_addr as u64, std::sync::atomic::Ordering::Relaxed);
                         if save {
                             let name = format!("Actual_inventory_FULL_ACCOUNT_{}_{:02}.txt", ts, saved + 1);
-                            if std::fs::write(blob_dir.join(&name), &seed).is_ok() { saved += 1; }
+                            let json = extract_blob_json(&seed)
+                                .expect("parsing succeeded, so the blob bounds are known");
+                            if std::fs::write(blob_dir.join(&name), &json).is_ok() { saved += 1; }
                         }
                         blob_tx.send(inv).ok();
                         found_result = true;
@@ -1555,5 +1565,18 @@ mod seed_tests {
         let buf = b"x\"SubscribedToEmails\":1}";
         let (marker_off, json_open) = blob_seed_offsets(buf);
         assert_eq!(json_open, marker_off);
+    }
+
+    #[test]
+    fn blob_json_stops_at_the_closing_brace_of_the_object() {
+        // A stitched scan buffer: the blob, then the rest of the memory region
+        // it happened to end in.
+        let mut raw = br#"{"SubscribedToEmails":0,"DeathSquadable":false}"#.to_vec();
+        let blob_len = raw.len();
+        raw.extend(std::iter::repeat(0xABu8).take(1_000_000));
+
+        let json = find_blob_end(&raw).map(|end| raw[..end].to_vec()).expect("end marker present");
+        assert_eq!(json.len(), blob_len);
+        assert!(serde_json::from_slice::<serde_json::Value>(&json).is_ok());
     }
 }


### PR DESCRIPTION
Saved inventory dumps (`Actual_inventory_FULL_ACCOUNT_*.txt`) contain a large
tail of unrelated bytes and are far bigger than the blob itself.

A scan buffer is whole memory regions stitched together until the end marker
shows up, so everything after the blob's closing brace is whatever else happened
to sit in the tail of that last region. The save path wrote the entire buffer.
On my account a 1,314,900 byte blob was saved as a 6.6 MB file; a capture that
ended in a bigger region came out at 35 MB.

`parse_full_account_blob` already cut at the end marker, so the parsed inventory
was never affected. This moves that cut into `extract_blob_json` and has both
save sites use it, so the dumps are valid JSON.

Verification: I can only build the Linux fork of this codebase, and the touched
save sites are inside `#[cfg(target_os = "windows")]`, so I have not compiled
them. The identical change passes tests on the fork, and the added test covers
the trimming itself.
