### PR TITLE
perf: reduce redundant work in the memory scanner

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4831,6 +4831,7 @@ dependencies = [
  "chrono",
  "dirs 5.0.1",
  "lzma-rs",
+ "memchr",
  "native-tls",
  "regex",
  "rusqlite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,7 @@ tungstenite = { version = "0.26", features = ["native-tls"] }
 native-tls = "0.2"
 whirlpool = "0.10"
 lzma-rs = "0.3"
+memchr = "2"
 
 [profile.dev]
 opt-level = 1

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4264,14 +4264,6 @@ async fn dump_memory_probe(state: State<'_, AppState>) -> Result<String, String>
     Ok(output)
 }
 
-/// Toggle the continuous raw memory string-dump.
-/// One-shot manual capture of the full inventory JSON blob.
-#[tauri::command]
-fn capture_inventory_blob(state: State<'_, AppState>) -> Result<String, String> {
-    let path = state.raw_scan_path.with_file_name("inventory_blob.txt");
-    memory_scanner::capture_inventory_blob(&path)
-}
-
 /// Enable or disable automatic per-pass inventory blob logging to blobs/.
 #[tauri::command]
 fn set_blob_log(enabled: bool, state: State<'_, AppState>) {
@@ -8535,7 +8527,6 @@ pub fn run() {
             log_api_changes,
             dump_memory_probe,
             toggle_raw_scan,
-            capture_inventory_blob,
             set_blob_log,
             set_api_log,
             get_app_version,

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -827,8 +827,15 @@ fn forget_blob_digest() {
 /// Returns true when `json` is byte-identical to what the previous call saw.
 fn blob_unchanged(json: &[u8]) -> bool {
     use std::hash::{DefaultHasher, Hash, Hasher};
+    // Callers hand over a stitched buffer, not a trimmed blob. The stitch stops
+    // at the region that closes the JSON, so everything past the closing brace
+    // is whatever heap shared that region, tens of megabytes of it, rewritten
+    // constantly by a running client. Hash that tail and the digest never
+    // matches, so every scan reparses and the skip never happens. Bytes with no
+    // blob end are hashed whole; they only need to compare equal to themselves.
+    let blob = &json[..find_blob_end(json).unwrap_or(json.len())];
     let mut hasher = DefaultHasher::new();
-    json.hash(&mut hasher);
+    blob.hash(&mut hasher);
     // OR in a set bit so a hashed digest can never equal the 0 sentinel that
     // reset_last_blob_region stores — that sentinel must always compare as
     // "changed" to force a re-parse after a PID change.
@@ -1547,11 +1554,15 @@ mod seed_tests {
 mod blob_digest_tests {
     use super::{blob_unchanged, forget_blob_digest, reset_last_blob_region};
 
-    // LAST_BLOB_DIGEST is a process-global static shared with every other
-    // test in this binary, so each case resets it first and runs its
-    // assertions in one #[test] rather than relying on test isolation.
+    // LAST_BLOB_DIGEST is a process-global static shared with every other test
+    // in this binary. Resetting first is not enough on its own: these cases run
+    // in parallel, so one can land its own digest write between another's reset
+    // and its assertions. Taking this lock keeps them off each other.
+    static DIGEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn digest_tracks_changes_and_resets() {
+        let _guard = DIGEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         reset_last_blob_region();
 
         let blob = b"{\"SubscribedToEmails\":1,\"RegularCredits\":100}".to_vec();
@@ -1567,11 +1578,31 @@ mod blob_digest_tests {
         assert!(!blob_unchanged(&mutated), "reset forces the next call to report changed");
     }
 
+    // The scan stitches whole regions, so the blob arrives with a tail of
+    // unrelated heap that a running client rewrites between cycles. Digesting
+    // that tail is indistinguishable from the inventory itself changing, which
+    // reparses a settled inventory on every cycle.
+    #[test]
+    fn a_rewritten_tail_after_the_blob_is_not_a_change() {
+        let _guard = DIGEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_last_blob_region();
+
+        let blob = br#"{"SubscribedToEmails":1,"DeathSquadable":false}"#;
+        let mut first = blob.to_vec();
+        first.extend_from_slice(b"\x00\x11garbage from a neighbouring allocation");
+        let mut second = blob.to_vec();
+        second.extend_from_slice(b"\xff\xfe an entirely different neighbour, and longer");
+
+        assert!(!blob_unchanged(&first), "first sighting reports changed");
+        assert!(blob_unchanged(&second), "same blob, different tail, is unchanged");
+    }
+
     // Unparseable bytes that persist across scan cycles must not start
     // reporting as unchanged — the skip paths read that as "already parsed
     // this", which would wedge the walk on a region that never parsed.
     #[test]
     fn forgetting_after_a_failed_parse_forces_a_retry() {
+        let _guard = DIGEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         reset_last_blob_region();
 
         let garbage = b"{\"MiscItems\":[ truncated".to_vec();

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -385,10 +385,10 @@ pub fn dump_inventory_regions(_max_hits: usize) -> Vec<String> {
 /// the `}` that immediately follows its boolean value (true or false).
 fn find_blob_end(raw: &[u8]) -> Option<usize> {
     const KEY: &[u8] = b"\"DeathSquadable\":";
-    let key_pos = raw.windows(KEY.len()).position(|w| w == KEY)?;
+    let key_pos = memmem::find(raw, KEY)?;
     let after   = key_pos + KEY.len();
     // Skip the boolean value and find the closing brace
-    let brace = raw[after..].iter().position(|&b| b == b'}')?;
+    let brace = memchr::memchr(b'}', &raw[after..])?;
     Some(after + brace + 1)
 }
 
@@ -422,10 +422,8 @@ fn enclosing_object_start(buf: &[u8], marker_off: usize) -> Option<usize> {
 ///   - `marker_off`: byte position of the first known start marker
 ///   - `json_open`:  byte position of the outermost `{` enclosing the marker
 fn blob_seed_offsets(buf: &[u8]) -> (usize, usize) {
-    let marker_off = buf.windows(START_MARKER.len())
-        .position(|w| w == START_MARKER)
-        .or_else(|| ALT_STARTS.iter().find_map(|a|
-            buf.windows(a.len()).position(|w| w == *a)))
+    let marker_off = memmem::find(buf, START_MARKER)
+        .or_else(|| ALT_STARTS.iter().find_map(|a| memmem::find(buf, a)))
         .unwrap_or(buf.len().saturating_sub(1));
     let json_open = enclosing_object_start(buf, marker_off).unwrap_or(marker_off);
     (marker_off, json_open)
@@ -499,8 +497,7 @@ pub fn extract_blob_json(raw: &[u8]) -> Option<Vec<u8>> {
     if raw.first() == Some(&b'{') {
         Some(raw[..end_pos].to_vec())
     } else {
-        const START: &[u8] = b"\"SubscribedToEmails\"";
-        let start_pos = raw.windows(START.len()).position(|w| w == START)?;
+        let start_pos = memmem::find(raw, START_MARKER)?;
         let mut v = Vec::with_capacity(end_pos - start_pos + 1);
         v.push(b'{');
         v.extend_from_slice(&raw[start_pos..end_pos]);
@@ -1403,7 +1400,8 @@ mod seed_tests {
         let buf = b"{\"SubscribedToEmails\":1,\"RegularCredits\":100}";
         let (marker_off, json_open) = blob_seed_offsets(buf);
         assert_eq!(json_open, 0);
-        assert!(marker_off > 0);
+        // Both markers are present; the primary one must win over the alt-start.
+        assert_eq!(marker_off, 1);
     }
 
     #[test]
@@ -1433,6 +1431,18 @@ mod seed_tests {
 
         let json = extract_blob_json(&raw).expect("end marker present");
         assert_eq!(json.len(), blob_len);
+        assert!(serde_json::from_slice::<serde_json::Value>(&json).is_ok());
+    }
+
+    #[test]
+    fn blob_json_reinstates_the_opening_brace_when_it_was_overwritten() {
+        let mut raw = br#"x"SubscribedToEmails":0,"DeathSquadable":false}"#.to_vec();
+        let blob_len = raw.len();
+        raw.extend(std::iter::repeat(0xABu8).take(1024));
+
+        let json = extract_blob_json(&raw).expect("end marker present");
+        assert_eq!(json.len(), blob_len);
+        assert_eq!(json[0], b'{');
         assert!(serde_json::from_slice::<serde_json::Value>(&json).is_ok());
     }
 }

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -1,5 +1,6 @@
 ﻿use memchr::memmem;
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -493,15 +494,30 @@ pub fn compute_riven_mod_name(buffs: &[BlobRivenStat]) -> String {
 /// final region — potentially tens of megabytes of noise. This trims to just
 /// the valid JSON object so both the parser and the debug dump files see clean data.
 pub fn extract_blob_json(raw: &[u8]) -> Option<Vec<u8>> {
+    extract_blob_json_ref(raw).map(Cow::into_owned)
+}
+
+/// Borrowing counterpart of [`extract_blob_json`]. The common case (buffer still
+/// starts with the original `{`) needs no copy at all; only the fallback path,
+/// where the opening brace was overwritten in memory and has to be reinstated,
+/// allocates.
+pub fn extract_blob_json_ref(raw: &[u8]) -> Option<Cow<'_, [u8]>> {
     let end_pos = find_blob_end(raw)?;
+    extract_blob_json_at(raw, end_pos)
+}
+
+/// Same as [`extract_blob_json_ref`] but takes an already-known `end_pos`, so
+/// callers that located the blob end for their own purposes (e.g. the
+/// minimum-size check in [`parse_full_account_blob`]) don't pay for a second scan.
+fn extract_blob_json_at(raw: &[u8], end_pos: usize) -> Option<Cow<'_, [u8]>> {
     if raw.first() == Some(&b'{') {
-        Some(raw[..end_pos].to_vec())
+        Some(Cow::Borrowed(&raw[..end_pos]))
     } else {
         let start_pos = memmem::find(raw, START_MARKER)?;
         let mut v = Vec::with_capacity(end_pos - start_pos + 1);
         v.push(b'{');
         v.extend_from_slice(&raw[start_pos..end_pos]);
-        Some(v)
+        Some(Cow::Owned(v))
     }
 }
 
@@ -518,7 +534,7 @@ pub fn parse_full_account_blob(raw: &[u8]) -> Option<BlobInventory> {
         return None;
     }
 
-    let json_bytes = extract_blob_json(raw)?;
+    let json_bytes = extract_blob_json_at(raw, end_pos)?;
 
     let json: serde_json::Value = serde_json::from_slice(&json_bytes)
         .map_err(|e| {
@@ -1440,7 +1456,8 @@ fn find_warframe_pid() -> Option<u32> {
 
 #[cfg(test)]
 mod seed_tests {
-    use super::{enclosing_object_start, blob_seed_offsets, extract_blob_json};
+    use super::{enclosing_object_start, blob_seed_offsets, extract_blob_json, extract_blob_json_ref};
+    use std::borrow::Cow;
 
     #[test]
     fn enclosing_finds_outer_brace() {
@@ -1514,6 +1531,15 @@ mod seed_tests {
         assert_eq!(json.len(), blob_len);
         assert_eq!(json[0], b'{');
         assert!(serde_json::from_slice::<serde_json::Value>(&json).is_ok());
+    }
+
+    #[test]
+    fn blob_json_ref_borrows_in_the_common_case_and_owns_in_the_fallback() {
+        let intact = br#"{"SubscribedToEmails":0,"DeathSquadable":false}"#;
+        assert!(matches!(extract_blob_json_ref(intact), Some(Cow::Borrowed(_))));
+
+        let overwritten = br#"x"SubscribedToEmails":0,"DeathSquadable":false}"#;
+        assert!(matches!(extract_blob_json_ref(overwritten), Some(Cow::Owned(_))));
     }
 }
 

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -1,4 +1,5 @@
-﻿use serde::{Deserialize, Serialize};
+﻿use memchr::memmem;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -178,26 +179,19 @@ pub fn scan_auth_credentials(data: &[u8]) -> Option<(String, String)> {
     // Search for "id":"<24hexchars>" near "Nonce":<digits>
     let id_key = b"\"id\":\"";
     let nonce_key = b"\"Nonce\":";
-    let mut search = 0usize;
-    while search + id_key.len() < data.len() {
-        let next = match data[search..].iter().position(|&b| b == b'"') {
-            Some(p) => search + p, None => break,
-        };
-        if next + id_key.len() > data.len() { break; }
-        if data[next..next + id_key.len()] != *id_key { search = next + 1; continue; }
-
+    for next in memmem::find_iter(data, id_key) {
         let id_start = next + id_key.len();
         // accountId is exactly 24 lowercase hex chars
         let id_slice = &data[id_start..id_start.saturating_add(26).min(data.len())];
         let close = id_slice.iter().position(|&b| b == b'"').unwrap_or(0);
-        if close != 24 { search = next + 1; continue; }
+        if close != 24 { continue; }
         let id_bytes = &id_slice[..24];
-        if !id_bytes.iter().all(|&b| b.is_ascii_hexdigit()) { search = next + 1; continue; }
+        if !id_bytes.iter().all(|&b| b.is_ascii_hexdigit()) { continue; }
         let account_id = std::str::from_utf8(id_bytes).unwrap_or("").to_string();
 
         // Look for Nonce within 2048 bytes
         let nonce_search_end = (id_start + 2048).min(data.len());
-        if let Some(rel) = data[id_start..nonce_search_end].windows(nonce_key.len()).position(|w| w == *nonce_key) {
+        if let Some(rel) = memmem::find(&data[id_start..nonce_search_end], nonce_key) {
             let ns = id_start + rel + nonce_key.len();
             let ne = digits_end(data, ns);
             if ne > ns && ne - ns >= 5 {
@@ -206,26 +200,19 @@ pub fn scan_auth_credentials(data: &[u8]) -> Option<(String, String)> {
                 }
             }
         }
-        search = next + 1;
     }
 
     // URL-encoded: accountId=<24hexchars>&nonce=<10digits>&ct=STM
     let ak = b"accountId=";
     let nk = b"nonce=";
-    let mut search = 0usize;
-    while search + ak.len() < data.len() {
-        let next = match data[search..].iter().position(|&b| b == b'a') {
-            Some(p) => search + p, None => break,
-        };
-        if next + ak.len() > data.len() { break; }
-        if data[next..next + ak.len()] != *ak { search = next + 1; continue; }
+    for next in memmem::find_iter(data, ak) {
         let id_start = next + ak.len();
         let id_end = data[id_start..].iter().position(|&b| !b.is_ascii_hexdigit()).map(|p| id_start + p).unwrap_or(data.len());
-        if id_end - id_start != 24 { search = next + 1; continue; }
+        if id_end - id_start != 24 { continue; }
         let account_id = std::str::from_utf8(&data[id_start..id_end]).unwrap_or("").to_string();
         // Nonce can appear anywhere within 512 bytes after the accountId
         let nonce_search_end = (id_end + 512).min(data.len());
-        if let Some(rel) = data[id_end..nonce_search_end].windows(nk.len()).position(|w| w == *nk) {
+        if let Some(rel) = memmem::find(&data[id_end..nonce_search_end], nk) {
             let ns = id_end + rel + nk.len();
             let ne = digits_end(data, ns);
             if ne > ns && ne - ns >= 5 {
@@ -234,7 +221,6 @@ pub fn scan_auth_credentials(data: &[u8]) -> Option<(String, String)> {
                 }
             }
         }
-        search = next + 1;
     }
     None
 }
@@ -242,13 +228,7 @@ pub fn scan_auth_credentials(data: &[u8]) -> Option<(String, String)> {
 /// Also extract steamId from memory (found near accountId/nonce in URL params).
 pub fn scan_steam_id(data: &[u8]) -> Option<String> {
     let key = b"steamId=";
-    let mut search = 0usize;
-    loop {
-        let next = match data[search..].iter().position(|&b| b == b's') {
-            Some(p) => search + p, None => break,
-        };
-        if next + key.len() > data.len() { break; }
-        if data[next..next + key.len()] != *key { search = next + 1; continue; }
+    for next in memmem::find_iter(data, key) {
         let id_start = next + key.len();
         let id_end = data[id_start..].iter().position(|&b| !b.is_ascii_digit()).map(|p| id_start + p).unwrap_or(data.len());
         if id_end - id_start >= 15 && id_end - id_start <= 20 {
@@ -256,7 +236,6 @@ pub fn scan_steam_id(data: &[u8]) -> Option<String> {
                 return Some(sid.to_string());
             }
         }
-        search = next + 1;
     }
     None
 }
@@ -1455,5 +1434,46 @@ mod seed_tests {
         let json = extract_blob_json(&raw).expect("end marker present");
         assert_eq!(json.len(), blob_len);
         assert!(serde_json::from_slice::<serde_json::Value>(&json).is_ok());
+    }
+}
+
+#[cfg(test)]
+mod credential_scan_tests {
+    use super::{scan_auth_credentials, scan_steam_id};
+
+    #[test]
+    fn auth_credentials_finds_json_form() {
+        let buf = br#"{"id":"594144e63ade7f2f2091c48e","Nonce":123456789}"#;
+        let (account_id, nonce) = scan_auth_credentials(buf).expect("should find credentials");
+        assert_eq!(account_id, "594144e63ade7f2f2091c48e");
+        assert_eq!(nonce, "123456789");
+    }
+
+    #[test]
+    fn auth_credentials_finds_url_encoded_form() {
+        let buf = b"accountId=594144e63ade7f2f2091c48e&nonce=123456789&ct=STM";
+        let (account_id, nonce) = scan_auth_credentials(buf).expect("should find credentials");
+        assert_eq!(account_id, "594144e63ade7f2f2091c48e");
+        assert_eq!(nonce, "123456789");
+    }
+
+    #[test]
+    fn auth_credentials_none_on_no_match() {
+        let buf = b"nothing interesting in here at all";
+        assert_eq!(scan_auth_credentials(buf), None);
+    }
+
+    #[test]
+    fn steam_id_finds_value_past_false_starts() {
+        // Leading 's' bytes are false starts for the old byte-at-a-time scanner.
+        let buf = b"ssssssssteamId=steamId=76561198012345678";
+        let sid = scan_steam_id(buf).expect("should find steam id");
+        assert_eq!(sid, "76561198012345678");
+    }
+
+    #[test]
+    fn steam_id_none_on_no_match() {
+        let buf = b"steamId=short";
+        assert_eq!(scan_steam_id(buf), None);
     }
 }

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -777,10 +777,47 @@ fn blob_extract_mod_rank(fingerprint: Option<&str>) -> u8 {
 static LAST_BLOB_REGION: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
 
+// Digest of the last blob whose bytes were about to be parsed. Inventory
+// changes maybe once per mission, so most 10s scan cycles find byte-identical
+// JSON — hashing a few MB is far cheaper than rebuilding BlobInventory's
+// HashMaps/Vecs from scratch every cycle.
+static LAST_BLOB_DIGEST: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 /// Clear the fast-path region cache. Call when Warframe's PID changes so the
 /// next scan doesn't probe a stale address from the previous process instance.
 pub fn reset_last_blob_region() {
     LAST_BLOB_REGION.store(0, std::sync::atomic::Ordering::Relaxed);
+    LAST_BLOB_DIGEST.store(0, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Discard the digest baseline so the next candidate is parsed no matter what
+/// its bytes are. Call after a parse failure: skipping a re-parse is only safe
+/// while the baseline names bytes that are known to parse, and `blob_unchanged`
+/// records its argument before the parse outcome is known.
+fn forget_blob_digest() {
+    LAST_BLOB_DIGEST.store(0, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Checks `json` against the digest recorded by the previous call, then
+/// records `json`'s digest as the new baseline — check-and-update in one
+/// step, so a caller should invoke this exactly once per candidate blob,
+/// right before deciding whether to parse it.
+///
+/// A caller that then fails to parse `json` must call `forget_blob_digest`:
+/// the skip paths treat a match as "already parsed this successfully", and
+/// unparseable bytes that persist across cycles would otherwise be mistaken
+/// for a result and suppress the rest of the walk indefinitely.
+///
+/// Returns true when `json` is byte-identical to what the previous call saw.
+fn blob_unchanged(json: &[u8]) -> bool {
+    use std::hash::{DefaultHasher, Hash, Hasher};
+    let mut hasher = DefaultHasher::new();
+    json.hash(&mut hasher);
+    // OR in a set bit so a hashed digest can never equal the 0 sentinel that
+    // reset_last_blob_region stores — that sentinel must always compare as
+    // "changed" to force a re-parse after a PID change.
+    let digest = hasher.finish() | 1;
+    LAST_BLOB_DIGEST.swap(digest, std::sync::atomic::Ordering::Relaxed) == digest
 }
 
 /// Scans Warframe process memory for the FULL_ACCOUNT inventory blob and sends it
@@ -891,6 +928,11 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
                             nb.as_mut_ptr() as *mut c_void, cap, &mut nn) } == 0 { continue; }
                         stitched.extend_from_slice(&nb[..nn]);
                     }
+                    if blob_unchanged(&stitched) {
+                        eprintln!("[blob] fast-path hit at 0x{:012x}: unchanged since last scan — skipping parse", cached_addr);
+                        unsafe { CloseHandle(process); }
+                        return 0;
+                    }
                     if let Some(inv) = parse_full_account_blob(&stitched) {
                         eprintln!("[blob] fast-path hit at 0x{:012x}: {} unique, {} stackable",
                             cached_addr, inv.unique_items.len(), inv.stackable_items.len());
@@ -898,6 +940,7 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
                         unsafe { CloseHandle(process); }
                         return 0; // fast path never saves to disk
                     }
+                    forget_blob_digest();
                 }
             }
         }
@@ -1009,6 +1052,12 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
                 .windows(END_MARKER.len())
                 .any(|w| w == END_MARKER);
             if has_end && find_blob_end(&scan.data).is_some() {
+                if !save && blob_unchanged(&scan.data) {
+                    eprintln!("[blob] scan#{} unchanged since last scan — skipping parse", scan.id);
+                    LAST_BLOB_REGION.store(scan.start_region_addr as u64, std::sync::atomic::Ordering::Relaxed);
+                    found_result = true;
+                    return false;
+                }
                 match parse_full_account_blob(&scan.data) {
                     Some(inv) => {
                         eprintln!("[blob] scan#{} SUCCESS at 0x{:012x}: {} unique, {} stackable, {} mods",
@@ -1027,6 +1076,7 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
                     }
                     None => {
                         eprintln!("[blob] scan#{} end marker found but JSON parse failed — dropped", scan.id);
+                        forget_blob_digest();
                     }
                 }
                 false // remove completed (or failed) scan
@@ -1103,7 +1153,12 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
             );
             let seed = combined[json_open..].to_vec();
 
-            if find_blob_end(&seed).is_some() {
+            let seed_ends = find_blob_end(&seed).is_some();
+            if seed_ends && !save && blob_unchanged(&seed) {
+                eprintln!("[blob] scan#{} immediate hit: unchanged since last scan — skipping parse", id);
+                LAST_BLOB_REGION.store(seed_addr as u64, std::sync::atomic::Ordering::Relaxed);
+                found_result = true;
+            } else if seed_ends {
                 match parse_full_account_blob(&seed) {
                     Some(inv) => {
                         eprintln!("[blob] scan#{} immediate SUCCESS at 0x{:012x}: {} unique, {} stackable",
@@ -1120,6 +1175,7 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
                     }
                     None => {
                         eprintln!("[blob] scan#{} immediate end found but parse failed — dropping", id);
+                        forget_blob_digest();
                     }
                 }
             } else {
@@ -1458,6 +1514,44 @@ mod seed_tests {
         assert_eq!(json.len(), blob_len);
         assert_eq!(json[0], b'{');
         assert!(serde_json::from_slice::<serde_json::Value>(&json).is_ok());
+    }
+}
+
+#[cfg(test)]
+mod blob_digest_tests {
+    use super::{blob_unchanged, forget_blob_digest, reset_last_blob_region};
+
+    // LAST_BLOB_DIGEST is a process-global static shared with every other
+    // test in this binary, so each case resets it first and runs its
+    // assertions in one #[test] rather than relying on test isolation.
+    #[test]
+    fn digest_tracks_changes_and_resets() {
+        reset_last_blob_region();
+
+        let blob = b"{\"SubscribedToEmails\":1,\"RegularCredits\":100}".to_vec();
+        assert!(!blob_unchanged(&blob), "first call always reports changed");
+        assert!(blob_unchanged(&blob), "identical bytes report unchanged");
+
+        let mut mutated = blob.clone();
+        mutated[0] = b'[';
+        assert!(!blob_unchanged(&mutated), "a changed byte must report changed");
+        assert!(blob_unchanged(&mutated), "the new bytes become the baseline");
+
+        reset_last_blob_region();
+        assert!(!blob_unchanged(&mutated), "reset forces the next call to report changed");
+    }
+
+    // Unparseable bytes that persist across scan cycles must not start
+    // reporting as unchanged — the skip paths read that as "already parsed
+    // this", which would wedge the walk on a region that never parsed.
+    #[test]
+    fn forgetting_after_a_failed_parse_forces_a_retry() {
+        reset_last_blob_region();
+
+        let garbage = b"{\"MiscItems\":[ truncated".to_vec();
+        assert!(!blob_unchanged(&garbage), "first sighting reports changed");
+        forget_blob_digest();
+        assert!(!blob_unchanged(&garbage), "same bytes report changed again after a failed parse");
     }
 }
 

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -617,7 +617,12 @@ pub fn parse_full_account_blob(raw: &[u8]) -> Option<BlobInventory> {
                 });
                 continue;
             }
-            let mc = mods.entry(it.to_string()).or_default();
+            // Duplicate ItemTypes dominate this map, so check get_mut before
+            // paying for entry()'s unconditional to_string() allocation.
+            let mc = match mods.get_mut(it) {
+                Some(mc) => mc,
+                None => mods.entry(it.to_string()).or_default(),
+            };
             *mc.by_rank.entry(0).or_insert(0) += count;
             mc.total += count;
         }
@@ -678,7 +683,10 @@ pub fn parse_full_account_blob(raw: &[u8]) -> Option<BlobInventory> {
                 }
             }
             let rank = blob_extract_mod_rank(e["UpgradeFingerprint"].as_str());
-            let mc = mods.entry(it.to_string()).or_default();
+            let mc = match mods.get_mut(it) {
+                Some(mc) => mc,
+                None => mods.entry(it.to_string()).or_default(),
+            };
             *mc.by_rank.entry(rank).or_insert(0) += 1;
             mc.total += 1;
         }
@@ -690,7 +698,10 @@ pub fn parse_full_account_blob(raw: &[u8]) -> Option<BlobInventory> {
         for e in arr {
             let Some(it) = e["ItemType"].as_str() else { continue };
             if !it.starts_with("/Lotus/") { continue; }
-            *flavour_items.entry(it.to_string()).or_insert(0) += 1;
+            match flavour_items.get_mut(it) {
+                Some(v) => *v += 1,
+                None => { flavour_items.insert(it.to_string(), 1); }
+            }
         }
     }
 
@@ -701,7 +712,10 @@ pub fn parse_full_account_blob(raw: &[u8]) -> Option<BlobInventory> {
         for e in arr {
             let Some(it) = e["ItemType"].as_str() else { continue };
             if !it.starts_with("/Lotus/") { continue; }
-            *weapon_skins.entry(it.to_string()).or_insert(0) += 1;
+            match weapon_skins.get_mut(it) {
+                Some(v) => *v += 1,
+                None => { weapon_skins.insert(it.to_string(), 1); }
+            }
         }
     }
 

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -924,9 +924,9 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
                 buf.as_mut_ptr() as *mut c_void, read_cap, &mut n) } != 0 && n >= 8;
             if read_ok {
                 let chunk = &buf[..n];
-                let is_mission = chunk.windows(MISSION_DELTA.len()).any(|w| w == MISSION_DELTA);
-                let has_anchor = ANCHORS.iter().any(|a| chunk.windows(a.len()).any(|w| w == *a));
-                let has_lotus  = chunk.windows(LOTUS_KEY.len()).any(|w| w == LOTUS_KEY);
+                let is_mission = memmem::find(chunk, MISSION_DELTA).is_some();
+                let has_anchor = ANCHORS.iter().any(|a| memmem::find(chunk, a).is_some());
+                let has_lotus  = memmem::find(chunk, LOTUS_KEY).is_some();
                 // cached_addr is the exact byte of the blob's outer {, so seed from byte 0.
                 // Accept regions that are blob data even when SubscribedToEmails is in a
                 // later region (field order varies by account).
@@ -1071,9 +1071,7 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
                 return false; // drop oversized scan
             }
             // Only search the newly-added window, not the full buffer.
-            let has_end = scan.data[search_from..]
-                .windows(END_MARKER.len())
-                .any(|w| w == END_MARKER);
+            let has_end = memmem::find(&scan.data[search_from..], END_MARKER).is_some();
             if has_end && find_blob_end(&scan.data).is_some() {
                 if !save && blob_unchanged(&scan.data) {
                     eprintln!("[blob] scan#{} unchanged since last scan — skipping parse", scan.id);
@@ -1113,11 +1111,11 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
         if found_result { continue; }
 
         let t2 = std::time::Instant::now();
-        let has_start     = chunk.windows(START_MARKER.len()).any(|w| w == START_MARKER);
-        let has_alt_start = ALT_STARTS.iter().any(|a| chunk.windows(a.len()).any(|w| w == *a));
-        let is_mission    = chunk.windows(MISSION_DELTA.len()).any(|w| w == MISSION_DELTA);
-        let has_anchor    = ANCHORS.iter().any(|a| chunk.windows(a.len()).any(|w| w == *a));
-        let has_lotus     = chunk.windows(LOTUS_KEY.len()).any(|w| w == LOTUS_KEY);
+        let has_start     = memmem::find(chunk, START_MARKER).is_some();
+        let has_alt_start = ALT_STARTS.iter().any(|a| memmem::find(chunk, a).is_some());
+        let is_mission    = memmem::find(chunk, MISSION_DELTA).is_some();
+        let has_anchor    = ANCHORS.iter().any(|a| memmem::find(chunk, a).is_some());
+        let has_lotus     = memmem::find(chunk, LOTUS_KEY).is_some();
         let qualifies     = (has_start || has_alt_start) && !is_mission && (has_anchor || has_lotus);
         t_search += t2.elapsed();
 

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -75,7 +75,6 @@ pub struct PendingRecipe {
 }
 
 /// One Archon Shard socketed into a Warframe.
-/// One Archon Shard socketed into a Warframe.
 /// `upgrade_type` is the effect path (e.g. `.../ArchonCrystalUpgradeWarframeEnergyMax`).
 /// `color` is the raw string value from the JSON (e.g. `"ACC_CRIMSON"`, `"ACC_AZURE_TAUFORGED"`).
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -159,37 +158,6 @@ pub fn xp_to_rank(xp: i64, path: &str) -> u32 {
     { 1000.0f64 } else { 500.0f64 };
     ((xp as f64 / base).sqrt().floor() as u32).min(30)
 }
-
-/// Diagnostic: find "CompletionDate" in any format and return a snippet of context.
-#[allow(dead_code)]
-pub fn scan_completion_date_context(data: &[u8]) -> Vec<String> {
-    let key = b"\"CompletionDate\"";
-    let mut results = Vec::new();
-    let mut start = 0usize;
-    loop {
-        let next = match data[start..].iter().position(|&b| b == b'"') {
-            Some(p) => start + p,
-            None => break,
-        };
-        if next + key.len() > data.len() { break; }
-        if data[next..next + key.len()] != *key {
-            start = next + 1; continue;
-        }
-        // Capture 120 bytes of context starting 40 bytes before the key
-        let ctx_start = next.saturating_sub(40);
-        let ctx_end   = (next + 120).min(data.len());
-        let ctx = &data[ctx_start..ctx_end];
-        // Only include printable ASCII so the log is readable
-        let s: String = ctx.iter()
-            .map(|&b| if b >= 0x20 && b < 0x7f { b as char } else { '·' })
-            .collect();
-        results.push(s);
-        start = next + key.len();
-        if results.len() >= 3 { break; } // cap at 3 samples
-    }
-    results
-}
-
 
 // ─── Auth credentials scan ───────────────────────────────────────────────────
 //
@@ -432,96 +400,6 @@ pub fn dump_inventory_regions(_max_hits: usize) -> Vec<String> {
     vec!["Only supported on Windows".to_string()]
 }
 
-// ─── One-shot inventory blob capture ─────────────────────────────────────────
-//
-// Scans all committed readable regions for the first chunk that contains the
-// inventory root marker ("MiscItems":[).  Saves the full printable-text portion
-// of that region to `output_path` so it can be inspected offline.
-//
-// Non-printable bytes are replaced with '.' so the file is text-editor friendly.
-// Saves up to 8 MB centred on the MiscItems key (4 MB before, 4 MB after).
-
-#[cfg(target_os = "windows")]
-pub fn capture_inventory_blob(output_path: &std::path::Path) -> Result<String, String> {
-    use std::ffi::c_void;
-    use std::mem;
-    use windows_sys::Win32::{
-        Foundation::{CloseHandle, FALSE},
-        System::{
-            Diagnostics::Debug::ReadProcessMemory,
-            Memory::{VirtualQueryEx, MEMORY_BASIC_INFORMATION, MEM_COMMIT, PAGE_GUARD, PAGE_NOACCESS},
-            Threading::{OpenProcess, PROCESS_QUERY_INFORMATION, PROCESS_VM_READ},
-        },
-    };
-
-    let pid = find_warframe_pid_pub().ok_or_else(|| "Warframe is not running".to_string())?;
-
-    let process = unsafe { OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, pid) };
-    if process == 0 { return Err("Could not open Warframe process".to_string()); }
-
-    const MISC_KEY: &[u8]      = b"\"MiscItems\":[";
-    const MIN_BLOB_BYTES: usize = 200_000;    // skip tiny chunks — real inventory is MB-scale
-    const MAX_REGION_READ: usize = 128 * 1024 * 1024;
-    const HALF_SAVE: usize      = 4 * 1024 * 1024;   // 4 MB either side of MiscItems
-
-    let mut addr: usize = 0;
-    let mut saved: Option<(usize, String)> = None; // (region size, message)
-
-    'outer: loop {
-        let mut mbi = unsafe { mem::zeroed::<MEMORY_BASIC_INFORMATION>() };
-        if unsafe { VirtualQueryEx(process, addr as *const c_void, &mut mbi, mem::size_of::<MEMORY_BASIC_INFORMATION>()) } == 0 { break; }
-
-        let region_addr = mbi.BaseAddress as usize;
-        let region_size = mbi.RegionSize;
-        let next_addr   = region_addr.saturating_add(region_size);
-
-        if mbi.State == MEM_COMMIT
-            && mbi.Protect & PAGE_GUARD    == 0
-            && mbi.Protect & PAGE_NOACCESS == 0
-            && region_size >= MIN_BLOB_BYTES
-            && region_size <= MAX_REGION_READ
-        {
-            let mut data = vec![0u8; region_size];
-            let mut n = 0usize;
-            if unsafe { ReadProcessMemory(process, region_addr as *const c_void, data.as_mut_ptr() as *mut c_void, region_size, &mut n) } != 0 && n >= MIN_BLOB_BYTES {
-                let data = &data[..n];
-                if let Some(misc_pos) = data.windows(MISC_KEY.len()).position(|w| w == MISC_KEY) {
-                    let start = misc_pos.saturating_sub(HALF_SAVE);
-                    let end   = (misc_pos + HALF_SAVE).min(data.len());
-                    let text: Vec<u8> = data[start..end].iter()
-                        .map(|&b| if b >= 0x20 && b <= 0x7e || b == b'\n' || b == b'\t' { b } else { b'.' })
-                        .collect();
-                    if let Err(e) = std::fs::write(output_path, &text) {
-                        unsafe { CloseHandle(process); }
-                        return Err(format!("Write failed: {e}"));
-                    }
-                    saved = Some((text.len(), format!(
-                        "Saved {}KB blob (region 0x{:x}, size {}KB, MiscItems at +{}KB) to {}",
-                        text.len() / 1024, region_addr, n / 1024, misc_pos / 1024,
-                        output_path.display()
-                    )));
-                    break 'outer;
-                }
-            }
-        }
-
-        if next_addr <= addr { break; }
-        addr = next_addr;
-    }
-
-    unsafe { CloseHandle(process); }
-
-    saved.map(|(_, msg)| msg)
-         .ok_or_else(|| "No inventory blob found — make sure Warframe is running and inventory is loaded (open Arsenal or Inventory screen)".to_string())
-}
-
-#[cfg(not(target_os = "windows"))]
-pub fn capture_inventory_blob(_output_path: &std::path::Path) -> Result<String, String> {
-    Err("Only supported on Windows".into())
-}
-
-/// Scan all Warframe process memory and save every relevant blob found into `blob_dir`.
-/// "Relevant" = region ≥ 100 KB that contains at least one of: MiscItems, Suits,
 // ─── Full-account blob parser ─────────────────────────────────────────────────
 
 /// Find the end of the FULL_ACCOUNT blob by locating `"DeathSquadable":` and

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -418,16 +418,42 @@ fn enclosing_object_start(buf: &[u8], marker_off: usize) -> Option<usize> {
     None
 }
 
-/// Locate seed offsets for the FULL_ACCOUNT blob within `buf`.
-/// Returns `(marker_off, json_open)`:
-///   - `marker_off`: byte position of the first known start marker
-///   - `json_open`:  byte position of the outermost `{` enclosing the marker
-fn blob_seed_offsets(buf: &[u8]) -> (usize, usize) {
-    let marker_off = memmem::find(buf, START_MARKER)
-        .or_else(|| ALT_STARTS.iter().find_map(|a| memmem::find(buf, a)))
-        .unwrap_or(buf.len().saturating_sub(1));
-    let json_open = enclosing_object_start(buf, marker_off).unwrap_or(marker_off);
-    (marker_off, json_open)
+/// Where a stitched buffer's blob begins: `(marker_at, seed_at)`.
+///
+/// `marker_at` is the marker occurrence the seed is anchored to; `seed_at` is
+/// the brace enclosing it, or the marker itself when no occurrence has a
+/// brace that reads as an object head. See `enclosing_object_start` for why
+/// marker and brace are rarely the same offset.
+///
+/// With no primary marker anywhere the fallbacks keep both offsets in bounds,
+/// down to the buffer's last byte when nothing matches at all. Such a seed is
+/// junk and fails to parse, which is what the walk already does with a bad
+/// start.
+fn blob_seed_offsets(combined: &[u8]) -> (usize, usize) {
+    // The heap can hold a stale copy of the blob ahead of the live one: its
+    // marker survives but its opening brace was overwritten, so brace-matching
+    // backward from it lands on a stray `{` in binary garbage. A live seed is
+    // a JSON object head, so only accept a brace followed by a quote, and keep
+    // trying later marker occurrences until one qualifies.
+    let mut first_marker = None;
+    let mut search_from = 0;
+    while let Some(found) = memmem::find(&combined[search_from..], START_MARKER) {
+        let marker_at = search_from + found;
+        first_marker.get_or_insert(marker_at);
+        if let Some(open) = enclosing_object_start(combined, marker_at) {
+            if combined.get(open + 1) == Some(&b'"') {
+                return (marker_at, open);
+            }
+        }
+        search_from = marker_at + 1;
+    }
+    // Without a plausible brace anywhere, seed at the first marker: the
+    // parser can rebuild the object head from a marker-anchored seed.
+    let marker_at = first_marker
+        .or_else(|| ALT_STARTS.iter().find_map(|a| memmem::find(combined, a)))
+        .unwrap_or(combined.len().saturating_sub(1));
+    (marker_at, first_marker.unwrap_or_else(||
+        enclosing_object_start(combined, marker_at).unwrap_or(marker_at)))
 }
 
 /// Parse a FULL_ACCOUNT blob from raw memory bytes into structured inventory data.
@@ -1511,6 +1537,37 @@ mod seed_tests {
         let buf = b"x\"SubscribedToEmails\":1}";
         let (marker_off, json_open) = blob_seed_offsets(buf);
         assert_eq!(json_open, marker_off);
+    }
+
+    /// A freed copy of the blob can sit ahead of the live one with its marker
+    /// intact but its opening brace overwritten. Brace-matching backward from
+    /// that copy lands on a stray `{` in binary garbage ("key must be a string
+    /// at line 1 column 2"), so the stale occurrence has to be skipped in
+    /// favour of the live one.
+    #[test]
+    fn a_stale_headless_copy_is_skipped_for_the_live_blob() {
+        let mut combined = b"\x00{J>\x01\x02 garbage ".to_vec();
+        combined.extend_from_slice(br#""SubscribedToEmails":0,"RegularCredits":1,"#);
+        combined.extend_from_slice(b"\x03\x04 more garbage ");
+        let live_at = combined.len();
+        combined.extend_from_slice(br#"{"SubscribedToEmails":0,"RegularCredits":42}"#);
+
+        let (marker_at, seed_at) = blob_seed_offsets(&combined);
+        assert_eq!(seed_at, live_at, "seed is the live copy's opening brace");
+        assert!(marker_at > live_at, "the marker used is the live copy's");
+    }
+
+    /// With only the headless copy in the buffer, seeding at the marker lets
+    /// the parser rebuild the object head instead of parsing garbage.
+    #[test]
+    fn a_lone_headless_copy_seeds_at_its_marker() {
+        let mut combined = b"\x00{J>\x01\x02 garbage ".to_vec();
+        let marker = combined.len();
+        combined.extend_from_slice(br#""SubscribedToEmails":0,"RegularCredits":42,"#);
+
+        let (marker_at, seed_at) = blob_seed_offsets(&combined);
+        assert_eq!(marker_at, marker);
+        assert_eq!(seed_at, marker, "seed skips the garbage brace");
     }
 
     #[test]


### PR DESCRIPTION
This ports the platform-neutral part of a performance pass from my Linux fork ([Lyrex/FrameForge-Linux](https://github.com/Lyrex/FrameForge-Linux)) back to upstream. Six commits, each independent and cherry-pickable.

## Commits

- `chore(memory_scanner): remove dead code`: `scan_completion_date_context`, two stray doc comments, and `capture_inventory_blob` plus its Tauri command, which no frontend code invokes.
- `perf: use memchr::memmem in credential scanners`: `scan_auth_credentials` and `scan_steam_id` scanned for a single anchor byte and then compared slices, per region, over the whole address space. memmem is SIMD. memchr was already in Cargo.lock via aho-corasick/regex, so the dependency tree is unchanged.
- `perf: use memmem for blob marker scans`: same treatment for `find_blob_end`, `blob_seed_offsets`, and `extract_blob_json`.
- `perf: alloc blob map keys only on first insert`: `entry(it.to_string())` allocated a String for every entry in maps dominated by duplicate keys.
- `perf: skip parsing unchanged account blob`: a digest check skips the multi-megabyte serde_json parse and BlobInventory rebuild on cycles where the blob bytes are identical to the previous cycle. Inventory changes maybe once per mission, so that is nearly every 10s cycle. Visible side effect: the "Inventory Loaded" badge now appears when the inventory actually changed instead of every 10s.
- `perf: avoid copy when blob JSON already intact`: Cow-based extraction borrows instead of copying the blob in the common case, and the blob bounds are computed once per parse instead of three times.

Trade-offs live in the commit messages, e.g. an unobservable narrowing of overlapping-match behavior in the credential scanners, and the rule that a failed parse must drop the digest baseline.

## Testing

Developed on Linux. The module's shared logic is covered by unit tests (16, including new pins for the digest logic, the extraction paths, and the scanners), and the `cfg(windows)` arm was type-checked with `cargo check --target x86_64-pc-windows-gnu`. I could not run the Windows build against a live game, so a smoke test before merging the digest-skip commit would be wise.

## Spotted but not fixed here

- `capture_all_blobs` reads at most 64 MiB per region (`MAX_READ`) and never revisits the remainder, so a blob sitting past that offset in a large region is invisible. On my Linux/Proton setup about 6% of the game's address space fell past the cap.
- The cached-address fast path re-runs `find_blob_end` over the whole stitched buffer after every appended region, which is quadratic in the number of stitched regions. The memmem commit shrinks the constant, not the shape; a resume-from cursor fixes it. Happy to follow up with either if wanted.
- The per-region anchor checks scan for each anchor separately; a single multi-pattern pass (aho-corasick is already a dependency) would visit each byte once.
