### PR TITLE
fix(settings): stop settings.json wipes from racing writers

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,10 +6,12 @@ use std::sync::{Arc, Mutex};
 
 /// Write `data` to `path` atomically: write to a `.tmp` sibling, then rename over the target.
 /// Prevents zero-byte corruption if the process or OS crashes mid-write.
-fn atomic_write(path: &PathBuf, data: &[u8]) -> std::io::Result<()> {
+fn atomic_write(path: &std::path::Path, data: &[u8]) -> std::io::Result<()> {
     let tmp = path.with_extension("tmp");
     std::fs::write(&tmp, data)?;
-    std::fs::rename(&tmp, path)
+    std::fs::rename(&tmp, path).inspect_err(|_| {
+        let _ = std::fs::remove_file(&tmp);
+    })
 }
 fn truncate_chars(s: &str, n: usize) -> String {
     s.chars().take(n).collect()
@@ -4210,20 +4212,41 @@ fn load_settings(state: State<AppState>) -> String {
     std::fs::read_to_string(&state.settings_path).unwrap_or_default()
 }
 
+// settings.json is written from several threads (the save_settings command,
+// window-event handlers on every move/resize). Every writer must go through
+// merge_settings; an unserialized or non-atomic write used to tear the file
+// and wipe all settings on the next merge.
+static SETTINGS_WRITE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn read_settings_map(path: &std::path::Path) -> Result<serde_json::Map<String, serde_json::Value>, String> {
+    let raw = std::fs::read_to_string(path).unwrap_or_default();
+    if raw.trim().is_empty() {
+        return Ok(serde_json::Map::new());
+    }
+    match serde_json::from_str::<serde_json::Value>(&raw) {
+        Ok(serde_json::Value::Object(m)) => Ok(m),
+        _ => Err(format!("{} exists but is not a valid JSON object; refusing to overwrite it", path.display())),
+    }
+}
+
+fn merge_settings(path: &std::path::Path, apply: impl FnOnce(&mut serde_json::Map<String, serde_json::Value>)) -> Result<(), String> {
+    // Poison recovery is safe: the lock guards the file, not the map, and a
+    // panicking closure bails before the write, leaving the file untouched.
+    let _guard = SETTINGS_WRITE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let mut map = read_settings_map(path)?;
+    apply(&mut map);
+    atomic_write(path, serde_json::Value::Object(map).to_string().as_bytes()).map_err(|e| e.to_string())
+}
+
 #[tauri::command]
 fn save_settings(app: tauri::AppHandle, state: State<AppState>, json: String) -> Result<(), String> {
     // Merge over existing file so geometry fields written by save_window_state are never erased
     let new_vals: serde_json::Value = serde_json::from_str(&json).map_err(|e| e.to_string())?;
-    let mut existing: serde_json::Map<String, serde_json::Value> = std::fs::read_to_string(&state.settings_path)
-        .ok()
-        .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
-        .and_then(|v| if let serde_json::Value::Object(m) = v { Some(m) } else { None })
-        .unwrap_or_default();
-    if let serde_json::Value::Object(new_map) = new_vals {
-        for (k, v) in new_map { existing.insert(k, v); }
-    }
-    std::fs::write(&state.settings_path, serde_json::Value::Object(existing).to_string())
-        .map_err(|e| e.to_string())?;
+    merge_settings(&state.settings_path, |existing| {
+        if let serde_json::Value::Object(new_map) = new_vals {
+            for (k, v) in new_map { existing.insert(k, v); }
+        }
+    })?;
     app.emit("settings-updated", ()).ok();
     Ok(())
 }
@@ -8181,43 +8204,33 @@ fn save_window_state(window: &tauri::WebviewWindow, settings_path: &std::path::P
     let pos  = window.outer_position().ok();
     let size = window.outer_size().ok();
 
-    let mut map: serde_json::Map<String, serde_json::Value> = std::fs::read_to_string(settings_path)
-        .ok()
-        .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
-        .and_then(|v| if let serde_json::Value::Object(m) = v { Some(m) } else { None })
-        .unwrap_or_default();
-
-    map.insert(format!("{}Maximized", prefix), maximized.into());
-    // Only overwrite position/size when not maximised/minimised.
-    // Also guard against the Windows minimized sentinel (-32000,-32000) and dummy size (160×28)
-    // which can slip through when is_minimized() is unreliable at CloseRequested time.
-    if !maximized && !minimized {
-        if let Some(p) = pos {
-            if p.x > -10_000 && p.y > -10_000 {
-                map.insert(format!("{}X", prefix), p.x.into());
-                map.insert(format!("{}Y", prefix), p.y.into());
+    let result = merge_settings(settings_path, |map| {
+        map.insert(format!("{}Maximized", prefix), maximized.into());
+        // Only overwrite position/size when not maximised/minimised.
+        // Also guard against the Windows minimized sentinel (-32000,-32000) and dummy size (160×28)
+        // which can slip through when is_minimized() is unreliable at CloseRequested time.
+        if !maximized && !minimized {
+            if let Some(p) = pos {
+                if p.x > -10_000 && p.y > -10_000 {
+                    map.insert(format!("{}X", prefix), p.x.into());
+                    map.insert(format!("{}Y", prefix), p.y.into());
+                }
+            }
+            if let Some(s) = size {
+                if s.width >= 100 && s.height >= 50 {
+                    map.insert(format!("{}Width",  prefix), (s.width  as i64).into());
+                    map.insert(format!("{}Height", prefix), (s.height as i64).into());
+                }
             }
         }
-        if let Some(s) = size {
-            if s.width >= 100 && s.height >= 50 {
-                map.insert(format!("{}Width",  prefix), (s.width  as i64).into());
-                map.insert(format!("{}Height", prefix), (s.height as i64).into());
-            }
-        }
+    });
+    if let Err(e) = result {
+        eprintln!("warning: not saving window state: {e}");
     }
-
-    let _ = std::fs::write(settings_path, serde_json::Value::Object(map).to_string());
 }
 
 fn restore_window_state(app: &tauri::AppHandle, window: &tauri::WebviewWindow, settings_path: &std::path::Path, prefix: &str, min_w: u32, min_h: u32) {
-    let json = match std::fs::read_to_string(settings_path) {
-        Ok(s) => s,
-        Err(_) => return,
-    };
-    let map = match serde_json::from_str::<serde_json::Value>(&json) {
-        Ok(serde_json::Value::Object(m)) => m,
-        _ => return,
-    };
+    let Ok(map) = read_settings_map(settings_path) else { return };
 
     let maximized = map.get(&format!("{}Maximized", prefix)).and_then(|v| v.as_bool()).unwrap_or(false);
     if maximized {
@@ -8670,6 +8683,96 @@ pub fn run() {
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod settings_merge_tests {
+    use super::{merge_settings, read_settings_map};
+    use std::path::PathBuf;
+
+    /// Each test gets its own file so they can run in parallel.
+    fn scratch(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join("frameforge-settings-tests");
+        std::fs::create_dir_all(&dir).expect("temp dir is always writable");
+        let path = dir.join(format!("{name}.json"));
+        let _ = std::fs::remove_file(&path);
+        path
+    }
+
+    /// A truncated settings.json (crash or app kill mid-write, e.g. during an
+    /// update) used to parse as "no settings", and the next merge rewrote the
+    /// file from an empty map, wiping tracked and favorites. A file that
+    /// exists but does not parse must be left exactly as it is.
+    #[test]
+    fn a_corrupt_settings_file_is_never_replaced() {
+        let path = scratch("corrupt");
+        let truncated = r#"{"tracked":["/Lotus/Weapons/Boar"],"favorites":["/Lo"#;
+        std::fs::write(&path, truncated).expect("scratch file is writable");
+
+        let result = merge_settings(&path, |map| {
+            map.insert("windowX".into(), 10.into());
+        });
+
+        assert!(result.is_err(), "merging over an unparseable file must refuse, not wipe");
+        let after = std::fs::read_to_string(&path).expect("file still exists");
+        assert_eq!(after, truncated, "the corrupt file must be preserved for recovery");
+    }
+
+    /// A missing or empty file is an ordinary first launch, not corruption.
+    #[test]
+    fn a_missing_or_empty_file_is_a_fresh_start() {
+        let path = scratch("fresh");
+        assert!(read_settings_map(&path).expect("missing file is fine").is_empty());
+        std::fs::write(&path, "").expect("scratch file is writable");
+        assert!(read_settings_map(&path).expect("empty file is fine").is_empty());
+        merge_settings(&path, |map| {
+            map.insert("tracked".into(), serde_json::json!(["a"]));
+        })
+        .expect("merging into a fresh file succeeds");
+    }
+
+    #[test]
+    fn merging_preserves_unrelated_keys() {
+        let path = scratch("preserve");
+        std::fs::write(&path, r#"{"tracked":["a"],"favorites":["b"]}"#).expect("scratch file is writable");
+        merge_settings(&path, |map| {
+            map.insert("windowX".into(), 42.into());
+        })
+        .expect("merge succeeds");
+        let map = read_settings_map(&path).expect("file parses");
+        assert_eq!(map["tracked"], serde_json::json!(["a"]));
+        assert_eq!(map["favorites"], serde_json::json!(["b"]));
+        assert_eq!(map["windowX"], serde_json::json!(42));
+    }
+
+    /// save_window_state fires on every window move while save_settings runs on
+    /// the command thread. Unserialized, one writer read the file mid-truncate
+    /// of the other and resurrected a stale or empty map.
+    #[test]
+    fn concurrent_merges_do_not_lose_keys() {
+        let path = scratch("concurrent");
+        std::fs::write(&path, r#"{"tracked":["a"]}"#).expect("scratch file is writable");
+        std::thread::scope(|s| {
+            for t in 0..8 {
+                let path = &path;
+                s.spawn(move || {
+                    for i in 0..25 {
+                        merge_settings(path, |map| {
+                            map.insert(format!("k{t}_{i}"), i.into());
+                        })
+                        .expect("merge never fails on a valid file");
+                    }
+                });
+            }
+        });
+        let map = read_settings_map(&path).expect("file parses after the storm");
+        assert_eq!(map["tracked"], serde_json::json!(["a"]));
+        for t in 0..8 {
+            for i in 0..25 {
+                assert!(map.contains_key(&format!("k{t}_{i}")), "lost k{t}_{i}");
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -268,9 +268,11 @@ function ModularWindowPage() {
   }, [catalog, quantities]);
   const [sectionOrder, setSectionOrder] = useState<string[]>(["tracking", "favorites", "timers", "fissures"]);
 
+  const popoutSettingsLoadedRef = useRef(false);
   useEffect(() => {
     invoke<string>("load_settings").then(json => {
-      if (!json) return;
+      // A missing file is a first launch and safe to write to.
+      if (!json) { popoutSettingsLoadedRef.current = true; return; }
       try {
         const s = JSON.parse(json);
         if (Array.isArray(s.tracked)) setTracked(s.tracked);
@@ -284,6 +286,9 @@ function ModularWindowPage() {
           setSectionOrder(order);
         }
       } catch {}
+      // Unblock saving even if the file failed to parse, since the backend
+      // refuses to overwrite a settings.json that is not a valid JSON object.
+      popoutSettingsLoadedRef.current = true;
     }).catch(() => {});
     invoke<CatalogItem[]>("get_all_items").then(setCatalog).catch(() => {});
     invoke<Record<string, number>>("get_current_quantities").then(setQuantities).catch(() => {});
@@ -314,6 +319,10 @@ function ModularWindowPage() {
   }, []);
 
   const saveModularSettings = useCallback((patch: object) => {
+    if (!popoutSettingsLoadedRef.current) {
+      console.error("save_settings skipped: settings not loaded yet in pop-out");
+      return;
+    }
     invoke("save_settings", { json: JSON.stringify(patch) }).catch((e) => {
       console.error("save_settings failed:", e);
     });
@@ -820,6 +829,13 @@ const [blobLogEnabled, setBlobLogEnabled] = useState(false);
   settingsRef.current = { overlayEnabled, overlayPriority, textScale, colorblindMode, clockFormat, companionApiEnabled, memoryScannerEnabled, blobLogEnabled, apiLogEnabled, autoDiagEnabled, tracked, favorites, timerFavorites, fissureWatches, modularWidth, modularSectionOrder, modularPopout, wfmInvisibleOnStart, wfmInvisibleOnClose, wfmAutoInvisible, wfmAutoInvisibleMins };
 
   const saveAllSettings = useCallback(() => {
+    // Until the on-disk settings have been applied, settingsRef still holds
+    // the defaults (tracked/favorites empty). Saving the full object at that
+    // point would overwrite the user's file with those defaults, so refuse.
+    if (!settingsLoadedRef.current) {
+      console.error("save_settings skipped: settings not loaded yet, saving now would clobber the file");
+      return;
+    }
     invoke("save_settings", { json: JSON.stringify(settingsRef.current) }).catch((e) => {
       console.error("save_settings failed:", e);
     });
@@ -930,7 +946,8 @@ const [blobLogEnabled, setBlobLogEnabled] = useState(false);
 
     // Load user settings from file — survives reinstalls unlike localStorage
     invoke<string>("load_settings").then(json => {
-      if (!json) return;
+      // A missing file is a first launch: nothing to clobber, saving is safe.
+      if (!json) { settingsLoadedRef.current = true; return; }
       try {
         const s = JSON.parse(json);
         // companionApiEnabled intentionally not loaded — feature suspended pending DE clarification
@@ -981,8 +998,10 @@ if (typeof s.autoDiagEnabled === "boolean") {
         if (typeof s.wfmInvisibleOnClose === "boolean") { setWfmInvisibleOnClose(s.wfmInvisibleOnClose); wfmInvisibleOnCloseRef.current = s.wfmInvisibleOnClose; }
         if (typeof s.wfmAutoInvisible    === "boolean") setWfmAutoInvisible(s.wfmAutoInvisible);
         if (typeof s.wfmAutoInvisibleMins === "number") setWfmAutoInvisibleMins(s.wfmAutoInvisibleMins);
-        settingsLoadedRef.current = true;
       } catch {}
+      // Unblock saving even if the file failed to parse, since the backend
+      // refuses to overwrite a settings.json that is not a valid JSON object.
+      settingsLoadedRef.current = true;
     }).catch(() => {});
 
     invoke<string>("get_system_locale").then(loc => { if (loc) setSystemLocale(loc); }).catch(() => {});


### PR DESCRIPTION
# fix(settings): stop settings.json wipes from racing writers

**Symptom.** A user can lose their tracked items and favourites. `settings.json` comes
back as a valid but nearly empty object. Nothing errors and nothing is logged, so
the first anyone knows is that the lists are gone.

**Root cause: two defects that compound.**

*Unserialized read-merge-write.* `save_settings` and `save_window_state` both do
read, merge, write with no lock between them. `save_window_state` fires on every
window move and resize, so the two overlap constantly. The write is
`std::fs::write`, which truncates first, so a reader landing in that window sees a
partial file.

*A partial file parses as "no settings".* The old read was

```rust
std::fs::read_to_string(&state.settings_path).ok()
    .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
    .and_then(|v| if let serde_json::Value::Object(m) = v { Some(m) } else { None })
    .unwrap_or_default();
```

Every failure mode collapses into `unwrap_or_default()`, an empty map. The merge
then writes that empty map back as the new complete settings. The file is now
valid JSON and the data is gone. The same thing happens to a file truncated by a
kill mid-write, which is most likely during an app update.

**Fix.**

- All writers go through one `merge_settings`, serialized behind `SETTINGS_WRITE_LOCK`,
  so read-merge-write is a single critical section.
- `read_settings_map` distinguishes *absent or empty* (a first launch, fine, start
  from an empty map) from *present but unparseable* (return `Err`). A merge over an
  unparseable file refuses and leaves the file untouched, so the corrupt file
  survives for recovery. A blocked save loses one change; a silent wipe loses
  everything.
- `atomic_write` now removes its `.tmp` file when the rename fails, instead of
  leaving it behind, and takes `&Path` rather than `&PathBuf`.
- The frontend stops writing its in-memory defaults over a file it has not loaded
  yet. `settingsLoadedRef` was previously set inside the `try`, so a parse failure
  left it `false` forever and every later save was skipped; it now also unblocks on
  the catch path, because the backend refuses the overwrite anyway. A missing file
  unblocks immediately, since a first launch has nothing to clobber.

**Tested.** Four tests in `settings_merge_tests`, including an 8-thread by 25-write
storm asserting no key is lost. Truncated-file, missing-file, empty-file and
key-preservation cases are covered.

**Verification.** `lib.rs` does not compile on Linux (the Win32 memory APIs), so I
copied the four functions verbatim into a scratch crate and ran the tests there:
4 passed. I also removed the lock and re-ran to confirm the storm test is
load-bearing. It fails with

    merge never fails on a valid file: "No such file or directory (os error 2)"

because concurrent writers collide on the shared `.tmp` path. `tsc --noEmit` passes
on the `App.tsx` change (against the dependency versions my fork has installed,
which satisfy this repo's ranges).

I have not run any of this on Windows. I develop on Linux and this has never been
executed on your platform, nor built by the real Tauri toolchain. That said,
nothing here touches a platform API: it is `std::fs`, `serde_json` and a `Mutex`.
The one Windows-specific consideration is that `std::fs::rename` over an existing
file is atomic on NTFS as it is on ext4, which the original `atomic_write` already
relied on.

**If you reimplement this rather than taking the commit, the load-bearing parts are:**

1. The lock must span read, merge and write as one critical section. Locking only
   the write leaves the tearing window open, and a reader still catches the truncate.
2. "Unparseable" and "absent" must be different outcomes. Collapsing both into an
   empty map *is* the bug. Absent or empty means an empty map and proceed; present
   but not a JSON object means refuse the write and keep the file.
3. A refused save must not be silently swallowed. `save_window_state` warns rather
   than propagating, since a window move is not worth an error dialog, but it must
   not look like success.
4. The frontend guard must unblock on the parse-failure path too. Setting the flag
   only inside the `try` means one bad parse disables saving for the rest of the
   session.

Note the `.tmp` collision above is its own small hazard: `atomic_write` derives the
temp path from the target path, so every writer shares one. The lock covers it. If
you drop the lock in favour of per-writer temp names, points 1 and 2 still stand.
