### PR TITLE
feat(logging): route diagnostics through tracing with a rolling file sink

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2043,6 +2043,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2188,6 +2194,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2324,6 +2339,15 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-conv"
@@ -3697,6 +3721,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3877,6 +3910,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -4317,6 +4356,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4546,6 +4594,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4563,6 +4624,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -4767,6 +4858,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4840,6 +4937,10 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-opener",
  "tokio",
+ "tracing",
+ "tracing-appender",
+ "tracing-log",
+ "tracing-subscriber",
  "tungstenite",
  "ureq",
  "whirlpool",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,10 @@ tungstenite = { version = "0.26", features = ["native-tls"] }
 native-tls = "0.2"
 whirlpool = "0.10"
 lzma-rs = "0.3"
+tracing = "0.1.44"
+tracing-appender = "0.2.5"
+tracing-log = "0.2.0"
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 
 [profile.dev]
 opt-level = 1

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 ﻿use std::collections::HashMap;
+use tracing::{debug, error, info, warn};
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -1073,11 +1074,11 @@ fn fetch_csrf_from_site(jwt: &str) -> Option<String> {
         .set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
         .call();
     let html = match resp {
-        Ok(r) => { eprintln!("[csrf] site fetch status=200"); r.into_string().ok()? }
+        Ok(r) => { debug!("site fetch status=200"); r.into_string().ok()? }
         Err(e) => {
-            eprintln!("[csrf] site fetch error: {} — trying JWT payload fallback", e);
+            warn!(error = %e, "site fetch failed, trying JWT payload fallback");
             if let Some(t) = jwt_payload_field(jwt, "csrf_token") {
-                eprintln!("[csrf] JWT payload csrf_token len={}", t.len());
+                debug!(len = t.len(), "JWT payload csrf_token");
                 return Some(t);
             }
             return None;
@@ -1090,16 +1091,16 @@ fn fetch_csrf_from_site(jwt: &str) -> Option<String> {
         if let Some(end_rel) = html[start..].find('"') {
             let token = html[start..start + end_rel].to_string();
             if !token.is_empty() {
-                eprintln!("[csrf] found meta token len={}", token.len());
+                debug!(len = token.len(), "found meta token");
                 return Some(token);
             }
         }
     }
-    eprintln!("[csrf] meta tag not found in HTML (len={}) — trying JWT payload fallback", html.len());
+    warn!(len = html.len(), "meta tag not found in HTML, trying JWT payload fallback");
     // Log a snippet to see what we got (first 200 chars)
-    eprintln!("[csrf] HTML snippet: {}", truncate_chars(&html, 200));
+    debug!(snippet = %truncate_chars(&html, 200), "HTML snippet");
     if let Some(t) = jwt_payload_field(jwt, "csrf_token") {
-        eprintln!("[csrf] JWT payload csrf_token len={}", t.len());
+        debug!(len = t.len(), "JWT payload csrf_token");
         Some(t)
     } else {
         None
@@ -1370,7 +1371,7 @@ fn wfm_receive_tokens(
     } else {
         fetch_csrf_from_site(&v1_jwt_val).unwrap_or_default()
     };
-    eprintln!("[csrf] captured csrf_token len={}", csrf.len());
+    info!(len = csrf.len(), "csrf_token captured");
     *state.wfm_session.lock().unwrap_or_else(|e| e.into_inner()) = Some(WfmSession {
         access_token, refresh_token, client_id, device_id, username: username.clone(), status,
         v1_jwt: v1_jwt_val,
@@ -1435,9 +1436,9 @@ fn wfm_set_jwt(state: State<AppState>, jwt: String) -> Result<(String, String), 
     let status   = json["data"]["status"].as_str().unwrap_or("offline").to_string();
     // If no saved CSRF token, fetch it from the site now
     if csrf_token.is_empty() && !v1_jwt.is_empty() {
-        eprintln!("[csrf] set_jwt: no saved token, fetching from site...");
+        debug!("set_jwt: no saved token, fetching from site");
         csrf_token = fetch_csrf_from_site(&v1_jwt).unwrap_or_default();
-        eprintln!("[csrf] set_jwt: csrf_token len={}", csrf_token.len());
+        debug!(len = csrf_token.len(), "set_jwt: csrf_token fetched");
     }
     *state.wfm_session.lock().unwrap_or_else(|e| e.into_inner()) = Some(WfmSession {
         access_token, refresh_token, client_id, device_id, username: username.clone(), status: status.clone(), v1_jwt, csrf_token,
@@ -2307,7 +2308,7 @@ fn load_riven_csv_from_url() -> Result<HashMap<String, RivenEntry>, String> {
             .and_then(|r| r.into_string().map_err(|e| e.to_string()))
         {
             Ok(csv) => { combined.extend(parse_riven_csv(&csv)); }
-            Err(e) => { eprintln!("[riven] Failed to load gid={}: {}", gid, e); }
+            Err(e) => { warn!(gid, error = %e, "failed to load riven sheet tab"); }
         }
     }
     if combined.is_empty() {
@@ -4319,7 +4320,7 @@ async fn toggle_raw_scan(state: State<'_, AppState>) -> Result<String, String> {
                         Err(e) => { let _ = writeln!(f, "--- pass {} error: {} ---", pass, e); }
                     }
                 }
-                Err(e) => { eprintln!("[raw_scan] open failed: {}", e); }
+                Err(e) => { warn!(error = %e, "raw_scan open failed"); }
             }
 
             // Sleep between passes so the user has time to navigate menus
@@ -4488,7 +4489,7 @@ async fn start_monitor(app: tauri::AppHandle, state: State<'_, AppState>) -> Res
     std::thread::spawn(move || {
         let conn = match rusqlite::Connection::open(&db_path) {
             Ok(c) => c,
-            Err(e) => { eprintln!("Monitor DB open failed: {}", e); return; }
+            Err(e) => { error!(error = %e, "monitor DB open failed"); return; }
         };
         let _ = conn.execute_batch("PRAGMA journal_mode=WAL;");
 
@@ -4785,7 +4786,7 @@ async fn start_monitor(app: tauri::AppHandle, state: State<'_, AppState>) -> Res
                     blob.unique_items.len(), blob.stackable_items.len(),
                     blob.mods.len(), blob.flavour_items.len()
                 );
-                eprintln!("[monitor] blob applied: {}", detail);
+                info!(detail = %detail, "blob applied");
                 let _ = app.emit("blob-status", BlobStatusPayload {
                     stage: "done".into(),
                     detail,
@@ -4815,7 +4816,7 @@ async fn start_monitor(app: tauri::AppHandle, state: State<'_, AppState>) -> Res
                 cached_game_running = current_pid.is_some();
                 if current_pid != last_pid {
                     if current_pid.is_some() {
-                        eprintln!("[monitor] Warframe PID changed ({:?} → {:?}), clearing blob region cache", last_pid, current_pid);
+                        info!(?last_pid, ?current_pid, "Warframe PID changed, clearing blob region cache");
                         memory_scanner::reset_last_blob_region();
                     }
                     last_pid = current_pid;
@@ -4839,7 +4840,7 @@ async fn start_monitor(app: tauri::AppHandle, state: State<'_, AppState>) -> Res
                         stage:  "scanning".into(),
                         detail: "Reading Warframe memory\u{2026}".into(),
                     });
-                    eprintln!("[monitor] blob capture starting (save={})", save);
+                    debug!(save, "blob capture starting");
                     std::thread::spawn(move || {
                         // Ensure the flag is cleared even if capture_all_blobs panics.
                         struct ClearOnDrop(std::sync::Arc<std::sync::atomic::AtomicBool>);
@@ -4848,7 +4849,7 @@ async fn start_monitor(app: tauri::AppHandle, state: State<'_, AppState>) -> Res
                         }
                         let _guard = ClearOnDrop(active);
                         let count = memory_scanner::capture_all_blobs(&dir, &ts, tx, save);
-                        eprintln!("[monitor] blob capture finished (files_saved={} save_flag={} ts={})", count, save, ts);
+                        debug!(files_saved = count, save_flag = save, ts = %ts, "blob capture finished");
                     });
                 }
                 prev_game_running = true;
@@ -5520,7 +5521,7 @@ async fn start_monitor(app: tauri::AppHandle, state: State<'_, AppState>) -> Res
                         ts0, trigger_line, prefilter_log, filtered_cat.len()
                     ));
                     if let Err(e) = write_err {
-                        eprintln!("[FrameForge] session log write failed: {e}");
+                        warn!(error = %e, "session log write failed");
                     }
                     // Create one diagnostics folder for this entire run.
                     let run_diag_dir = diag_dir().join(
@@ -7365,7 +7366,7 @@ fn show_overlay_window(
     // off-screen. If it's still on about:blank, navigate to the overlay URL now.
     if let Ok(url) = win.url() {
         if url.as_str() == "about:blank" || url.as_str().starts_with("about:") {
-            eprintln!("[overlay] WebView2 deferred load detected (url={}) — navigating to overlay URL", url);
+            debug!(%url, "WebView2 deferred load detected, navigating to overlay URL");
             let overlay_url = if cfg!(debug_assertions) {
                 "http://localhost:1420/index.html?overlay"
             } else {
@@ -7411,18 +7412,18 @@ fn show_test_overlay_window(app: tauri::AppHandle) -> Result<(), String> {
     // Log current URL and force navigation in case WebView2 deferred loading while off-screen
     match win.url() {
         Ok(url) => {
-            eprintln!("[OVERLAY-TEST] current url: {url}");
+            debug!(%url, "current url");
             // Only re-navigate if we're on blank (WebView2 never loaded the app URL)
             if url.as_str() == "about:blank" || url.as_str().starts_with("about:") {
-                eprintln!("[OVERLAY-TEST] was on about:blank — navigating to app URL");
+                debug!("was on about:blank, navigating to app URL");
                 if let Ok(nav_url) = tauri::Url::parse("http://localhost:1420/index.html?overlaytest") {
                     let _ = win.navigate(nav_url);
                 }
             }
         }
-        Err(e) => eprintln!("[OVERLAY-TEST] url() error: {e}"),
+        Err(e) => warn!(error = %e, "url() error"),
     }
-    eprintln!("[OVERLAY-TEST] show_test_overlay_window: moved to logical(400,300), alwaysOnTop=true");
+    debug!("show_test_overlay_window: moved to logical(400,300), alwaysOnTop=true");
     Ok(())
 }
 
@@ -7436,7 +7437,7 @@ fn hide_test_overlay_window(app: tauri::AppHandle) -> Result<(), String> {
     let _ = win.set_position(tauri::Position::Physical(
         tauri::PhysicalPosition { x: 0, y: -3000 }
     ));
-    eprintln!("[OVERLAY-TEST] hide_test_overlay_window: moved offscreen");
+    debug!("hide_test_overlay_window: moved offscreen");
     Ok(())
 }
 
@@ -7560,7 +7561,7 @@ async fn prewarm_image_cache(state: tauri::State<'_, AppState>) -> Result<(), St
             .collect();
 
         if names.is_empty() { return; }
-        eprintln!("[img_cache] Prewarming {} images in background", names.len());
+        debug!(count = names.len(), "prewarming images in background");
 
         for chunk in names.chunks(8) {
             let handles: Vec<_> = chunk.iter().map(|name| {
@@ -7578,7 +7579,7 @@ async fn prewarm_image_cache(state: tauri::State<'_, AppState>) -> Result<(), St
             }).collect();
             for h in handles { let _ = h.join(); }
         }
-        eprintln!("[img_cache] Prewarm complete");
+        debug!("prewarm complete");
     }); // intentionally not awaited — fire and forget
 
     Ok(())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1024,6 +1024,21 @@ fn wfm_request(method: &str, path: &str, auth_header: &str) -> ureq::Request {
        .set("User-Agent", "FrameForge/2.1.0")
 }
 
+#[tracing::instrument(level = "debug", skip_all, fields(method = %method, path = %path))]
+fn wfm_call(method: &str, path: &str, auth_header: &str) -> Result<ureq::Response, ureq::Error> {
+    wfm_request(method, path, auth_header).call()
+}
+
+#[tracing::instrument(level = "debug", skip_all, fields(method = %method, path = %path))]
+fn wfm_send_json(
+    method: &str,
+    path: &str,
+    auth_header: &str,
+    body: impl serde::Serialize,
+) -> Result<ureq::Response, ureq::Error> {
+    wfm_request(method, path, auth_header).send_json(body)
+}
+
 /// Like wfm_request but authenticates via Cookie (JWT=...) instead of Authorization header.
 
 /// Decode the payload of a JWT (base64url, middle part) and extract a field by name.
@@ -1066,6 +1081,7 @@ fn base64_decode_url(s: &str) -> Option<Vec<u8>> {
 /// Fetch the CSRF token from warframe.market by loading the authenticated page.
 /// The meta tag `<meta name="csrf-token" content="...">` in the response HTML contains it.
 /// Falls back to the csrf_token embedded in the JWT payload if the page fetch fails.
+#[tracing::instrument(level = "debug", skip_all)]
 fn fetch_csrf_from_site(jwt: &str) -> Option<String> {
     if jwt.is_empty() { return None; }
     let resp = ureq::get("https://warframe.market/")
@@ -1895,8 +1911,8 @@ fn session_v1_auth(state: &State<AppState>) -> Result<String, String> {
 fn wfm_get_orders(state: State<AppState>) -> Result<serde_json::Value, String> {
     let auth = session_auth(&state)?;
     wfm_wait();
-    let json: serde_json::Value = wfm_request("GET", "/v2/orders/my", &auth)
-        .call().map_err(|e| format!("Get orders: {}", e))?
+    let json: serde_json::Value = wfm_call("GET", "/v2/orders/my", &auth)
+        .map_err(|e| format!("Get orders: {}", e))?
         .into_json().map_err(|e| format!("Parse: {}", e))?;
     Ok(json["data"].clone())
 }
@@ -3351,8 +3367,8 @@ fn analyze_riven(weapon: String, positives: Vec<String>, negatives: Vec<String>)
 fn wfm_debug_dump(state: State<AppState>, path: String) -> Result<String, String> {
     let auth = session_auth(&state)?;
     wfm_wait();
-    let json: serde_json::Value = wfm_request("GET", &path, &auth)
-        .call().map_err(|e| format!("Dump: {}", e))?
+    let json: serde_json::Value = wfm_call("GET", &path, &auth)
+        .map_err(|e| format!("Dump: {}", e))?
         .into_json().map_err(|e| format!("Parse: {}", e))?;
     serde_json::to_string_pretty(&json).map_err(|e| e.to_string())
 }
@@ -3394,8 +3410,8 @@ fn wfm_get_item_info(state: State<AppState>, url_name: String) -> Result<serde_j
     let auth = state.wfm_session.lock().unwrap_or_else(|e| e.into_inner())
         .as_ref().map(|s| s.auth_header()).unwrap_or_default();
     wfm_wait();
-    let mut data = wfm_request("GET", &format!("/v2/items/{}", url_name), &auth)
-        .call().map_err(|e| format!("Item info: {}", e))?
+    let mut data = wfm_call("GET", &format!("/v2/items/{}", url_name), &auth)
+        .map_err(|e| format!("Item info: {}", e))?
         .into_json::<serde_json::Value>().map_err(|e| format!("Parse: {}", e))
         .map(|j| j["data"].clone())?;
 
@@ -3426,8 +3442,8 @@ fn wfm_create_order(state: State<AppState>, item_id: String, order_type: String,
         body["rank"] = serde_json::json!(rank);
     }
     wfm_wait();
-    wfm_request("POST", "/v2/order", &auth)
-        .send_string(&body.to_string()).map_err(|e| format!("Create order: {}", e))?
+    wfm_send_json("POST", "/v2/order", &auth, &body)
+        .map_err(|e| format!("Create order: {}", e))?
         .into_json::<serde_json::Value>().map_err(|e| format!("Parse: {}", e))
         .map(|j| j["data"].clone())
 }
@@ -3438,8 +3454,8 @@ fn wfm_update_order(state: State<AppState>, order_id: String, platinum: u32, qua
     let auth = session_auth(&state)?;
     let body = serde_json::json!({ "platinum": platinum, "quantity": quantity, "visible": visible });
     wfm_wait();
-    wfm_request("PATCH", &format!("/v2/order/{}", order_id), &auth)
-        .send_string(&body.to_string()).map_err(|e| format!("Update order: {}", e))?
+    wfm_send_json("PATCH", &format!("/v2/order/{}", order_id), &auth, &body)
+        .map_err(|e| format!("Update order: {}", e))?
         .into_json::<serde_json::Value>().map_err(|e| format!("Parse: {}", e))
         .map(|j| j["data"].clone())
 }
@@ -3449,8 +3465,8 @@ fn wfm_update_order(state: State<AppState>, order_id: String, platinum: u32, qua
 fn wfm_delete_order(state: State<AppState>, order_id: String) -> Result<(), String> {
     let auth = session_auth(&state)?;
     wfm_wait();
-    wfm_request("DELETE", &format!("/v2/order/{}", order_id), &auth)
-        .call().map_err(|e| format!("Delete order: {}", e))?;
+    wfm_call("DELETE", &format!("/v2/order/{}", order_id), &auth)
+        .map_err(|e| format!("Delete order: {}", e))?;
     Ok(())
 }
 
@@ -3498,8 +3514,8 @@ fn wfm_create_riven_auction(
     // WFM v1 requires buyout_price to be present in the payload (null = no buyout).
     payload["buyout_price"] = serde_json::json!(buyout_price);
     wfm_auction_wait();
-    let resp = wfm_request("POST", "/v1/auctions/create", &auth)
-        .send_json(payload)
+    let resp = wfm_send_json("POST", "/v1/auctions/create", &auth, payload)
+        
         .map_err(|e| match e {
             ureq::Error::Status(code, r) => {
                 let body = r.into_string().unwrap_or_default();
@@ -3534,10 +3550,10 @@ async fn wfm_get_my_riven_auctions(state: tauri::State<'_, AppState>) -> Result<
     tauri::async_runtime::spawn_blocking(move || {
         // Phase 1: profile endpoint with Bearer auth — returns visible auctions.
         wfm_auction_wait();
-        let profile_resp: serde_json::Value = wfm_request(
+        let profile_resp: serde_json::Value = wfm_call(
             "GET", &format!("/v1/profile/{}/auctions", username), &v1_auth,
         )
-        .call()
+        
         .map_err(|e| format!("Fetch auctions: {}", e))?
         .into_json()
         .map_err(|e| format!("Parse auctions: {}", e))?;
@@ -3554,9 +3570,9 @@ async fn wfm_get_my_riven_auctions(state: tauri::State<'_, AppState>) -> Result<
         for id in &stored_ids {
             if seen_ids.contains(id) { continue; }
             wfm_auction_wait();
-            let entry: serde_json::Value = match wfm_request(
+            let entry: serde_json::Value = match wfm_call(
                 "GET", &format!("/v1/auctions/entry/{}", id), &v1_auth,
-            ).call() {
+            ) {
                 Ok(r) => match r.into_json() {
                     Ok(j) => j,
                     Err(_) => continue,
@@ -3601,8 +3617,8 @@ fn wfm_switch_riven_type(
 
     // Step 1: fetch full auction detail so we have all fields (attributes, polarity, etc.).
     wfm_auction_wait();
-    let entry: serde_json::Value = wfm_request("GET", &format!("/v1/auctions/entry/{}", auction_id), &auth)
-        .call()
+    let entry: serde_json::Value = wfm_call("GET", &format!("/v1/auctions/entry/{}", auction_id), &auth)
+        
         .map_err(|e| match e {
             ureq::Error::Status(code, r) => format!("Fetch auction: HTTP {}: {}", code, r.into_string().unwrap_or_default()),
             other => format!("Fetch auction: {}", other),
@@ -3628,8 +3644,8 @@ fn wfm_switch_riven_type(
 
     // Step 2: close the old auction.
     wfm_auction_wait();
-    wfm_request("PUT", &format!("/v1/auctions/entry/{}/close", auction_id), &auth)
-        .call()
+    wfm_call("PUT", &format!("/v1/auctions/entry/{}/close", auction_id), &auth)
+        
         .map_err(|e| match e {
             ureq::Error::Status(code, r) => format!("Delete auction: HTTP {}: {}", code, r.into_string().unwrap_or_default()),
             other => format!("Delete auction: {}", other),
@@ -3649,8 +3665,8 @@ fn wfm_switch_riven_type(
     payload["buyout_price"] = serde_json::json!(buyout_price);
 
     wfm_auction_wait();
-    let resp = wfm_request("POST", "/v1/auctions/create", &auth)
-        .send_json(payload)
+    let resp = wfm_send_json("POST", "/v1/auctions/create", &auth, payload)
+        
         .map_err(|e| match e {
             ureq::Error::Status(code, r) => format!("Create riven auction: HTTP {}: {}", code, r.into_string().unwrap_or_default()),
             other => format!("Create riven auction: {}", other),
@@ -3674,8 +3690,8 @@ fn wfm_switch_riven_type(
 fn wfm_delete_auction(state: State<AppState>, auction_id: String) -> Result<(), String> {
     let auth = session_v1_auth(&state)?;
     wfm_auction_wait();
-    wfm_request("PUT", &format!("/v1/auctions/entry/{}/close", auction_id), &auth)
-        .call()
+    wfm_call("PUT", &format!("/v1/auctions/entry/{}/close", auction_id), &auth)
+        
         .map_err(|e| match e {
             ureq::Error::Status(code, r) => {
                 let body = r.into_string().unwrap_or_default();
@@ -3696,8 +3712,8 @@ fn wfm_update_auction(state: State<AppState>, auction_id: String, starting_price
     let mut body = serde_json::json!({ "starting_price": starting_price, "visible": visible });
     body["buyout_price"] = buyout_price.map_or(serde_json::Value::Null, |v| serde_json::json!(v));
     wfm_auction_wait();
-    wfm_request("PUT", &format!("/v1/auctions/entry/{}", auction_id), &auth)
-        .send_json(body)
+    wfm_send_json("PUT", &format!("/v1/auctions/entry/{}", auction_id), &auth, body)
+        
         .map_err(|e| match e {
             ureq::Error::Status(code, r) => {
                 let body = r.into_string().unwrap_or_default();
@@ -3713,8 +3729,8 @@ fn wfm_update_auction(state: State<AppState>, auction_id: String, starting_price
 fn wfm_set_auction_visible(state: State<AppState>, auction_id: String, visible: bool) -> Result<(), String> {
     let auth = session_v1_auth(&state)?;
     wfm_auction_wait();
-    wfm_request("PUT", &format!("/v1/auctions/entry/{}", auction_id), &auth)
-        .send_json(serde_json::json!({ "visible": visible }))
+    wfm_send_json("PUT", &format!("/v1/auctions/entry/{}", auction_id), &auth, serde_json::json!({ "visible": visible }))
+        
         .map_err(|e| match e {
             ureq::Error::Status(code, r) => {
                 let body = r.into_string().unwrap_or_default();
@@ -3878,6 +3894,7 @@ fn trimmed_median_from_stats(arr: &[serde_json::Value]) -> Option<u32> {
     Some(median.round() as u32)
 }
 
+#[tracing::instrument(level = "debug", skip_all, fields(slug = %slug))]
 fn wfm_price_for_slug(slug: &str) -> Result<Option<u32>, String> {
     wfm_wait();
     let url = format!("https://api.warframe.market/v1/items/{}/statistics", slug);
@@ -7850,6 +7867,7 @@ const PRICING_BASE: &str = "https://raw.githubusercontent.com/WyrmStudios/FrameF
 /// Returns (by_name, by_slug):
 ///   by_name: item display name (lowercase) → median sell price  (for get_item_price)
 ///   by_slug: authoritative WFM slug         → median sell price  (for wfm_price_cache)
+#[tracing::instrument(level = "debug", skip_all)]
 fn fetch_relics_run_data() -> (HashMap<String, u32>, HashMap<String, u32>) {
     // items.json gives the authoritative name → WFM slug mapping for every tradeable item.
     let name_to_slug: HashMap<String, String> = ureq::get(&format!("{}/items.json", PRICING_BASE))

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ use tauri::{Emitter, Manager, State};
 
 mod console_login; // [console-login feature] remove this line to drop the feature
 mod db;
+mod logging;
 mod memory_scanner;
 mod ocr;
 mod wfcd;
@@ -8428,6 +8429,8 @@ pub fn run() {
         })
         .setup(|app| {
             use tauri::Manager;
+
+            logging::init(app.handle());
 
             // Spin up a tiny local HTTP server that serves cached item images from disk.
             // This is more reliable than convertFileSrc (which needs assetProtocol scope).

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -1,0 +1,93 @@
+//! Subscriber setup: a compact daily-rolling file log plus a coloured console
+//! log, both fed from the same `tracing` events.
+
+use std::sync::OnceLock;
+
+use tauri::Manager;
+use tracing_subscriber::{
+    EnvFilter, fmt,
+    layer::{Layer, SubscriberExt},
+    util::SubscriberInitExt,
+};
+
+/// Dropping the `WorkerGuard` flushes the non-blocking writer's buffer, so it
+/// has to outlive every log call; otherwise the last events (including a
+/// panic) never reach disk.
+static FILE_GUARD: OnceLock<tracing_appender::non_blocking::WorkerGuard> = OnceLock::new();
+
+/// Installs the global subscriber, log-crate bridge and panic hook. Safe to
+/// call more than once; later calls do nothing.
+pub fn init(app: &tauri::AppHandle) {
+    if FILE_GUARD.get().is_some() {
+        return;
+    }
+
+    let log_dir = app
+        .path()
+        .app_log_dir()
+        .expect("Tauri always resolves a log dir on supported platforms");
+    let _ = std::fs::create_dir_all(&log_dir);
+
+    let appender = tracing_appender::rolling::Builder::new()
+        .rotation(tracing_appender::rolling::Rotation::DAILY)
+        .filename_prefix("frameforge")
+        .filename_suffix("log")
+        .max_log_files(5)
+        .build(&log_dir)
+        .expect("log dir was just created");
+    // Non-blocking so the scanner and OCR hot loops never stall on disk I/O.
+    let (writer, guard) = tracing_appender::non_blocking(appender);
+    let _ = FILE_GUARD.set(guard);
+
+    let file_layer = fmt::layer()
+        .compact()
+        .with_ansi(false)
+        .with_target(true)
+        // Span-close events carry time.busy/time.idle, which is where the
+        // scanner and OCR timings surface.
+        .with_span_events(fmt::format::FmtSpan::CLOSE)
+        .with_writer(writer)
+        .with_filter(filter("warn,warframe_companion_lib=debug"));
+
+    let console_layer = fmt::layer()
+        .compact()
+        .with_ansi(true)
+        .with_target(true)
+        .with_writer(std::io::stderr)
+        .with_filter(filter("info,warframe_companion_lib=info"));
+
+    let _ = tracing_subscriber::registry()
+        .with(file_layer)
+        .with(console_layer)
+        .try_init();
+
+    let _ = tracing_log::LogTracer::init();
+
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let payload = info.payload();
+        let message = payload
+            .downcast_ref::<&str>()
+            .copied()
+            .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+            .unwrap_or("<non-string panic payload>");
+        tracing::error!(
+            location = %info.location().map_or_else(|| "unknown".to_string(), ToString::to_string),
+            message,
+            "panic"
+        );
+        previous(info);
+    }));
+
+    tracing::info!(
+        version = env!("CARGO_PKG_VERSION"),
+        pid = std::process::id(),
+        os = std::env::consts::OS,
+        log_dir = %log_dir.display(),
+        "FrameForge starting"
+    );
+}
+
+fn filter(default: &str) -> EnvFilter {
+    EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default))
+}

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -1,5 +1,6 @@
 ﻿use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use tracing::{debug, info, warn};
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct ModCount {
@@ -660,7 +661,7 @@ pub fn parse_full_account_blob(raw: &[u8]) -> Option<BlobInventory> {
     // small false-positive fragment that matched the end marker by coincidence.
     const MIN_PARSE_BYTES: usize = 50_000;
     if end_pos < MIN_PARSE_BYTES {
-        eprintln!("[blob-parse] too small ({} B < {} B) — skipping", end_pos, MIN_PARSE_BYTES);
+        debug!(target: "frameforge::blob_parse", end_pos, min = MIN_PARSE_BYTES, "too small — skipping");
         return None;
     }
 
@@ -670,7 +671,7 @@ pub fn parse_full_account_blob(raw: &[u8]) -> Option<BlobInventory> {
         .map_err(|e| {
             let head: String = json_bytes[..json_bytes.len().min(48)]
                 .iter().map(|&b| if b >= 0x20 && b < 0x7f { b as char } else { '.' }).collect();
-            eprintln!("[blob-parse] JSON error: {} | head: {:?}", e, head);
+            debug!(target: "frameforge::blob_parse", error = %e, head = ?head, "JSON error");
         })
         .ok()?;
 
@@ -1024,8 +1025,12 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
                         stitched.extend_from_slice(&nb[..nn]);
                     }
                     if let Some(inv) = parse_full_account_blob(&stitched) {
-                        eprintln!("[blob] fast-path hit at 0x{:012x}: {} unique, {} stackable",
-                            cached_addr, inv.unique_items.len(), inv.stackable_items.len());
+                        info!(
+                            addr = format_args!("0x{cached_addr:012x}"),
+                            unique = inv.unique_items.len(),
+                            stackable = inv.stackable_items.len(),
+                            "fast-path hit"
+                        );
                         blob_tx.send(inv).ok();
                         unsafe { CloseHandle(process); }
                         return 0; // fast path never saves to disk
@@ -1034,7 +1039,7 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
             }
         }
         // Cache miss — fall through to full walk and update the cache when found
-        eprintln!("[blob] fast-path miss at 0x{:012x} — doing full walk", cached_addr);
+        debug!(addr = format_args!("0x{cached_addr:012x}"), "fast-path miss — doing full walk");
     }
 
     struct ActiveScan {
@@ -1133,7 +1138,7 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
             scan.search_from = scan.data.len().saturating_sub(END_MARKER.len() - 1);
             scan.data.extend_from_slice(chunk);
             if scan.data.len() > MAX_SCAN {
-                eprintln!("[blob] scan#{} exceeded {} MB without end — dropped", scan.id, MAX_SCAN / 1024 / 1024);
+                warn!(scan_id = scan.id, max_mb = MAX_SCAN / 1024 / 1024, "scan exceeded size limit without end — dropped");
                 return false; // drop oversized scan
             }
             // Only search the newly-added window, not the full buffer.
@@ -1143,8 +1148,14 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
             if has_end && find_blob_end(&scan.data).is_some() {
                 match parse_full_account_blob(&scan.data) {
                     Some(inv) => {
-                        eprintln!("[blob] scan#{} SUCCESS at 0x{:012x}: {} unique, {} stackable, {} mods",
-                            scan.id, region_addr, inv.unique_items.len(), inv.stackable_items.len(), inv.mods.len());
+                        info!(
+                            scan_id = scan.id,
+                            addr = format_args!("0x{region_addr:012x}"),
+                            unique = inv.unique_items.len(),
+                            stackable = inv.stackable_items.len(),
+                            mods = inv.mods.len(),
+                            "scan SUCCESS"
+                        );
                         // Cache the START region (not this region) so the fast path works next cycle.
                         LAST_BLOB_REGION.store(scan.start_region_addr as u64, std::sync::atomic::Ordering::Relaxed);
                         if save {
@@ -1158,7 +1169,7 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
                         found_result = true;
                     }
                     None => {
-                        eprintln!("[blob] scan#{} end marker found but JSON parse failed — dropped", scan.id);
+                        warn!(scan_id = scan.id, "end marker found but JSON parse failed — dropped");
                     }
                 }
                 false // remove completed (or failed) scan
@@ -1229,17 +1240,27 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
             next_scan_id += 1;
             starts_found += 1;
             let pre_bytes = combined.len() - n;
-            eprintln!(
-                "[blob] scan#{} started at 0x{:012x}+{} (json_open={} seed=0x{:012x} pre={}B)",
-                id, region_addr, start_off, json_open, seed_addr, pre_bytes
+            debug!(
+                scan_id = id,
+                addr = format_args!("0x{region_addr:012x}"),
+                start_off,
+                json_open,
+                seed = format_args!("0x{seed_addr:012x}"),
+                pre_bytes,
+                "scan started"
             );
             let seed = combined[json_open..].to_vec();
 
             if find_blob_end(&seed).is_some() {
                 match parse_full_account_blob(&seed) {
                     Some(inv) => {
-                        eprintln!("[blob] scan#{} immediate SUCCESS at 0x{:012x}: {} unique, {} stackable",
-                            id, region_addr, inv.unique_items.len(), inv.stackable_items.len());
+                        info!(
+                            scan_id = id,
+                            addr = format_args!("0x{region_addr:012x}"),
+                            unique = inv.unique_items.len(),
+                            stackable = inv.stackable_items.len(),
+                            "scan immediate SUCCESS"
+                        );
                         LAST_BLOB_REGION.store(seed_addr as u64, std::sync::atomic::Ordering::Relaxed);
                         if save {
                             let name = format!("Actual_inventory_FULL_ACCOUNT_{}_{:02}.txt", ts, saved + 1);
@@ -1251,7 +1272,7 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
                         found_result = true;
                     }
                     None => {
-                        eprintln!("[blob] scan#{} immediate end found but parse failed — dropping", id);
+                        warn!(scan_id = id, "immediate end found but parse failed — dropping");
                     }
                 }
             } else {
@@ -1260,17 +1281,20 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
         }
     }
 
-    eprintln!(
-        "[blob-capture] done: read={} skipped={} starts={} saved={} bytes={}MB | \
-         vquery={:.0}ms read={:.0}ms search={:.0}ms",
-        regions_read, regions_skipped, starts_found, saved, bytes_read / 1_000_000,
-        t_vquery.as_secs_f64() * 1000.0,
-        t_read.as_secs_f64()   * 1000.0,
-        t_search.as_secs_f64() * 1000.0,
+    debug!(
+        target: "frameforge::blob_capture",
+        regions_read,
+        regions_skipped,
+        starts_found,
+        saved,
+        bytes_mb = bytes_read / 1_000_000,
+        vquery_ms = t_vquery.as_secs_f64() * 1000.0,
+        read_ms = t_read.as_secs_f64() * 1000.0,
+        search_ms = t_search.as_secs_f64() * 1000.0,
+        "capture done"
     );
     if starts_found == 0 {
-        eprintln!("[blob-capture] WARNING: no start-marker found — FULL_ACCOUNT not in memory \
-            (game in mission, on login screen, or Arsenal not open?)");
+        warn!(target: "frameforge::blob_capture", "no start-marker found — FULL_ACCOUNT not in memory (game in mission, on login screen, or Arsenal not open?)");
     }
     unsafe { CloseHandle(process); }
     saved

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -309,6 +309,7 @@ pub fn find_warframe_pid_pub() -> Option<u32> { None }
 // the actual JSON format for inventory items without any parsing assumptions.
 
 #[cfg(target_os = "windows")]
+#[tracing::instrument(level = "info", skip_all, fields(max_hits = max_hits))]
 pub fn dump_inventory_regions(max_hits: usize) -> Vec<String> {
     use std::ffi::c_void;
     use std::mem;
@@ -654,6 +655,7 @@ pub fn extract_blob_json(raw: &[u8]) -> Option<Vec<u8>> {
 
 /// `raw` must span from the JSON opening `{` (or from `"SubscribedToEmails"`) through
 /// `"DeathSquadable":`. Returns `None` if neither start can be located or JSON is malformed.
+#[tracing::instrument(level = "debug", skip_all)]
 pub fn parse_full_account_blob(raw: &[u8]) -> Option<BlobInventory> {
     let end_pos = find_blob_end(raw)?;
 
@@ -940,6 +942,7 @@ pub fn reset_last_blob_region() {
 /// When `save=true` also writes the raw text to `blob_dir` for debugging.
 /// Returns the number of files written (always 0 when `save=false`).
 #[cfg(target_os = "windows")]
+#[tracing::instrument(level = "debug", skip_all, fields(save = save))]
 pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::sync::mpsc::Sender<BlobInventory>, save: bool) -> usize {
     use std::ffi::c_void;
     use std::mem;

--- a/src-tauri/src/ocr.rs
+++ b/src-tauri/src/ocr.rs
@@ -25,6 +25,7 @@ fn avg_brightness(pixels: &[u8]) -> u32 {
 /// from the very top of the frame (FPS counters, ping overlays, etc.) without cropping.
 /// capture_info describes which path was used and the pixel brightness, for session logging.
 #[cfg(target_os = "windows")]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn capture_warframe_reward_area() -> Option<(Vec<u8>, u32, u32, u32, String)> {
     // ── Path A: PrintWindow (Windowed / Borderless Windowed) ──────────────────
     if let Some((pixels, w, cap_h, full_h)) = capture_printwindow() {
@@ -68,6 +69,7 @@ pub fn capture_warframe_reward_area() -> Option<(Vec<u8>, u32, u32, u32, String)
 
 /// GDI PrintWindow capture — works for Windowed and Borderless Windowed.
 #[cfg(target_os = "windows")]
+#[tracing::instrument(level = "debug", skip_all)]
 fn capture_printwindow() -> Option<(Vec<u8>, u32, u32, u32)> {
     use std::mem;
     use windows_sys::Win32::{
@@ -137,6 +139,7 @@ fn capture_printwindow() -> Option<(Vec<u8>, u32, u32, u32)> {
 /// Capture the Warframe window using PrintWindow and return raw BGRA pixels + dimensions.
 /// Single capture can be reused for multiple OCR regions via `ocr_pixels_rect`.
 #[cfg(target_os = "windows")]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn capture_warframe_pixels() -> Result<(Vec<u8>, u32, u32), String> {
     use std::mem;
     use windows_sys::Win32::{
@@ -396,6 +399,7 @@ fn capture_screen_gdi_scaled(num: u32, denom: u32) -> Option<(Vec<u8>, u32, u32)
 /// for any number of monitors, any primary/secondary arrangement, and any resolution.
 /// Falls back to the primary monitor if the Warframe window can't be found.
 #[cfg(target_os = "windows")]
+#[tracing::instrument(level = "debug", skip_all)]
 fn capture_dxgi(cap_frac: f32) -> Option<(Vec<u8>, u32, u32, u32)> {
     use windows::core::Interface; // required for .cast() on COM types
     use windows::Win32::Graphics::{
@@ -572,6 +576,7 @@ pub fn to_bmp(pixels_bgra: &[u8], width: u32, height: u32) -> Vec<u8> {
 /// Run Windows.Media.Ocr on a BMP. Returns (full_text, line_positions).
 /// line_positions: Vec<(line_text, x_frac)> — X centre per line from word bounding rects.
 #[cfg(target_os = "windows")]
+#[tracing::instrument(level = "info", skip_all)]
 pub fn run_windows_ocr(bmp: Vec<u8>, img_w: u32, img_h: u32) -> Result<(String, Vec<(String, f32, f32)>), String> {
     // Ensure COM is initialized for this thread. Tokio spawn_blocking threads
     // start without a COM apartment; WinRT calls fail or return empty silently.

--- a/src-tauri/src/wfcd.rs
+++ b/src-tauri/src/wfcd.rs
@@ -79,6 +79,7 @@ pub struct FetchResult {
 /// Fetch the complete list of relic reward display names from the Warframe Wiki's
 /// Module:Void Lua table via the MediaWiki API.
 /// Returns a set of lower-cased names like "xaku prime neuroptics blueprint".
+#[tracing::instrument(level = "debug", skip_all)]
 fn fetch_wiki_reward_names() -> HashSet<String> {
     let mut names: HashSet<String> = HashSet::new();
 
@@ -213,6 +214,7 @@ struct ExportRecipe {
 
 /// Fetch ExportRecipes from warframe-public-export-plus (stable URL, pre-processed, always current).
 /// Returns a map from resultType (= what gets crafted) → ExportRecipe.
+#[tracing::instrument(level = "debug", skip_all)]
 fn fetch_export_recipes() -> Result<HashMap<String, ExportRecipe>, String> {
     // Try two URLs: the warframe-public-export-plus repo (pre-processed) and a fallback
     let urls = [
@@ -264,6 +266,7 @@ fn fetch_export_recipes() -> Result<HashMap<String, ExportRecipe>, String> {
 /// Fetch complete syndicate store catalog from warframe-drop-data/syndicates.json.
 /// This covers all vendor-purchased items: sigils, specters, health restores,
 /// weapon blueprints, augment mods — items that WFCD's `drops` field mostly omits.
+#[tracing::instrument(level = "debug", skip_all)]
 fn fetch_syndicate_store_catalog(items: &[WfcdItem]) -> HashMap<String, Vec<SyndicateOffer>> {
     const URL: &str =
         "https://raw.githubusercontent.com/WFCD/warframe-drop-data/gh-pages/data/syndicates.json";
@@ -546,6 +549,7 @@ fn wfcd_category_to_display(wfcd_cat: &str) -> &'static str {
 /// Fetch relic → reward mappings from WFCD Relics.json.
 /// Each entry is one specific refinement (Bronze/Silver/Gold/Platinum) with a
 /// uniqueName that matches the EE.log path exactly — no normalization needed.
+#[tracing::instrument(level = "debug", skip_all)]
 fn fetch_relics_rewards(image_by_name: &HashMap<String, String>) -> HashMap<String, Vec<RelicReward>> {
     const URL: &str =
         "https://raw.githubusercontent.com/WFCD/warframe-items/master/data/json/Relics.json";
@@ -610,6 +614,7 @@ fn fetch_relics_rewards(image_by_name: &HashMap<String, String>) -> HashMap<Stri
     result
 }
 
+#[tracing::instrument(level = "debug", skip_all)]
 fn fetch_from_wfcd() -> Result<FetchResult, String> {
     let mut items: Vec<WfcdItem> = Vec::new();
     let mut seen: HashSet<String> = HashSet::new();

--- a/src-tauri/src/wfcd.rs
+++ b/src-tauri/src/wfcd.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use tracing::warn;
 use std::io::{Cursor, Read};
 
 #[derive(Clone, Debug)]
@@ -275,7 +276,7 @@ fn fetch_syndicate_store_catalog(items: &[WfcdItem]) -> HashMap<String, Vec<Synd
     {
         Some(v) => v,
         None => {
-            eprintln!("[syndicate] failed to fetch syndicates.json");
+            warn!("failed to fetch syndicates.json");
             return HashMap::new();
         }
     };
@@ -555,7 +556,7 @@ fn fetch_relics_rewards(image_by_name: &HashMap<String, String>) -> HashMap<Stri
     {
         Some(v) => v,
         None => {
-            eprintln!("[relic_rewards] failed to fetch Relics.json");
+            warn!("failed to fetch Relics.json");
             return HashMap::new();
         }
     };


### PR DESCRIPTION
# feat(logging): route diagnostics through tracing with a rolling file sink

Three commits, meant to be reviewed in order: subscriber, then the mechanical
`eprintln!` sweep, then the spans. If you want the first and not the rest, the
first stands alone.

**The problem, stated narrowly.** There are 40 `eprintln!`/`println!` diagnostics
across `lib.rs`, `memory_scanner.rs` and `wfcd.rs`. They go to stderr, which a
packaged Tauri app does not have, so in the field they go nowhere. They are also
all-or-nothing: there is no way to ask a user for scanner detail without asking for
everything.

**What this is not.** You already have file logging: `append_to_file` /
`append_to_diag`, 35 call sites, writing `%TEMP%\frameforge_riven_session.txt` and
the per-session `diagnostics/` tree. This change does not touch any of it. I
considered folding it in and decided against it. That trail is what you debug riven
OCR with, its format is presumably load-bearing for you, and I cannot run the
Windows path to check I had not made your debugging worse. So the two coexist after
this PR, which is a real wart and worth saying out loud rather than leaving for you
to notice. Unifying them is a separate conversation, and yours to start.

**What lands.**

1. `feat(logging): add a tracing subscriber with a rolling file sink`. New
   `src-tauri/src/logging.rs` (93 lines), four dependencies, `mod logging;`, and a
   `logging::init(app.handle())` at the top of `setup`. Two sinks: stderr as
   before, and a daily-rolling file in the platform log dir (`app_log_dir()`, Tauri's
   own resolver) keeping five files. Both filtered by `RUST_LOG`. A panic hook
   records panics with location before delegating to the previous hook, and
   `tracing_log::LogTracer` captures anything logging through the `log` crate.
   Writing is non-blocking so the scanner and OCR loops never stall on disk.
2. `refactor(logging): replace eprintln diagnostics with tracing macros`, the
   mechanical sweep. Levels follow intent: `info!` for results and state changes,
   `debug!` for per-cycle detail, `warn!` for dropped scans and failed fetches,
   `error!` where data is lost. Values formatted into messages become structured
   fields. This commit is boring by design and should read at a glance.
3. `feat(logging): instrument the scan, OCR and market paths`. Spans on the
   capture, OCR, blob-parse and fetch entry points; the subscriber emits span-close
   events carrying `time.busy` / `time.idle`, so the log records how long each
   stage took. warframe.market needed a small shape change to be timeable at all:
   every site built a request with `wfm_request` and issued the call itself, so a
   span on the builder would have timed struct construction. Two helpers,
   `wfm_call` and `wfm_send_json`, wrap request and call together; 15 sites route
   through them. Two of those were `.send_string(&body.to_string())` and are now
   `wfm_send_json(..., &body)`, the same bytes on the wire, since the body was
   already a `serde_json::Value`.

**Dependencies.** Four: `tracing`, `tracing-appender`, `tracing-log`,
`tracing-subscriber` (with `env-filter`). All MIT/Apache-2.0. `Cargo.lock` grows by
101 lines and nothing existing is bumped. I updated it surgically rather than
regenerating, because a full `cargo generate-lockfile` on my machine rewrites 1,800
lines and drags in `dbus` and `objc2` entries from my platform. Worth a sanity check
on your side that the lock still resolves the same for you.

**Verification.**

- `memory_scanner.rs` conversions: the scanner tests run on Linux (7 passed) and
  the Windows arm type-checks under `--target x86_64-pc-windows-gnu`. That covers
  the file with the most conversions.
- `lib.rs`, `wfcd.rs`, `ocr.rs`: not compiled. Those files do not build on Linux
  (Win32 memory APIs, WinRT OCR), and I have no MSVC linker here. The conversions
  are mechanical and mostly one-line, but "mechanical" is not "compiled" and you
  should expect to fix at least a stray format-argument mismatch.
- `logging.rs` itself has never run. `app_log_dir()` resolves on Windows by
  contract, not by my having watched it.
- I develop on Linux. None of this has been executed on your platform.

**If you reimplement this rather than taking the commits, the load-bearing parts are:**

1. The `WorkerGuard` must outlive the process. `tracing_appender::non_blocking`
   returns a guard whose drop flushes the buffer; dropping it at the end of `init`
   means the last events, including the panic that made you look, never reach
   disk. That is why it goes in a `OnceLock`.
2. The panic hook must delegate to the previous hook. Replacing it outright
   loses the default backtrace behaviour.
3. `init` must be idempotent. It is called from `setup`, and a second global
   subscriber install would otherwise panic or silently no-op depending on order.
4. The file sink and console sink need separate filters. A single filter forces
   the file to be as quiet as the console, which defeats the point: the file wants
   `debug`, the console wants `info`.
5. If you keep the spans, keep `FmtSpan::CLOSE`. Without it the spans are
   structure with no timings, which is most of what they are for.
6. Instrument `wfm_call`, not `wfm_request`. Timing the builder measures nothing.
