### PR TITLE
perf(monitor): probe the cached blob instead of walking every 10 s

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4831,6 +4831,7 @@ dependencies = [
  "chrono",
  "dirs 5.0.1",
  "lzma-rs",
+ "memchr",
  "native-tls",
  "regex",
  "rusqlite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,7 @@ tungstenite = { version = "0.26", features = ["native-tls"] }
 native-tls = "0.2"
 whirlpool = "0.10"
 lzma-rs = "0.3"
+memchr = "2"
 
 [profile.dev]
 opt-level = 1

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4264,14 +4264,6 @@ async fn dump_memory_probe(state: State<'_, AppState>) -> Result<String, String>
     Ok(output)
 }
 
-/// Toggle the continuous raw memory string-dump.
-/// One-shot manual capture of the full inventory JSON blob.
-#[tauri::command]
-fn capture_inventory_blob(state: State<'_, AppState>) -> Result<String, String> {
-    let path = state.raw_scan_path.with_file_name("inventory_blob.txt");
-    memory_scanner::capture_inventory_blob(&path)
-}
-
 /// Enable or disable automatic per-pass inventory blob logging to blobs/.
 #[tauri::command]
 fn set_blob_log(enabled: bool, state: State<'_, AppState>) {
@@ -8535,7 +8527,6 @@ pub fn run() {
             log_api_changes,
             dump_memory_probe,
             toggle_raw_scan,
-            capture_inventory_blob,
             set_blob_log,
             set_api_log,
             get_app_version,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -64,6 +64,11 @@ pub struct AppState {
     /// Controls the raw memory string-dump background thread.
     pub raw_scan_active: Arc<AtomicBool>,
     pub raw_scan_path: PathBuf,
+    /// Set by the EE.log tail when Warframe reports finishing an inventory
+    /// refresh; cleared by the monitor loop when it acts on it. A bool rather
+    /// than a count because the game flushes its log in bursts, so several
+    /// markers can land at once and all of them call for the same single walk.
+    pub blob_sync_pending: Arc<AtomicBool>,
     /// When true, save a timestamped inventory blob to blobs/ on each full scan pass.
     pub blob_log_enabled: Arc<AtomicBool>,
     pub blob_log_dir: PathBuf,
@@ -2852,6 +2857,12 @@ fn start_log_watcher(app: tauri::AppHandle) -> Result<(), String> {
         .map(|d| d.join("Warframe").join("EE.log"))
         .ok_or("Cannot find LocalAppData")?;
 
+    // Second source for the inventory-sync marker, and the slower of the two:
+    // the tail only sees a line once Warframe flushes it. With no EE.log at all
+    // the monitor still escalates on its own interval, so a missing tail costs
+    // latency rather than correctness.
+    let blob_sync_pending = app.state::<AppState>().blob_sync_pending.clone();
+
     std::thread::spawn(move || {
         use std::io::{Read, Seek, SeekFrom};
         let mut file_pos: u64 = std::fs::metadata(&log_path).map(|m| m.len()).unwrap_or(0);
@@ -2891,6 +2902,12 @@ fn start_log_watcher(app: tauri::AppHandle) -> Result<(), String> {
             if f.read_to_string(&mut buf).is_err() { continue; }
             file_pos = len;
             if buf.is_empty() { continue; }
+            // Separates "the game fetched inventory" from "some unrelated
+            // allocation moved". The monitor uses it to decide whether a cache
+            // miss is worth a full memory walk.
+            if buf.contains(memory_scanner::INVENTORY_SYNC_MARKER) {
+                blob_sync_pending.store(true, Ordering::SeqCst);
+            }
             let lower = buf.to_lowercase();
 
             // ── Riven reroll / unveil ─────────────────────────────────────────
@@ -4387,6 +4404,51 @@ pub struct InventoryUpdate {
     pub player_name: Option<String>,
 }
 
+/// Floor on walk frequency, inherited from the fixed cadence this policy
+/// replaced: whatever the probe reports, walking is never worth doing faster.
+const WALK_MIN_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
+/// A client with no blob found yet is usually at the login screen. The marker
+/// ends that wait as soon as the inventory arrives, so this interval only
+/// applies when no marker reaches us at all.
+const WALK_COLD_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+/// Covers the state a probe cannot detect: the game reallocates the blob but
+/// the old address still holds a parseable copy of the old bytes, so every
+/// probe answers "unchanged". That is rare and a walk costs the player frames,
+/// hence the long interval.
+const WALK_MAX_INTERVAL: std::time::Duration = std::time::Duration::from_secs(900);
+/// Nothing changes the inventory without a sync, and a sync is always logged,
+/// so this only covers syncs that both marker sources missed. Kept below
+/// [`WALK_MAX_INTERVAL`] so the walk intervals still get evaluated on their own
+/// schedule.
+const BLOB_PROBE_FALLBACK: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Whether a full region walk is worth its cost this tick.
+///
+/// A walk reads gigabytes and drops the player's framerate, so most of these
+/// rules exist to skip walks that cannot find anything new.
+///
+/// None of this depends on the marker for correctness. Every case has an
+/// interval that fires without one, so a missing EE.log or an unlocatable log
+/// buffer costs only latency.
+fn walk_is_due(
+    outcome: &memory_scanner::ScanOutcome,
+    sync_seen: bool,
+    has_cached_blob: bool,
+    since_walk: std::time::Duration,
+) -> bool {
+    use memory_scanner::ScanOutcome;
+    match outcome {
+        ScanOutcome::Updated => false,
+        ScanOutcome::CacheMiss if sync_seen => true,
+        ScanOutcome::CacheMiss if has_cached_blob => since_walk >= WALK_MIN_INTERVAL,
+        // A sync that moved nothing looks identical to a stale address still
+        // holding the old bytes, and the probe cannot tell them apart.
+        ScanOutcome::Unchanged if sync_seen => since_walk >= WALK_MIN_INTERVAL,
+        ScanOutcome::CacheMiss => since_walk >= WALK_COLD_INTERVAL,
+        ScanOutcome::Unchanged => since_walk >= WALK_MAX_INTERVAL,
+    }
+}
+
 #[tauri::command]
 async fn start_monitor(app: tauri::AppHandle, state: State<'_, AppState>) -> Result<(), String> {
     if state.monitor_active.swap(true, Ordering::SeqCst) {
@@ -4471,6 +4533,7 @@ async fn start_monitor(app: tauri::AppHandle, state: State<'_, AppState>) -> Res
     let shared_crafting      = state.current_crafting.clone();
     let blob_log_enabled     = state.blob_log_enabled.clone();
     let blob_log_dir         = state.blob_log_dir.clone();
+    let blob_sync_pending    = state.blob_sync_pending.clone();
     let reward_app = app.clone();  // clone before app is moved into the inventory thread
 
     // Channel for the blob capture thread to deliver a parsed BlobInventory to the monitor loop.
@@ -4590,7 +4653,11 @@ async fn start_monitor(app: tauri::AppHandle, state: State<'_, AppState>) -> Res
             .filter(|(_, v)| !v.archon_shards.is_empty())
             .map(|(k, v)| (k.clone(), v.archon_shards.clone()))
             .collect();
-        let mut last_blob_time: Option<std::time::Instant> = None;
+        // last_probe_time paces the probe itself; last_blob_probe is the last
+        // probe that got as far as re-reading the blob, which most do not.
+        let mut last_walk_time: Option<std::time::Instant> = None;
+        let mut last_probe_time: Option<std::time::Instant> = None;
+        let mut last_blob_probe: Option<std::time::Instant> = None;
         // Guard against overlapping captures: a full memory walk can take >10 s on large
         // game processes, so without this flag we'd stack up concurrent scan threads.
         let blob_scan_active = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -4795,9 +4862,6 @@ async fn start_monitor(app: tauri::AppHandle, state: State<'_, AppState>) -> Res
                 }
             }
 
-            // Periodic blob capture every 10s while game is running.
-            // blob_scan_active prevents overlapping captures — a full memory walk on a
-            // large game process can exceed 10 s, so without the guard we'd stack threads.
             // Re-enumerate processes at most every 5 s (CreateToolhelp32Snapshot overhead).
             let needs_pid_check = last_pid_check
                 .map_or(true, |t: std::time::Instant| t.elapsed().as_secs() >= 5);
@@ -4808,6 +4872,7 @@ async fn start_monitor(app: tauri::AppHandle, state: State<'_, AppState>) -> Res
                     if current_pid.is_some() {
                         eprintln!("[monitor] Warframe PID changed ({:?} → {:?}), clearing blob region cache", last_pid, current_pid);
                         memory_scanner::reset_last_blob_region();
+                        memory_scanner::reset_log_region();
                     }
                     last_pid = current_pid;
                 }
@@ -4815,12 +4880,67 @@ async fn start_monitor(app: tauri::AppHandle, state: State<'_, AppState>) -> Res
             }
             let game_running = cached_game_running;
             if game_running {
-                let should_capture = last_blob_time
-                    .map_or(true, |t: std::time::Instant| t.elapsed() >= std::time::Duration::from_secs(10));
-                let already_running = blob_scan_active.load(Ordering::SeqCst);
-                if should_capture && !already_running {
+                // ── Blob capture: cheap probe, rate-limited walk ──────────────
+                // The marker is read at this cadence; re-reading the blob is
+                // gated separately, on BLOB_PROBE_FALLBACK below.
+                const PROBE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
+                let walk_in_flight = blob_scan_active.load(Ordering::SeqCst);
+                let probe_due = last_probe_time
+                    .map_or(true, |t: std::time::Instant| t.elapsed() >= PROBE_INTERVAL);
+
+                // Probes run inline, so one must never start behind a walk that
+                // is already reading the same process.
+                let mut should_capture = false;
+                if probe_due && !walk_in_flight {
+                    last_probe_time = Some(std::time::Instant::now());
+                    let stitch_due = last_blob_probe
+                        .map_or(true, |t: std::time::Instant| t.elapsed() >= BLOB_PROBE_FALLBACK)
+                        || blob_sync_pending.load(Ordering::SeqCst)
+                        || !memory_scanner::has_cached_blob();
+                    let (outcome, sync_marker) = match last_pid {
+                        Some(pid) => memory_scanner::probe_tick(pid, blob_tx.clone(), stitch_due),
+                        None => (None, false),
+                    };
+                    if outcome.is_some() {
+                        last_blob_probe = Some(std::time::Instant::now());
+                    }
+                    // The memory probe reports each marker exactly once, so it
+                    // has to be folded into the held flag rather than read
+                    // beside it. Otherwise a marker arriving on a tick that
+                    // cannot act on it is lost.
+                    if sync_marker {
+                        blob_sync_pending.store(true, Ordering::SeqCst);
+                    }
+                    let sync_seen = blob_sync_pending.load(Ordering::SeqCst);
+                    let blob_known = memory_scanner::has_cached_blob();
+                    let since_walk = last_walk_time
+                        .map_or(std::time::Duration::MAX, |t: std::time::Instant| t.elapsed());
+                    // A tick that did not re-read the blob has no fresh evidence
+                    // to escalate on, and the marker that would justify a walk
+                    // is exactly what makes the probe run in the first place.
+                    should_capture = outcome
+                        .as_ref()
+                        .is_some_and(|outcome| walk_is_due(outcome, sync_seen, blob_known, since_walk));
+                    // A marker dropped while the rate limit says "not yet" is
+                    // never revisited, so it is only cleared once something has
+                    // acted on it.
+                    if should_capture || outcome == Some(memory_scanner::ScanOutcome::Updated) {
+                        blob_sync_pending.store(false, Ordering::SeqCst);
+                    }
+                    if should_capture {
+                        let since = match last_walk_time {
+                            Some(t) => format!("{:.1}s", t.elapsed().as_secs_f64()),
+                            None => "never".into(),
+                        };
+                        eprintln!("[monitor] escalating to full walk (outcome={:?} sync_marker={} blob_known={} since_last_walk={})",
+                            outcome, sync_seen, blob_known, since);
+                    }
+                }
+
+                if should_capture {
                     blob_scan_active.store(true, Ordering::SeqCst);
-                    last_blob_time = Some(std::time::Instant::now());
+                    last_walk_time = Some(std::time::Instant::now());
                     let ts     = chrono::Utc::now().format("%Y-%m-%dT%H-%M-%S").to_string();
                     let dir    = blob_log_dir.clone();
                     let tx     = blob_tx.clone();
@@ -8397,6 +8517,7 @@ pub fn run() {
             monitor_active: Arc::new(AtomicBool::new(false)),
             raw_scan_active: Arc::new(AtomicBool::new(false)),
             raw_scan_path,
+            blob_sync_pending: Arc::new(AtomicBool::new(false)),
             blob_log_enabled: Arc::new(AtomicBool::new(false)),
             blob_log_dir,
             api_log_enabled: Arc::new(AtomicBool::new(false)),
@@ -8826,5 +8947,72 @@ MR 11
                 "-25.4% Ammo Maximum",
             ]
         );
+    }
+}
+
+#[cfg(test)]
+mod walk_policy_tests {
+    use super::{walk_is_due, WALK_COLD_INTERVAL, WALK_MAX_INTERVAL, WALK_MIN_INTERVAL};
+    use crate::memory_scanner::ScanOutcome;
+    use std::time::Duration;
+
+    /// At the login screen no blob has ever been found, and re-checking that
+    /// every WALK_MIN_INTERVAL reads gigabytes and costs the player frames for
+    /// seconds at a time.
+    #[test]
+    fn a_client_with_no_blob_yet_waits_for_the_backstop() {
+        let just_walked = WALK_MIN_INTERVAL + Duration::from_secs(1);
+        assert!(!walk_is_due(&ScanOutcome::CacheMiss, false, false, just_walked));
+        assert!(walk_is_due(&ScanOutcome::CacheMiss, false, false, WALK_COLD_INTERVAL));
+    }
+
+    /// A settled inventory answers "unchanged" every couple of seconds for as
+    /// long as the player stays docked, so walking gigabytes each minute to
+    /// check it again is wasted work.
+    #[test]
+    fn a_settled_inventory_does_not_walk_on_the_minute() {
+        assert!(!walk_is_due(&ScanOutcome::Unchanged, false, true, Duration::from_secs(60)));
+        assert!(!walk_is_due(&ScanOutcome::Unchanged, false, true, Duration::from_secs(300)));
+        assert!(walk_is_due(&ScanOutcome::Unchanged, false, true, WALK_MAX_INTERVAL));
+    }
+
+    /// The client announced a fetch and our copy did not move. Usually a sync
+    /// with no delta, but it is also what a stale address holding the old bytes
+    /// looks like, which the probe cannot distinguish.
+    #[test]
+    fn an_unchanged_probe_with_a_marker_still_walks() {
+        assert!(walk_is_due(&ScanOutcome::Unchanged, true, true, WALK_MIN_INTERVAL));
+        assert!(!walk_is_due(&ScanOutcome::Unchanged, true, true, Duration::from_secs(3)));
+    }
+
+    /// The probe already delivered the new inventory, so a walk would read
+    /// gigabytes to produce what the monitor already has.
+    #[test]
+    fn a_fresh_parse_never_escalates() {
+        assert!(!walk_is_due(&ScanOutcome::Updated, true, true, Duration::MAX));
+    }
+
+    /// Once a blob is known, a miss plausibly means the game reallocated it
+    /// because the inventory changed, which is worth checking at the old
+    /// cadence.
+    #[test]
+    fn a_miss_on_a_known_blob_keeps_the_old_cadence() {
+        assert!(walk_is_due(&ScanOutcome::CacheMiss, false, true, WALK_MIN_INTERVAL));
+        assert!(!walk_is_due(&ScanOutcome::CacheMiss, false, true, Duration::from_secs(4)));
+    }
+
+    /// The marker resolves the ambiguity, including at the login screen where
+    /// the first sync arrives.
+    #[test]
+    fn a_sync_marker_escalates_immediately() {
+        assert!(walk_is_due(&ScanOutcome::CacheMiss, true, false, Duration::ZERO));
+        assert!(walk_is_due(&ScanOutcome::CacheMiss, true, true, Duration::ZERO));
+    }
+
+    /// The first tick after the game appears has no previous walk to rate-limit
+    /// against, so the app still gets one immediately at startup.
+    #[test]
+    fn the_first_walk_is_never_delayed() {
+        assert!(walk_is_due(&ScanOutcome::CacheMiss, false, false, Duration::MAX));
     }
 }

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -827,8 +827,15 @@ fn forget_blob_digest() {
 /// Returns true when `json` is byte-identical to what the previous call saw.
 fn blob_unchanged(json: &[u8]) -> bool {
     use std::hash::{DefaultHasher, Hash, Hasher};
+    // Callers hand over a stitched buffer, not a trimmed blob. The stitch stops
+    // at the region that closes the JSON, so everything past the closing brace
+    // is whatever heap shared that region, tens of megabytes of it, rewritten
+    // constantly by a running client. Hash that tail and the digest never
+    // matches, so every scan reparses and the skip never happens. Bytes with no
+    // blob end are hashed whole; they only need to compare equal to themselves.
+    let blob = &json[..find_blob_end(json).unwrap_or(json.len())];
     let mut hasher = DefaultHasher::new();
-    json.hash(&mut hasher);
+    blob.hash(&mut hasher);
     // OR in a set bit so a hashed digest can never equal the 0 sentinel that
     // reset_last_blob_region stores — that sentinel must always compare as
     // "changed" to force a re-parse after a PID change.
@@ -1547,11 +1554,15 @@ mod seed_tests {
 mod blob_digest_tests {
     use super::{blob_unchanged, forget_blob_digest, reset_last_blob_region};
 
-    // LAST_BLOB_DIGEST is a process-global static shared with every other
-    // test in this binary, so each case resets it first and runs its
-    // assertions in one #[test] rather than relying on test isolation.
+    // LAST_BLOB_DIGEST is a process-global static shared with every other test
+    // in this binary. Resetting first is not enough on its own: these cases run
+    // in parallel, so one can land its own digest write between another's reset
+    // and its assertions. Taking this lock keeps them off each other.
+    static DIGEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn digest_tracks_changes_and_resets() {
+        let _guard = DIGEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         reset_last_blob_region();
 
         let blob = b"{\"SubscribedToEmails\":1,\"RegularCredits\":100}".to_vec();
@@ -1567,11 +1578,31 @@ mod blob_digest_tests {
         assert!(!blob_unchanged(&mutated), "reset forces the next call to report changed");
     }
 
+    // The scan stitches whole regions, so the blob arrives with a tail of
+    // unrelated heap that a running client rewrites between cycles. Digesting
+    // that tail is indistinguishable from the inventory itself changing, which
+    // reparses a settled inventory on every cycle.
+    #[test]
+    fn a_rewritten_tail_after_the_blob_is_not_a_change() {
+        let _guard = DIGEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_last_blob_region();
+
+        let blob = br#"{"SubscribedToEmails":1,"DeathSquadable":false}"#;
+        let mut first = blob.to_vec();
+        first.extend_from_slice(b"\x00\x11garbage from a neighbouring allocation");
+        let mut second = blob.to_vec();
+        second.extend_from_slice(b"\xff\xfe an entirely different neighbour, and longer");
+
+        assert!(!blob_unchanged(&first), "first sighting reports changed");
+        assert!(blob_unchanged(&second), "same blob, different tail, is unchanged");
+    }
+
     // Unparseable bytes that persist across scan cycles must not start
     // reporting as unchanged — the skip paths read that as "already parsed
     // this", which would wedge the walk on a region that never parsed.
     #[test]
     fn forgetting_after_a_failed_parse_forces_a_retry() {
+        let _guard = DIGEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         reset_last_blob_region();
 
         let garbage = b"{\"MiscItems\":[ truncated".to_vec();

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -385,10 +385,10 @@ pub fn dump_inventory_regions(_max_hits: usize) -> Vec<String> {
 /// the `}` that immediately follows its boolean value (true or false).
 fn find_blob_end(raw: &[u8]) -> Option<usize> {
     const KEY: &[u8] = b"\"DeathSquadable\":";
-    let key_pos = raw.windows(KEY.len()).position(|w| w == KEY)?;
+    let key_pos = memmem::find(raw, KEY)?;
     let after   = key_pos + KEY.len();
     // Skip the boolean value and find the closing brace
-    let brace = raw[after..].iter().position(|&b| b == b'}')?;
+    let brace = memchr::memchr(b'}', &raw[after..])?;
     Some(after + brace + 1)
 }
 
@@ -422,10 +422,8 @@ fn enclosing_object_start(buf: &[u8], marker_off: usize) -> Option<usize> {
 ///   - `marker_off`: byte position of the first known start marker
 ///   - `json_open`:  byte position of the outermost `{` enclosing the marker
 fn blob_seed_offsets(buf: &[u8]) -> (usize, usize) {
-    let marker_off = buf.windows(START_MARKER.len())
-        .position(|w| w == START_MARKER)
-        .or_else(|| ALT_STARTS.iter().find_map(|a|
-            buf.windows(a.len()).position(|w| w == *a)))
+    let marker_off = memmem::find(buf, START_MARKER)
+        .or_else(|| ALT_STARTS.iter().find_map(|a| memmem::find(buf, a)))
         .unwrap_or(buf.len().saturating_sub(1));
     let json_open = enclosing_object_start(buf, marker_off).unwrap_or(marker_off);
     (marker_off, json_open)
@@ -499,8 +497,7 @@ pub fn extract_blob_json(raw: &[u8]) -> Option<Vec<u8>> {
     if raw.first() == Some(&b'{') {
         Some(raw[..end_pos].to_vec())
     } else {
-        const START: &[u8] = b"\"SubscribedToEmails\"";
-        let start_pos = raw.windows(START.len()).position(|w| w == START)?;
+        let start_pos = memmem::find(raw, START_MARKER)?;
         let mut v = Vec::with_capacity(end_pos - start_pos + 1);
         v.push(b'{');
         v.extend_from_slice(&raw[start_pos..end_pos]);
@@ -1403,7 +1400,8 @@ mod seed_tests {
         let buf = b"{\"SubscribedToEmails\":1,\"RegularCredits\":100}";
         let (marker_off, json_open) = blob_seed_offsets(buf);
         assert_eq!(json_open, 0);
-        assert!(marker_off > 0);
+        // Both markers are present; the primary one must win over the alt-start.
+        assert_eq!(marker_off, 1);
     }
 
     #[test]
@@ -1433,6 +1431,18 @@ mod seed_tests {
 
         let json = extract_blob_json(&raw).expect("end marker present");
         assert_eq!(json.len(), blob_len);
+        assert!(serde_json::from_slice::<serde_json::Value>(&json).is_ok());
+    }
+
+    #[test]
+    fn blob_json_reinstates_the_opening_brace_when_it_was_overwritten() {
+        let mut raw = br#"x"SubscribedToEmails":0,"DeathSquadable":false}"#.to_vec();
+        let blob_len = raw.len();
+        raw.extend(std::iter::repeat(0xABu8).take(1024));
+
+        let json = extract_blob_json(&raw).expect("end marker present");
+        assert_eq!(json.len(), blob_len);
+        assert_eq!(json[0], b'{');
         assert!(serde_json::from_slice::<serde_json::Value>(&json).is_ok());
     }
 }

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -1,5 +1,6 @@
 ﻿use memchr::memmem;
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -493,15 +494,30 @@ pub fn compute_riven_mod_name(buffs: &[BlobRivenStat]) -> String {
 /// final region — potentially tens of megabytes of noise. This trims to just
 /// the valid JSON object so both the parser and the debug dump files see clean data.
 pub fn extract_blob_json(raw: &[u8]) -> Option<Vec<u8>> {
+    extract_blob_json_ref(raw).map(Cow::into_owned)
+}
+
+/// Borrowing counterpart of [`extract_blob_json`]. The common case (buffer still
+/// starts with the original `{`) needs no copy at all; only the fallback path,
+/// where the opening brace was overwritten in memory and has to be reinstated,
+/// allocates.
+pub fn extract_blob_json_ref(raw: &[u8]) -> Option<Cow<'_, [u8]>> {
     let end_pos = find_blob_end(raw)?;
+    extract_blob_json_at(raw, end_pos)
+}
+
+/// Same as [`extract_blob_json_ref`] but takes an already-known `end_pos`, so
+/// callers that located the blob end for their own purposes (e.g. the
+/// minimum-size check in [`parse_full_account_blob`]) don't pay for a second scan.
+fn extract_blob_json_at(raw: &[u8], end_pos: usize) -> Option<Cow<'_, [u8]>> {
     if raw.first() == Some(&b'{') {
-        Some(raw[..end_pos].to_vec())
+        Some(Cow::Borrowed(&raw[..end_pos]))
     } else {
         let start_pos = memmem::find(raw, START_MARKER)?;
         let mut v = Vec::with_capacity(end_pos - start_pos + 1);
         v.push(b'{');
         v.extend_from_slice(&raw[start_pos..end_pos]);
-        Some(v)
+        Some(Cow::Owned(v))
     }
 }
 
@@ -518,7 +534,7 @@ pub fn parse_full_account_blob(raw: &[u8]) -> Option<BlobInventory> {
         return None;
     }
 
-    let json_bytes = extract_blob_json(raw)?;
+    let json_bytes = extract_blob_json_at(raw, end_pos)?;
 
     let json: serde_json::Value = serde_json::from_slice(&json_bytes)
         .map_err(|e| {
@@ -1440,7 +1456,8 @@ fn find_warframe_pid() -> Option<u32> {
 
 #[cfg(test)]
 mod seed_tests {
-    use super::{enclosing_object_start, blob_seed_offsets, extract_blob_json};
+    use super::{enclosing_object_start, blob_seed_offsets, extract_blob_json, extract_blob_json_ref};
+    use std::borrow::Cow;
 
     #[test]
     fn enclosing_finds_outer_brace() {
@@ -1514,6 +1531,15 @@ mod seed_tests {
         assert_eq!(json.len(), blob_len);
         assert_eq!(json[0], b'{');
         assert!(serde_json::from_slice::<serde_json::Value>(&json).is_ok());
+    }
+
+    #[test]
+    fn blob_json_ref_borrows_in_the_common_case_and_owns_in_the_fallback() {
+        let intact = br#"{"SubscribedToEmails":0,"DeathSquadable":false}"#;
+        assert!(matches!(extract_blob_json_ref(intact), Some(Cow::Borrowed(_))));
+
+        let overwritten = br#"x"SubscribedToEmails":0,"DeathSquadable":false}"#;
+        assert!(matches!(extract_blob_json_ref(overwritten), Some(Cow::Owned(_))));
     }
 }
 

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -1,4 +1,5 @@
-﻿use serde::{Deserialize, Serialize};
+﻿use memchr::memmem;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -178,26 +179,19 @@ pub fn scan_auth_credentials(data: &[u8]) -> Option<(String, String)> {
     // Search for "id":"<24hexchars>" near "Nonce":<digits>
     let id_key = b"\"id\":\"";
     let nonce_key = b"\"Nonce\":";
-    let mut search = 0usize;
-    while search + id_key.len() < data.len() {
-        let next = match data[search..].iter().position(|&b| b == b'"') {
-            Some(p) => search + p, None => break,
-        };
-        if next + id_key.len() > data.len() { break; }
-        if data[next..next + id_key.len()] != *id_key { search = next + 1; continue; }
-
+    for next in memmem::find_iter(data, id_key) {
         let id_start = next + id_key.len();
         // accountId is exactly 24 lowercase hex chars
         let id_slice = &data[id_start..id_start.saturating_add(26).min(data.len())];
         let close = id_slice.iter().position(|&b| b == b'"').unwrap_or(0);
-        if close != 24 { search = next + 1; continue; }
+        if close != 24 { continue; }
         let id_bytes = &id_slice[..24];
-        if !id_bytes.iter().all(|&b| b.is_ascii_hexdigit()) { search = next + 1; continue; }
+        if !id_bytes.iter().all(|&b| b.is_ascii_hexdigit()) { continue; }
         let account_id = std::str::from_utf8(id_bytes).unwrap_or("").to_string();
 
         // Look for Nonce within 2048 bytes
         let nonce_search_end = (id_start + 2048).min(data.len());
-        if let Some(rel) = data[id_start..nonce_search_end].windows(nonce_key.len()).position(|w| w == *nonce_key) {
+        if let Some(rel) = memmem::find(&data[id_start..nonce_search_end], nonce_key) {
             let ns = id_start + rel + nonce_key.len();
             let ne = digits_end(data, ns);
             if ne > ns && ne - ns >= 5 {
@@ -206,26 +200,19 @@ pub fn scan_auth_credentials(data: &[u8]) -> Option<(String, String)> {
                 }
             }
         }
-        search = next + 1;
     }
 
     // URL-encoded: accountId=<24hexchars>&nonce=<10digits>&ct=STM
     let ak = b"accountId=";
     let nk = b"nonce=";
-    let mut search = 0usize;
-    while search + ak.len() < data.len() {
-        let next = match data[search..].iter().position(|&b| b == b'a') {
-            Some(p) => search + p, None => break,
-        };
-        if next + ak.len() > data.len() { break; }
-        if data[next..next + ak.len()] != *ak { search = next + 1; continue; }
+    for next in memmem::find_iter(data, ak) {
         let id_start = next + ak.len();
         let id_end = data[id_start..].iter().position(|&b| !b.is_ascii_hexdigit()).map(|p| id_start + p).unwrap_or(data.len());
-        if id_end - id_start != 24 { search = next + 1; continue; }
+        if id_end - id_start != 24 { continue; }
         let account_id = std::str::from_utf8(&data[id_start..id_end]).unwrap_or("").to_string();
         // Nonce can appear anywhere within 512 bytes after the accountId
         let nonce_search_end = (id_end + 512).min(data.len());
-        if let Some(rel) = data[id_end..nonce_search_end].windows(nk.len()).position(|w| w == *nk) {
+        if let Some(rel) = memmem::find(&data[id_end..nonce_search_end], nk) {
             let ns = id_end + rel + nk.len();
             let ne = digits_end(data, ns);
             if ne > ns && ne - ns >= 5 {
@@ -234,7 +221,6 @@ pub fn scan_auth_credentials(data: &[u8]) -> Option<(String, String)> {
                 }
             }
         }
-        search = next + 1;
     }
     None
 }
@@ -242,13 +228,7 @@ pub fn scan_auth_credentials(data: &[u8]) -> Option<(String, String)> {
 /// Also extract steamId from memory (found near accountId/nonce in URL params).
 pub fn scan_steam_id(data: &[u8]) -> Option<String> {
     let key = b"steamId=";
-    let mut search = 0usize;
-    loop {
-        let next = match data[search..].iter().position(|&b| b == b's') {
-            Some(p) => search + p, None => break,
-        };
-        if next + key.len() > data.len() { break; }
-        if data[next..next + key.len()] != *key { search = next + 1; continue; }
+    for next in memmem::find_iter(data, key) {
         let id_start = next + key.len();
         let id_end = data[id_start..].iter().position(|&b| !b.is_ascii_digit()).map(|p| id_start + p).unwrap_or(data.len());
         if id_end - id_start >= 15 && id_end - id_start <= 20 {
@@ -256,7 +236,6 @@ pub fn scan_steam_id(data: &[u8]) -> Option<String> {
                 return Some(sid.to_string());
             }
         }
-        search = next + 1;
     }
     None
 }
@@ -1455,5 +1434,46 @@ mod seed_tests {
         let json = extract_blob_json(&raw).expect("end marker present");
         assert_eq!(json.len(), blob_len);
         assert!(serde_json::from_slice::<serde_json::Value>(&json).is_ok());
+    }
+}
+
+#[cfg(test)]
+mod credential_scan_tests {
+    use super::{scan_auth_credentials, scan_steam_id};
+
+    #[test]
+    fn auth_credentials_finds_json_form() {
+        let buf = br#"{"id":"594144e63ade7f2f2091c48e","Nonce":123456789}"#;
+        let (account_id, nonce) = scan_auth_credentials(buf).expect("should find credentials");
+        assert_eq!(account_id, "594144e63ade7f2f2091c48e");
+        assert_eq!(nonce, "123456789");
+    }
+
+    #[test]
+    fn auth_credentials_finds_url_encoded_form() {
+        let buf = b"accountId=594144e63ade7f2f2091c48e&nonce=123456789&ct=STM";
+        let (account_id, nonce) = scan_auth_credentials(buf).expect("should find credentials");
+        assert_eq!(account_id, "594144e63ade7f2f2091c48e");
+        assert_eq!(nonce, "123456789");
+    }
+
+    #[test]
+    fn auth_credentials_none_on_no_match() {
+        let buf = b"nothing interesting in here at all";
+        assert_eq!(scan_auth_credentials(buf), None);
+    }
+
+    #[test]
+    fn steam_id_finds_value_past_false_starts() {
+        // Leading 's' bytes are false starts for the old byte-at-a-time scanner.
+        let buf = b"ssssssssteamId=steamId=76561198012345678";
+        let sid = scan_steam_id(buf).expect("should find steam id");
+        assert_eq!(sid, "76561198012345678");
+    }
+
+    #[test]
+    fn steam_id_none_on_no_match() {
+        let buf = b"steamId=short";
+        assert_eq!(scan_steam_id(buf), None);
     }
 }

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -777,10 +777,47 @@ fn blob_extract_mod_rank(fingerprint: Option<&str>) -> u8 {
 static LAST_BLOB_REGION: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
 
+// Digest of the last blob whose bytes were about to be parsed. Inventory
+// changes maybe once per mission, so most 10s scan cycles find byte-identical
+// JSON — hashing a few MB is far cheaper than rebuilding BlobInventory's
+// HashMaps/Vecs from scratch every cycle.
+static LAST_BLOB_DIGEST: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 /// Clear the fast-path region cache. Call when Warframe's PID changes so the
 /// next scan doesn't probe a stale address from the previous process instance.
 pub fn reset_last_blob_region() {
     LAST_BLOB_REGION.store(0, std::sync::atomic::Ordering::Relaxed);
+    LAST_BLOB_DIGEST.store(0, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Discard the digest baseline so the next candidate is parsed no matter what
+/// its bytes are. Call after a parse failure: skipping a re-parse is only safe
+/// while the baseline names bytes that are known to parse, and `blob_unchanged`
+/// records its argument before the parse outcome is known.
+fn forget_blob_digest() {
+    LAST_BLOB_DIGEST.store(0, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Checks `json` against the digest recorded by the previous call, then
+/// records `json`'s digest as the new baseline — check-and-update in one
+/// step, so a caller should invoke this exactly once per candidate blob,
+/// right before deciding whether to parse it.
+///
+/// A caller that then fails to parse `json` must call `forget_blob_digest`:
+/// the skip paths treat a match as "already parsed this successfully", and
+/// unparseable bytes that persist across cycles would otherwise be mistaken
+/// for a result and suppress the rest of the walk indefinitely.
+///
+/// Returns true when `json` is byte-identical to what the previous call saw.
+fn blob_unchanged(json: &[u8]) -> bool {
+    use std::hash::{DefaultHasher, Hash, Hasher};
+    let mut hasher = DefaultHasher::new();
+    json.hash(&mut hasher);
+    // OR in a set bit so a hashed digest can never equal the 0 sentinel that
+    // reset_last_blob_region stores — that sentinel must always compare as
+    // "changed" to force a re-parse after a PID change.
+    let digest = hasher.finish() | 1;
+    LAST_BLOB_DIGEST.swap(digest, std::sync::atomic::Ordering::Relaxed) == digest
 }
 
 /// Scans Warframe process memory for the FULL_ACCOUNT inventory blob and sends it
@@ -891,6 +928,11 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
                             nb.as_mut_ptr() as *mut c_void, cap, &mut nn) } == 0 { continue; }
                         stitched.extend_from_slice(&nb[..nn]);
                     }
+                    if blob_unchanged(&stitched) {
+                        eprintln!("[blob] fast-path hit at 0x{:012x}: unchanged since last scan — skipping parse", cached_addr);
+                        unsafe { CloseHandle(process); }
+                        return 0;
+                    }
                     if let Some(inv) = parse_full_account_blob(&stitched) {
                         eprintln!("[blob] fast-path hit at 0x{:012x}: {} unique, {} stackable",
                             cached_addr, inv.unique_items.len(), inv.stackable_items.len());
@@ -898,6 +940,7 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
                         unsafe { CloseHandle(process); }
                         return 0; // fast path never saves to disk
                     }
+                    forget_blob_digest();
                 }
             }
         }
@@ -1009,6 +1052,12 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
                 .windows(END_MARKER.len())
                 .any(|w| w == END_MARKER);
             if has_end && find_blob_end(&scan.data).is_some() {
+                if !save && blob_unchanged(&scan.data) {
+                    eprintln!("[blob] scan#{} unchanged since last scan — skipping parse", scan.id);
+                    LAST_BLOB_REGION.store(scan.start_region_addr as u64, std::sync::atomic::Ordering::Relaxed);
+                    found_result = true;
+                    return false;
+                }
                 match parse_full_account_blob(&scan.data) {
                     Some(inv) => {
                         eprintln!("[blob] scan#{} SUCCESS at 0x{:012x}: {} unique, {} stackable, {} mods",
@@ -1027,6 +1076,7 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
                     }
                     None => {
                         eprintln!("[blob] scan#{} end marker found but JSON parse failed — dropped", scan.id);
+                        forget_blob_digest();
                     }
                 }
                 false // remove completed (or failed) scan
@@ -1103,7 +1153,12 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
             );
             let seed = combined[json_open..].to_vec();
 
-            if find_blob_end(&seed).is_some() {
+            let seed_ends = find_blob_end(&seed).is_some();
+            if seed_ends && !save && blob_unchanged(&seed) {
+                eprintln!("[blob] scan#{} immediate hit: unchanged since last scan — skipping parse", id);
+                LAST_BLOB_REGION.store(seed_addr as u64, std::sync::atomic::Ordering::Relaxed);
+                found_result = true;
+            } else if seed_ends {
                 match parse_full_account_blob(&seed) {
                     Some(inv) => {
                         eprintln!("[blob] scan#{} immediate SUCCESS at 0x{:012x}: {} unique, {} stackable",
@@ -1120,6 +1175,7 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
                     }
                     None => {
                         eprintln!("[blob] scan#{} immediate end found but parse failed — dropping", id);
+                        forget_blob_digest();
                     }
                 }
             } else {
@@ -1458,6 +1514,44 @@ mod seed_tests {
         assert_eq!(json.len(), blob_len);
         assert_eq!(json[0], b'{');
         assert!(serde_json::from_slice::<serde_json::Value>(&json).is_ok());
+    }
+}
+
+#[cfg(test)]
+mod blob_digest_tests {
+    use super::{blob_unchanged, forget_blob_digest, reset_last_blob_region};
+
+    // LAST_BLOB_DIGEST is a process-global static shared with every other
+    // test in this binary, so each case resets it first and runs its
+    // assertions in one #[test] rather than relying on test isolation.
+    #[test]
+    fn digest_tracks_changes_and_resets() {
+        reset_last_blob_region();
+
+        let blob = b"{\"SubscribedToEmails\":1,\"RegularCredits\":100}".to_vec();
+        assert!(!blob_unchanged(&blob), "first call always reports changed");
+        assert!(blob_unchanged(&blob), "identical bytes report unchanged");
+
+        let mut mutated = blob.clone();
+        mutated[0] = b'[';
+        assert!(!blob_unchanged(&mutated), "a changed byte must report changed");
+        assert!(blob_unchanged(&mutated), "the new bytes become the baseline");
+
+        reset_last_blob_region();
+        assert!(!blob_unchanged(&mutated), "reset forces the next call to report changed");
+    }
+
+    // Unparseable bytes that persist across scan cycles must not start
+    // reporting as unchanged — the skip paths read that as "already parsed
+    // this", which would wedge the walk on a region that never parsed.
+    #[test]
+    fn forgetting_after_a_failed_parse_forces_a_retry() {
+        reset_last_blob_region();
+
+        let garbage = b"{\"MiscItems\":[ truncated".to_vec();
+        assert!(!blob_unchanged(&garbage), "first sighting reports changed");
+        forget_blob_digest();
+        assert!(!blob_unchanged(&garbage), "same bytes report changed again after a failed parse");
     }
 }
 

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -617,7 +617,12 @@ pub fn parse_full_account_blob(raw: &[u8]) -> Option<BlobInventory> {
                 });
                 continue;
             }
-            let mc = mods.entry(it.to_string()).or_default();
+            // Duplicate ItemTypes dominate this map, so check get_mut before
+            // paying for entry()'s unconditional to_string() allocation.
+            let mc = match mods.get_mut(it) {
+                Some(mc) => mc,
+                None => mods.entry(it.to_string()).or_default(),
+            };
             *mc.by_rank.entry(0).or_insert(0) += count;
             mc.total += count;
         }
@@ -678,7 +683,10 @@ pub fn parse_full_account_blob(raw: &[u8]) -> Option<BlobInventory> {
                 }
             }
             let rank = blob_extract_mod_rank(e["UpgradeFingerprint"].as_str());
-            let mc = mods.entry(it.to_string()).or_default();
+            let mc = match mods.get_mut(it) {
+                Some(mc) => mc,
+                None => mods.entry(it.to_string()).or_default(),
+            };
             *mc.by_rank.entry(rank).or_insert(0) += 1;
             mc.total += 1;
         }
@@ -690,7 +698,10 @@ pub fn parse_full_account_blob(raw: &[u8]) -> Option<BlobInventory> {
         for e in arr {
             let Some(it) = e["ItemType"].as_str() else { continue };
             if !it.starts_with("/Lotus/") { continue; }
-            *flavour_items.entry(it.to_string()).or_insert(0) += 1;
+            match flavour_items.get_mut(it) {
+                Some(v) => *v += 1,
+                None => { flavour_items.insert(it.to_string(), 1); }
+            }
         }
     }
 
@@ -701,7 +712,10 @@ pub fn parse_full_account_blob(raw: &[u8]) -> Option<BlobInventory> {
         for e in arr {
             let Some(it) = e["ItemType"].as_str() else { continue };
             if !it.starts_with("/Lotus/") { continue; }
-            *weapon_skins.entry(it.to_string()).or_insert(0) += 1;
+            match weapon_skins.get_mut(it) {
+                Some(v) => *v += 1,
+                None => { weapon_skins.insert(it.to_string(), 1); }
+            }
         }
     }
 

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -924,9 +924,9 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
                 buf.as_mut_ptr() as *mut c_void, read_cap, &mut n) } != 0 && n >= 8;
             if read_ok {
                 let chunk = &buf[..n];
-                let is_mission = chunk.windows(MISSION_DELTA.len()).any(|w| w == MISSION_DELTA);
-                let has_anchor = ANCHORS.iter().any(|a| chunk.windows(a.len()).any(|w| w == *a));
-                let has_lotus  = chunk.windows(LOTUS_KEY.len()).any(|w| w == LOTUS_KEY);
+                let is_mission = memmem::find(chunk, MISSION_DELTA).is_some();
+                let has_anchor = ANCHORS.iter().any(|a| memmem::find(chunk, a).is_some());
+                let has_lotus  = memmem::find(chunk, LOTUS_KEY).is_some();
                 // cached_addr is the exact byte of the blob's outer {, so seed from byte 0.
                 // Accept regions that are blob data even when SubscribedToEmails is in a
                 // later region (field order varies by account).
@@ -1071,9 +1071,7 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
                 return false; // drop oversized scan
             }
             // Only search the newly-added window, not the full buffer.
-            let has_end = scan.data[search_from..]
-                .windows(END_MARKER.len())
-                .any(|w| w == END_MARKER);
+            let has_end = memmem::find(&scan.data[search_from..], END_MARKER).is_some();
             if has_end && find_blob_end(&scan.data).is_some() {
                 if !save && blob_unchanged(&scan.data) {
                     eprintln!("[blob] scan#{} unchanged since last scan — skipping parse", scan.id);
@@ -1113,11 +1111,11 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
         if found_result { continue; }
 
         let t2 = std::time::Instant::now();
-        let has_start     = chunk.windows(START_MARKER.len()).any(|w| w == START_MARKER);
-        let has_alt_start = ALT_STARTS.iter().any(|a| chunk.windows(a.len()).any(|w| w == *a));
-        let is_mission    = chunk.windows(MISSION_DELTA.len()).any(|w| w == MISSION_DELTA);
-        let has_anchor    = ANCHORS.iter().any(|a| chunk.windows(a.len()).any(|w| w == *a));
-        let has_lotus     = chunk.windows(LOTUS_KEY.len()).any(|w| w == LOTUS_KEY);
+        let has_start     = memmem::find(chunk, START_MARKER).is_some();
+        let has_alt_start = ALT_STARTS.iter().any(|a| memmem::find(chunk, a).is_some());
+        let is_mission    = memmem::find(chunk, MISSION_DELTA).is_some();
+        let has_anchor    = ANCHORS.iter().any(|a| memmem::find(chunk, a).is_some());
+        let has_lotus     = memmem::find(chunk, LOTUS_KEY).is_some();
         let qualifies     = (has_start || has_alt_start) && !is_mission && (has_anchor || has_lotus);
         t_search += t2.elapsed();
 

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -75,7 +75,6 @@ pub struct PendingRecipe {
 }
 
 /// One Archon Shard socketed into a Warframe.
-/// One Archon Shard socketed into a Warframe.
 /// `upgrade_type` is the effect path (e.g. `.../ArchonCrystalUpgradeWarframeEnergyMax`).
 /// `color` is the raw string value from the JSON (e.g. `"ACC_CRIMSON"`, `"ACC_AZURE_TAUFORGED"`).
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -159,37 +158,6 @@ pub fn xp_to_rank(xp: i64, path: &str) -> u32 {
     { 1000.0f64 } else { 500.0f64 };
     ((xp as f64 / base).sqrt().floor() as u32).min(30)
 }
-
-/// Diagnostic: find "CompletionDate" in any format and return a snippet of context.
-#[allow(dead_code)]
-pub fn scan_completion_date_context(data: &[u8]) -> Vec<String> {
-    let key = b"\"CompletionDate\"";
-    let mut results = Vec::new();
-    let mut start = 0usize;
-    loop {
-        let next = match data[start..].iter().position(|&b| b == b'"') {
-            Some(p) => start + p,
-            None => break,
-        };
-        if next + key.len() > data.len() { break; }
-        if data[next..next + key.len()] != *key {
-            start = next + 1; continue;
-        }
-        // Capture 120 bytes of context starting 40 bytes before the key
-        let ctx_start = next.saturating_sub(40);
-        let ctx_end   = (next + 120).min(data.len());
-        let ctx = &data[ctx_start..ctx_end];
-        // Only include printable ASCII so the log is readable
-        let s: String = ctx.iter()
-            .map(|&b| if b >= 0x20 && b < 0x7f { b as char } else { '·' })
-            .collect();
-        results.push(s);
-        start = next + key.len();
-        if results.len() >= 3 { break; } // cap at 3 samples
-    }
-    results
-}
-
 
 // ─── Auth credentials scan ───────────────────────────────────────────────────
 //
@@ -432,96 +400,6 @@ pub fn dump_inventory_regions(_max_hits: usize) -> Vec<String> {
     vec!["Only supported on Windows".to_string()]
 }
 
-// ─── One-shot inventory blob capture ─────────────────────────────────────────
-//
-// Scans all committed readable regions for the first chunk that contains the
-// inventory root marker ("MiscItems":[).  Saves the full printable-text portion
-// of that region to `output_path` so it can be inspected offline.
-//
-// Non-printable bytes are replaced with '.' so the file is text-editor friendly.
-// Saves up to 8 MB centred on the MiscItems key (4 MB before, 4 MB after).
-
-#[cfg(target_os = "windows")]
-pub fn capture_inventory_blob(output_path: &std::path::Path) -> Result<String, String> {
-    use std::ffi::c_void;
-    use std::mem;
-    use windows_sys::Win32::{
-        Foundation::{CloseHandle, FALSE},
-        System::{
-            Diagnostics::Debug::ReadProcessMemory,
-            Memory::{VirtualQueryEx, MEMORY_BASIC_INFORMATION, MEM_COMMIT, PAGE_GUARD, PAGE_NOACCESS},
-            Threading::{OpenProcess, PROCESS_QUERY_INFORMATION, PROCESS_VM_READ},
-        },
-    };
-
-    let pid = find_warframe_pid_pub().ok_or_else(|| "Warframe is not running".to_string())?;
-
-    let process = unsafe { OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, pid) };
-    if process == 0 { return Err("Could not open Warframe process".to_string()); }
-
-    const MISC_KEY: &[u8]      = b"\"MiscItems\":[";
-    const MIN_BLOB_BYTES: usize = 200_000;    // skip tiny chunks — real inventory is MB-scale
-    const MAX_REGION_READ: usize = 128 * 1024 * 1024;
-    const HALF_SAVE: usize      = 4 * 1024 * 1024;   // 4 MB either side of MiscItems
-
-    let mut addr: usize = 0;
-    let mut saved: Option<(usize, String)> = None; // (region size, message)
-
-    'outer: loop {
-        let mut mbi = unsafe { mem::zeroed::<MEMORY_BASIC_INFORMATION>() };
-        if unsafe { VirtualQueryEx(process, addr as *const c_void, &mut mbi, mem::size_of::<MEMORY_BASIC_INFORMATION>()) } == 0 { break; }
-
-        let region_addr = mbi.BaseAddress as usize;
-        let region_size = mbi.RegionSize;
-        let next_addr   = region_addr.saturating_add(region_size);
-
-        if mbi.State == MEM_COMMIT
-            && mbi.Protect & PAGE_GUARD    == 0
-            && mbi.Protect & PAGE_NOACCESS == 0
-            && region_size >= MIN_BLOB_BYTES
-            && region_size <= MAX_REGION_READ
-        {
-            let mut data = vec![0u8; region_size];
-            let mut n = 0usize;
-            if unsafe { ReadProcessMemory(process, region_addr as *const c_void, data.as_mut_ptr() as *mut c_void, region_size, &mut n) } != 0 && n >= MIN_BLOB_BYTES {
-                let data = &data[..n];
-                if let Some(misc_pos) = data.windows(MISC_KEY.len()).position(|w| w == MISC_KEY) {
-                    let start = misc_pos.saturating_sub(HALF_SAVE);
-                    let end   = (misc_pos + HALF_SAVE).min(data.len());
-                    let text: Vec<u8> = data[start..end].iter()
-                        .map(|&b| if b >= 0x20 && b <= 0x7e || b == b'\n' || b == b'\t' { b } else { b'.' })
-                        .collect();
-                    if let Err(e) = std::fs::write(output_path, &text) {
-                        unsafe { CloseHandle(process); }
-                        return Err(format!("Write failed: {e}"));
-                    }
-                    saved = Some((text.len(), format!(
-                        "Saved {}KB blob (region 0x{:x}, size {}KB, MiscItems at +{}KB) to {}",
-                        text.len() / 1024, region_addr, n / 1024, misc_pos / 1024,
-                        output_path.display()
-                    )));
-                    break 'outer;
-                }
-            }
-        }
-
-        if next_addr <= addr { break; }
-        addr = next_addr;
-    }
-
-    unsafe { CloseHandle(process); }
-
-    saved.map(|(_, msg)| msg)
-         .ok_or_else(|| "No inventory blob found — make sure Warframe is running and inventory is loaded (open Arsenal or Inventory screen)".to_string())
-}
-
-#[cfg(not(target_os = "windows"))]
-pub fn capture_inventory_blob(_output_path: &std::path::Path) -> Result<String, String> {
-    Err("Only supported on Windows".into())
-}
-
-/// Scan all Warframe process memory and save every relevant blob found into `blob_dir`.
-/// "Relevant" = region ≥ 100 KB that contains at least one of: MiscItems, Suits,
 // ─── Full-account blob parser ─────────────────────────────────────────────────
 
 /// Find the end of the FULL_ACCOUNT blob by locating `"DeathSquadable":` and

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -418,16 +418,42 @@ fn enclosing_object_start(buf: &[u8], marker_off: usize) -> Option<usize> {
     None
 }
 
-/// Locate seed offsets for the FULL_ACCOUNT blob within `buf`.
-/// Returns `(marker_off, json_open)`:
-///   - `marker_off`: byte position of the first known start marker
-///   - `json_open`:  byte position of the outermost `{` enclosing the marker
-fn blob_seed_offsets(buf: &[u8]) -> (usize, usize) {
-    let marker_off = memmem::find(buf, START_MARKER)
-        .or_else(|| ALT_STARTS.iter().find_map(|a| memmem::find(buf, a)))
-        .unwrap_or(buf.len().saturating_sub(1));
-    let json_open = enclosing_object_start(buf, marker_off).unwrap_or(marker_off);
-    (marker_off, json_open)
+/// Where a stitched buffer's blob begins: `(marker_at, seed_at)`.
+///
+/// `marker_at` is the marker occurrence the seed is anchored to; `seed_at` is
+/// the brace enclosing it, or the marker itself when no occurrence has a
+/// brace that reads as an object head. See `enclosing_object_start` for why
+/// marker and brace are rarely the same offset.
+///
+/// With no primary marker anywhere the fallbacks keep both offsets in bounds,
+/// down to the buffer's last byte when nothing matches at all. Such a seed is
+/// junk and fails to parse, which is what the walk already does with a bad
+/// start.
+fn blob_seed_offsets(combined: &[u8]) -> (usize, usize) {
+    // The heap can hold a stale copy of the blob ahead of the live one: its
+    // marker survives but its opening brace was overwritten, so brace-matching
+    // backward from it lands on a stray `{` in binary garbage. A live seed is
+    // a JSON object head, so only accept a brace followed by a quote, and keep
+    // trying later marker occurrences until one qualifies.
+    let mut first_marker = None;
+    let mut search_from = 0;
+    while let Some(found) = memmem::find(&combined[search_from..], START_MARKER) {
+        let marker_at = search_from + found;
+        first_marker.get_or_insert(marker_at);
+        if let Some(open) = enclosing_object_start(combined, marker_at) {
+            if combined.get(open + 1) == Some(&b'"') {
+                return (marker_at, open);
+            }
+        }
+        search_from = marker_at + 1;
+    }
+    // Without a plausible brace anywhere, seed at the first marker: the
+    // parser can rebuild the object head from a marker-anchored seed.
+    let marker_at = first_marker
+        .or_else(|| ALT_STARTS.iter().find_map(|a| memmem::find(combined, a)))
+        .unwrap_or(combined.len().saturating_sub(1));
+    (marker_at, first_marker.unwrap_or_else(||
+        enclosing_object_start(combined, marker_at).unwrap_or(marker_at)))
 }
 
 /// Parse a FULL_ACCOUNT blob from raw memory bytes into structured inventory data.
@@ -1511,6 +1537,37 @@ mod seed_tests {
         let buf = b"x\"SubscribedToEmails\":1}";
         let (marker_off, json_open) = blob_seed_offsets(buf);
         assert_eq!(json_open, marker_off);
+    }
+
+    /// A freed copy of the blob can sit ahead of the live one with its marker
+    /// intact but its opening brace overwritten. Brace-matching backward from
+    /// that copy lands on a stray `{` in binary garbage ("key must be a string
+    /// at line 1 column 2"), so the stale occurrence has to be skipped in
+    /// favour of the live one.
+    #[test]
+    fn a_stale_headless_copy_is_skipped_for_the_live_blob() {
+        let mut combined = b"\x00{J>\x01\x02 garbage ".to_vec();
+        combined.extend_from_slice(br#""SubscribedToEmails":0,"RegularCredits":1,"#);
+        combined.extend_from_slice(b"\x03\x04 more garbage ");
+        let live_at = combined.len();
+        combined.extend_from_slice(br#"{"SubscribedToEmails":0,"RegularCredits":42}"#);
+
+        let (marker_at, seed_at) = blob_seed_offsets(&combined);
+        assert_eq!(seed_at, live_at, "seed is the live copy's opening brace");
+        assert!(marker_at > live_at, "the marker used is the live copy's");
+    }
+
+    /// With only the headless copy in the buffer, seeding at the marker lets
+    /// the parser rebuild the object head instead of parsing garbage.
+    #[test]
+    fn a_lone_headless_copy_seeds_at_its_marker() {
+        let mut combined = b"\x00{J>\x01\x02 garbage ".to_vec();
+        let marker = combined.len();
+        combined.extend_from_slice(br#""SubscribedToEmails":0,"RegularCredits":42,"#);
+
+        let (marker_at, seed_at) = blob_seed_offsets(&combined);
+        assert_eq!(marker_at, marker);
+        assert_eq!(seed_at, marker, "seed skips the garbage brace");
     }
 
     #[test]

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -825,11 +825,35 @@ static LAST_BLOB_REGION: std::sync::atomic::AtomicU64 =
 // HashMaps/Vecs from scratch every cycle.
 static LAST_BLOB_DIGEST: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
+#[cfg(target_os = "windows")]
+enum CachedBlobScan {
+    Fresh(usize, BlobInventory),
+    Unchanged,
+}
+
+/// Set once the probe has reported that nothing changed, cleared as soon as
+/// anything does. Probes run every couple of seconds and nearly all of them
+/// find byte-identical JSON, so logging each one drowns out the rest of the
+/// log. Only the transition into that state is logged.
+static STEADY_STATE_LOGGED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+fn steady_state_notice_due() -> bool {
+    !STEADY_STATE_LOGGED.swap(true, std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Whether a previous scan left an address for the probe to re-read. Without
+/// one the probe can only ever miss, so the caller must walk instead.
+pub fn has_cached_blob() -> bool {
+    LAST_BLOB_REGION.load(std::sync::atomic::Ordering::Relaxed) != 0
+}
+
 /// Clear the fast-path region cache. Call when Warframe's PID changes so the
 /// next scan doesn't probe a stale address from the previous process instance.
 pub fn reset_last_blob_region() {
     LAST_BLOB_REGION.store(0, std::sync::atomic::Ordering::Relaxed);
     LAST_BLOB_DIGEST.store(0, std::sync::atomic::Ordering::Relaxed);
+    STEADY_STATE_LOGGED.store(false, std::sync::atomic::Ordering::Relaxed);
 }
 
 /// Discard the digest baseline so the next candidate is parsed no matter what
@@ -866,7 +890,13 @@ fn blob_unchanged(json: &[u8]) -> bool {
     // reset_last_blob_region stores — that sentinel must always compare as
     // "changed" to force a re-parse after a PID change.
     let digest = hasher.finish() | 1;
-    LAST_BLOB_DIGEST.swap(digest, std::sync::atomic::Ordering::Relaxed) == digest
+    let unchanged = LAST_BLOB_DIGEST.swap(digest, std::sync::atomic::Ordering::Relaxed) == digest;
+    if !unchanged {
+        // Bytes moved, so the next settle into the steady state is worth
+        // saying out loud again.
+        STEADY_STATE_LOGGED.store(false, std::sync::atomic::Ordering::Relaxed);
+    }
+    unchanged
 }
 
 /// Scans Warframe process memory for the FULL_ACCOUNT inventory blob and sends it
@@ -890,6 +920,113 @@ fn blob_unchanged(json: &[u8]) -> bool {
 ///      The walk always continues through all of memory — every blob start is found.
 ///   5. Drop any scan that grows past MAX_SCAN_BYTES without finding the end.
 ///
+// Shared by the cold walk and the cached-region fast path, so a region
+// rejected as a mission delta or a scan dropped for growing past the cap
+// means the same thing in either place.
+#[cfg(target_os = "windows")]
+const MAX_READ: usize = 64 * 1024 * 1024;
+#[cfg(target_os = "windows")]
+const MAX_SCAN: usize = 20 * 1024 * 1024;
+#[cfg(target_os = "windows")]
+const MISSION_DELTA: &[u8] = b"\"InventoryChanges\":";
+#[cfg(target_os = "windows")]
+const LOTUS_KEY: &[u8] = b"/Lotus/";
+#[cfg(target_os = "windows")]
+const ANCHORS: &[&[u8]] = &[
+    b"\"SubscribedToEmails\"",
+    b"\"MiscItems\":[",
+    b"\"Suits\":[",
+    b"\"LongGuns\":[",
+    b"\"Melee\":[",
+    b"\"Pistols\":[",
+];
+
+/// Re-read the blob straight from the address the last successful scan found
+/// it at, stitching forward through following regions until the JSON closes.
+///
+/// Returns `None` whenever anything looks different from last time, which puts
+/// the caller back on the full walk rather than reporting a stale inventory.
+#[cfg(target_os = "windows")]
+fn scan_windows_cached_blob(process: windows_sys::Win32::Foundation::HANDLE) -> Option<CachedBlobScan> {
+    use std::ffi::c_void;
+    use std::mem;
+    use windows_sys::Win32::System::{
+        Diagnostics::Debug::ReadProcessMemory,
+        Memory::{VirtualQueryEx, MEMORY_BASIC_INFORMATION, MEM_COMMIT, PAGE_GUARD, PAGE_NOACCESS},
+    };
+
+    let cached_addr = LAST_BLOB_REGION.load(std::sync::atomic::Ordering::Relaxed) as usize;
+    if cached_addr == 0 {
+        return None;
+    }
+
+    let mut mbi = unsafe { mem::zeroed::<MEMORY_BASIC_INFORMATION>() };
+    let ok = unsafe { VirtualQueryEx(process, cached_addr as *const c_void, &mut mbi,
+        mem::size_of::<MEMORY_BASIC_INFORMATION>()) } != 0;
+    if !ok || mbi.State != MEM_COMMIT
+        || mbi.Protect & PAGE_GUARD != 0
+        || mbi.Protect & PAGE_NOACCESS != 0
+    {
+        return None;
+    }
+
+    let read_cap = mbi.RegionSize.min(MAX_READ);
+    let mut buf = vec![0u8; read_cap];
+    let mut n = 0usize;
+    let read_ok = unsafe { ReadProcessMemory(process, cached_addr as *const c_void,
+        buf.as_mut_ptr() as *mut c_void, read_cap, &mut n) } != 0 && n >= 8;
+    if !read_ok {
+        return None;
+    }
+
+    buf.truncate(n);
+    let chunk = &buf[..];
+    let is_mission = memmem::find(chunk, MISSION_DELTA).is_some();
+    let has_anchor = ANCHORS.iter().any(|a| memmem::find(chunk, a).is_some());
+    let has_lotus  = memmem::find(chunk, LOTUS_KEY).is_some();
+    // cached_addr is the exact byte of the blob's outer {, so seed from byte 0.
+    // Accept regions that are blob data even when SubscribedToEmails is in a
+    // later region (field order varies by account).
+    if is_mission || !(has_anchor || has_lotus) || !chunk.starts_with(b"{\"") {
+        return None;
+    }
+
+    let mut stitched = buf;
+    let mut walk = cached_addr + n;
+    while stitched.len() < MAX_SCAN && find_blob_end(&stitched).is_none() {
+        let mut nmbi = unsafe { mem::zeroed::<MEMORY_BASIC_INFORMATION>() };
+        if unsafe { VirtualQueryEx(process, walk as *const c_void, &mut nmbi,
+            mem::size_of::<MEMORY_BASIC_INFORMATION>()) } == 0 { break; }
+        let nr = nmbi.BaseAddress as usize;
+        let ns = nmbi.RegionSize;
+        walk = nr + ns;
+        if nmbi.State != MEM_COMMIT
+            || nmbi.Protect & PAGE_GUARD != 0
+            || nmbi.Protect & PAGE_NOACCESS != 0
+            || ns == 0 { continue; }
+        let cap = ns.min(MAX_READ);
+        let mut nb = vec![0u8; cap];
+        let mut nn = 0usize;
+        if unsafe { ReadProcessMemory(process, nr as *const c_void,
+            nb.as_mut_ptr() as *mut c_void, cap, &mut nn) } == 0 { continue; }
+        stitched.extend_from_slice(&nb[..nn]);
+    }
+
+    if blob_unchanged(&stitched) {
+        if steady_state_notice_due() {
+            eprintln!("[blob] fast-path hit at 0x{cached_addr:012x}: unchanged since last scan, quiet until it changes");
+        }
+        return Some(CachedBlobScan::Unchanged);
+    }
+    match parse_full_account_blob(&stitched) {
+        Some(inventory) => Some(CachedBlobScan::Fresh(cached_addr, inventory)),
+        None => {
+            forget_blob_digest();
+            None
+        }
+    }
+}
+
 /// When `save=true` also writes the raw text to `blob_dir` for debugging.
 /// Returns the number of files written (always 0 when `save=false`).
 #[cfg(target_os = "windows")]
@@ -910,8 +1047,6 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
     if process == 0 { return 0; }
 
     const MIN_REGION:    usize = 64_000;   // skip regions smaller than 64 KB
-    const MAX_READ:      usize = 64  * 1024 * 1024;
-    const MAX_SCAN:      usize = 20  * 1024 * 1024;
     const MAX_BLOBS:     usize = 25;
 
     // Executable pages never contain heap data — safe to skip.
@@ -921,82 +1056,9 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
     const PAGE_EXECUTE_WC:   u32 = 0x80;
     const EXEC_MASK: u32 = PAGE_EXECUTE | PAGE_EXECUTE_READ | PAGE_EXECUTE_RW | PAGE_EXECUTE_WC;
 
-    const MISSION_DELTA: &[u8] = b"\"InventoryChanges\":";
-    const LOTUS_KEY:     &[u8] = b"/Lotus/";
-    const ANCHORS: &[&[u8]] = &[
-        b"\"SubscribedToEmails\"",
-        b"\"MiscItems\":[",
-        b"\"Suits\":[",
-        b"\"LongGuns\":[",
-        b"\"Melee\":[",
-        b"\"Pistols\":[",
-    ];
-
-    // ── Fast path: try the cached region from last successful scan ─────────────
-    // If the blob is still at the same address, we skip the entire memory walk.
-    let cached_addr = LAST_BLOB_REGION.load(std::sync::atomic::Ordering::Relaxed) as usize;
-    if cached_addr != 0 && !save {
-        let mut mbi = unsafe { mem::zeroed::<MEMORY_BASIC_INFORMATION>() };
-        let ok = unsafe { VirtualQueryEx(process, cached_addr as *const c_void, &mut mbi,
-            mem::size_of::<MEMORY_BASIC_INFORMATION>()) } != 0;
-        if ok && mbi.State == MEM_COMMIT
-            && mbi.Protect & PAGE_GUARD == 0
-            && mbi.Protect & PAGE_NOACCESS == 0
-        {
-            let read_cap = mbi.RegionSize.min(MAX_READ);
-            let mut buf = vec![0u8; read_cap];
-            let mut n = 0usize;
-            let read_ok = unsafe { ReadProcessMemory(process, cached_addr as *const c_void,
-                buf.as_mut_ptr() as *mut c_void, read_cap, &mut n) } != 0 && n >= 8;
-            if read_ok {
-                let chunk = &buf[..n];
-                let is_mission = memmem::find(chunk, MISSION_DELTA).is_some();
-                let has_anchor = ANCHORS.iter().any(|a| memmem::find(chunk, a).is_some());
-                let has_lotus  = memmem::find(chunk, LOTUS_KEY).is_some();
-                // cached_addr is the exact byte of the blob's outer {, so seed from byte 0.
-                // Accept regions that are blob data even when SubscribedToEmails is in a
-                // later region (field order varies by account).
-                if !is_mission && (has_anchor || has_lotus) && chunk.starts_with(b"{\"") {
-                    let mut stitched = chunk.to_vec();
-                    let mut walk = cached_addr + n;
-                    while stitched.len() < MAX_SCAN && find_blob_end(&stitched).is_none() {
-                        let mut nmbi = unsafe { mem::zeroed::<MEMORY_BASIC_INFORMATION>() };
-                        if unsafe { VirtualQueryEx(process, walk as *const c_void, &mut nmbi,
-                            mem::size_of::<MEMORY_BASIC_INFORMATION>()) } == 0 { break; }
-                        let nr = nmbi.BaseAddress as usize;
-                        let ns = nmbi.RegionSize;
-                        walk = nr + ns;
-                        if nmbi.State != MEM_COMMIT
-                            || nmbi.Protect & PAGE_GUARD != 0
-                            || nmbi.Protect & PAGE_NOACCESS != 0
-                            || ns == 0 { continue; }
-                        let cap = ns.min(MAX_READ);
-                        let mut nb = vec![0u8; cap];
-                        let mut nn = 0usize;
-                        if unsafe { ReadProcessMemory(process, nr as *const c_void,
-                            nb.as_mut_ptr() as *mut c_void, cap, &mut nn) } == 0 { continue; }
-                        stitched.extend_from_slice(&nb[..nn]);
-                    }
-                    if blob_unchanged(&stitched) {
-                        eprintln!("[blob] fast-path hit at 0x{:012x}: unchanged since last scan — skipping parse", cached_addr);
-                        unsafe { CloseHandle(process); }
-                        return 0;
-                    }
-                    if let Some(inv) = parse_full_account_blob(&stitched) {
-                        eprintln!("[blob] fast-path hit at 0x{:012x}: {} unique, {} stackable",
-                            cached_addr, inv.unique_items.len(), inv.stackable_items.len());
-                        blob_tx.send(inv).ok();
-                        unsafe { CloseHandle(process); }
-                        return 0; // fast path never saves to disk
-                    }
-                    forget_blob_digest();
-                }
-            }
-        }
-        // Cache miss — fall through to full walk and update the cache when found
-        eprintln!("[blob] fast-path miss at 0x{:012x} — doing full walk", cached_addr);
-    }
-
+    // No fast path here on purpose: the monitor already ran that scan in
+    // `probe_tick` and escalated to this walk on the result, so repeating it
+    // would answer the same and skip the walk it asked for.
     struct ActiveScan {
         data: Vec<u8>,
         id: usize,
@@ -1249,6 +1311,334 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
 
 #[cfg(not(target_os = "windows"))]
 pub fn capture_all_blobs(_blob_dir: &std::path::Path, _ts: &str, _blob_tx: std::sync::mpsc::Sender<BlobInventory>, _save: bool) -> usize { 0 }
+
+// ─── Cheap probe ──────────────────────────────────────────────────────────────
+
+/// What a probe of the cached blob address concluded.
+///
+/// `Unchanged` and `Updated` are definitive answers obtained for a few
+/// megabytes of reads. `CacheMiss` is not: the game may have reallocated the
+/// blob because the inventory changed, or the address may be stale for some
+/// unrelated reason, and telling those apart costs a full region walk.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ScanOutcome {
+    Unchanged,
+    Updated,
+    CacheMiss,
+}
+
+/// Map a cached-region scan onto a probe outcome, sending any fresh inventory.
+#[cfg(target_os = "windows")]
+fn probe_outcome(
+    scan: Option<CachedBlobScan>,
+    blob_tx: &std::sync::mpsc::Sender<BlobInventory>,
+) -> ScanOutcome {
+    match scan {
+        Some(CachedBlobScan::Fresh(address, inventory)) => {
+            eprintln!("[blob] probe hit at 0x{address:012x}: {} unique, {} stackable",
+                inventory.unique_items.len(), inventory.stackable_items.len());
+            blob_tx.send(inventory).ok();
+            ScanOutcome::Updated
+        }
+        Some(CachedBlobScan::Unchanged) => ScanOutcome::Unchanged,
+        None => ScanOutcome::CacheMiss,
+    }
+}
+
+/// One monitor tick: re-read the blob from its remembered address, and check
+/// whether the game has logged an inventory sync since the last tick.
+///
+/// Never falls back to a full region walk. `capture_all_blobs` does that, which
+/// makes it unusable as a poll: probing at 1-2 Hz would mean walking memory at
+/// 1-2 Hz for as long as the cached address stays stale. Splitting the two lets
+/// the caller poll cheaply and decide for itself when a miss is worth the walk.
+///
+/// The marker is read first and every tick, because it is what tells the blob
+/// scan it has something to look at. The scan itself runs only when `force` or
+/// that marker says so; between syncs it can only ever conclude that nothing
+/// moved. `None` means it was not scanned this tick, which is not the same as
+/// a miss.
+#[cfg(target_os = "windows")]
+pub fn probe_tick(
+    pid: u32,
+    blob_tx: std::sync::mpsc::Sender<BlobInventory>,
+    force: bool,
+) -> (Option<ScanOutcome>, bool) {
+    use windows_sys::Win32::{
+        Foundation::{CloseHandle, FALSE},
+        System::Threading::{OpenProcess, PROCESS_QUERY_INFORMATION, PROCESS_VM_READ},
+    };
+
+    let process = unsafe { OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, pid) };
+    if process == 0 {
+        return (None, false);
+    }
+    let sync = sync_marker_is_new(windows_newest_sync_timestamp(process));
+    let outcome = (force || sync)
+        .then(|| probe_outcome(scan_windows_cached_blob(process), &blob_tx));
+    unsafe { CloseHandle(process) };
+    (outcome, sync)
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn probe_tick(
+    _pid: u32,
+    _blob_tx: std::sync::mpsc::Sender<BlobInventory>,
+    _force: bool,
+) -> (Option<ScanOutcome>, bool) {
+    (None, false)
+}
+
+// ─── Inventory-sync marker, read from memory rather than from EE.log ──────────
+//
+// Warframe composes its log lines in process memory long before they reach
+// EE.log: the game buffers writes and flushes in bursts, and sampling the live
+// client showed the newest in-memory line running 23 s ahead of the newest line
+// on disk. Tailing the file therefore reports an inventory sync at an unknown,
+// variable delay, and that delay lands on every capture gated behind it.
+//
+// The formatted lines are findable by content, so no pointer chain and no
+// per-build offsets are involved:
+//
+//   19761.848 Sys [Info]: OnInventoryResults completed in 339ms
+//
+// Only the log text holds ` Sys [Info]: ` preceded by a seconds-since-launch
+// timestamp, and once the buffer is found its address caches like
+// LAST_BLOB_REGION.
+
+/// The formatted marker. Shared with the EE.log tail in `start_log_watcher`
+/// rather than re-spelled: a mismatch between the two readers degrades to
+/// plain interval polling, which is hard to tell from working correctly.
+pub const INVENTORY_SYNC_MARKER: &str = "OnInventoryResults completed in";
+
+const SYNC_MARKER: &[u8] = INVENTORY_SYNC_MARKER.as_bytes();
+
+/// Present on every log line, so it identifies the buffer regardless of what
+/// the game happens to have logged recently.
+const LOG_LINE_MARKER: &[u8] = b" Sys [Info]: ";
+
+/// The candidate buffers are a few MB against several GB of readable mappings,
+/// so anything larger is some other allocation that happens to quote a log line.
+const MAX_LOG_REGION: usize = 16 * 1024 * 1024;
+
+static LAST_LOG_REGION: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Probes still to skip before the cold search may run again.
+static LOG_SEARCH_BACKOFF: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Whether the cold search is allowed to run on this probe. That search reads
+/// every non-executable region under [`MAX_LOG_REGION`], hundreds of MB.
+///
+/// Without this, a client whose log buffers cannot be located pays a walk-sized
+/// read on the monitor thread every couple of seconds for the whole session.
+/// Backing off costs only latency: the marker is an optimisation, and the
+/// EE.log tail reports the same syncs meanwhile.
+fn cold_log_search_due() -> bool {
+    use std::sync::atomic::Ordering::Relaxed;
+    LOG_SEARCH_BACKOFF
+        .fetch_update(Relaxed, Relaxed, |left| Some(left.saturating_sub(1)))
+        .is_ok_and(|left| left == 0)
+}
+
+/// Probes to sit out after a failed cold search, at the monitor's 2 s cadence.
+const LOG_SEARCH_BACKOFF_PROBES: u64 = 30;
+
+/// Game timestamp of the newest sync marker already reported, as `f64` bits.
+static LAST_SYNC_TIMESTAMP: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Forget the log buffer's address and the marker baseline. Call alongside
+/// [`reset_last_blob_region`] when the PID changes: the timestamps are seconds
+/// since *that* client launched, so a baseline from the previous process would
+/// swallow every marker the new one writes.
+pub fn reset_log_region() {
+    LAST_LOG_REGION.store(0, std::sync::atomic::Ordering::Relaxed);
+    LAST_SYNC_TIMESTAMP.store(0, std::sync::atomic::Ordering::Relaxed);
+    LOG_SEARCH_BACKOFF.store(0, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Seconds-since-launch stamp opening the line that `offset` falls inside, e.g.
+/// `19761.848` from `19761.848 Sys [Info]: …`.
+///
+/// Both buffers hold complete formatted lines but end them differently: the
+/// pending file-write buffer uses CRLF, the heap ring LF, so the search back
+/// to the line start stops at either.
+fn line_timestamp(chunk: &[u8], offset: usize) -> Option<f64> {
+    let start = chunk[..offset]
+        .iter()
+        .rposition(|&byte| byte == b'\n' || byte == b'\r')
+        .map_or(0, |index| index + 1);
+    // `offset` lands on the space opening ` Sys [Info]: ` for one caller and
+    // partway into the message for the other, so the stamp runs to whichever
+    // comes first: the next space, or the marker itself.
+    let line = &chunk[start..offset];
+    let end = line.iter().position(|&byte| byte == b' ').unwrap_or(line.len());
+    let stamp = std::str::from_utf8(&line[..end]).ok()?;
+    // Reject anything that is not the timestamp shape: a bare integer or a
+    // stray word would otherwise parse and then compare as a valid ordering.
+    let (seconds, millis) = stamp.split_once('.')?;
+    if seconds.is_empty()
+        || !seconds.bytes().all(|byte| byte.is_ascii_digit())
+        || millis.len() != 3
+        || !millis.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return None;
+    }
+    stamp.parse().ok()
+}
+
+/// True when `chunk` holds formatted log lines rather than, say, the `.rdata`
+/// copy of the format string. The timestamp is what tells the two apart.
+fn looks_like_log_buffer(chunk: &[u8]) -> bool {
+    let mut from = 0;
+    // A handful of probes is enough: the log text is dense with these, so a
+    // buffer that fails several in a row is not it.
+    for _ in 0..8 {
+        let Some(hit) = memmem::find(&chunk[from..], LOG_LINE_MARKER) else { return false };
+        let offset = from + hit;
+        if line_timestamp(chunk, offset).is_some() {
+            return true;
+        }
+        from = offset + LOG_LINE_MARKER.len();
+    }
+    false
+}
+
+/// Newest game timestamp among the sync markers in `chunk`.
+///
+/// Every match is examined rather than just the last, because the heap ring
+/// wraps: the newest line is not necessarily the one at the highest address.
+fn newest_sync_timestamp(chunk: &[u8]) -> Option<f64> {
+    let mut newest: Option<f64> = None;
+    let mut from = 0;
+    while let Some(hit) = memmem::find(&chunk[from..], SYNC_MARKER) {
+        let offset = from + hit;
+        if let Some(stamp) = line_timestamp(chunk, offset) {
+            newest = Some(newest.map_or(stamp, |best: f64| best.max(stamp)));
+        }
+        from = offset + SYNC_MARKER.len();
+    }
+    newest
+}
+
+/// Fold a freshly-observed marker timestamp into the baseline, reporting
+/// whether it names a sync that has not been reported yet.
+///
+/// Any difference from the baseline counts, in both directions. The stamps are
+/// seconds since the client launched, so the only way they run backwards is a
+/// game restart, and the sync logged just after one is the login sync that
+/// populates the inventory.
+///
+/// The first observation counts too, rather than being spent establishing a
+/// baseline. A buffer that already holds markers at app start is reporting
+/// history, but reporting it costs nothing, because the first capture walks
+/// memory unconditionally and nothing reads the marker on that tick. Spending
+/// the first observation would instead swallow the login sync after every
+/// restart, since the PID change clears the baseline right before it arrives.
+fn sync_marker_is_new(newest: Option<f64>) -> bool {
+    let Some(newest) = newest else { return false };
+    let previous = f64::from_bits(LAST_SYNC_TIMESTAMP.swap(newest.to_bits(), std::sync::atomic::Ordering::Relaxed));
+    let is_new = newest != previous;
+    if is_new {
+        // Four in a 40-minute session, and the walk policy keys off them, so
+        // they are logged rather than left to be inferred from the walks.
+        eprintln!("[sync] inventory sync marker at {newest:.3}s");
+    }
+    is_new
+}
+
+/// Newest sync-marker timestamp currently in the game's log buffers, probing
+/// the remembered region first and searching for it again when that fails.
+#[cfg(target_os = "windows")]
+fn windows_newest_sync_timestamp(process: windows_sys::Win32::Foundation::HANDLE) -> Option<f64> {
+    use std::ffi::c_void;
+    use std::mem;
+    use windows_sys::Win32::System::{
+        Diagnostics::Debug::ReadProcessMemory,
+        Memory::{VirtualQueryEx, MEMORY_BASIC_INFORMATION, MEM_COMMIT, PAGE_GUARD, PAGE_NOACCESS},
+    };
+
+    // Executable pages hold the `.rdata` copy of the format string, never a
+    // formatted line, so skipping them also skips the obvious false positive.
+    const EXEC_MASK: u32 = 0x10 | 0x20 | 0x40 | 0x80;
+
+    let mut buffer = Vec::new();
+    let read_region = |address: usize, size: usize, buffer: &mut Vec<u8>| -> Option<usize> {
+        buffer.resize(size.min(MAX_LOG_REGION), 0);
+        let mut read = 0usize;
+        let ok = unsafe { ReadProcessMemory(process, address as *const c_void,
+            buffer.as_mut_ptr() as *mut c_void, buffer.len(), &mut read) } != 0;
+        (ok && read > LOG_LINE_MARKER.len()).then_some(read)
+    };
+    let query = |address: usize| -> Option<MEMORY_BASIC_INFORMATION> {
+        let mut mbi = unsafe { mem::zeroed::<MEMORY_BASIC_INFORMATION>() };
+        let ok = unsafe { VirtualQueryEx(process, address as *const c_void, &mut mbi,
+            mem::size_of::<MEMORY_BASIC_INFORMATION>()) } != 0;
+        ok.then_some(mbi)
+    };
+    let readable = |mbi: &MEMORY_BASIC_INFORMATION| {
+        mbi.State == MEM_COMMIT
+            && mbi.Protect & PAGE_GUARD == 0
+            && mbi.Protect & PAGE_NOACCESS == 0
+            && mbi.Protect & EXEC_MASK == 0
+            && mbi.RegionSize > 0
+    };
+
+    let cached = LAST_LOG_REGION.load(std::sync::atomic::Ordering::Relaxed) as usize;
+    if cached != 0 {
+        if let Some(mbi) = query(cached).filter(readable).filter(|mbi| mbi.BaseAddress as usize == cached) {
+            if let Some(read) = read_region(cached, mbi.RegionSize, &mut buffer) {
+                if looks_like_log_buffer(&buffer[..read]) {
+                    return newest_sync_timestamp(&buffer[..read]);
+                }
+            }
+        }
+        // The region is gone or holds something else now; fall through and
+        // look again rather than reporting a silent nothing from here on.
+        LAST_LOG_REGION.store(0, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    if !cold_log_search_due() {
+        return None;
+    }
+
+    // Cold search. There are two copies of the log text: the pending
+    // file-write buffer and a heap ring of recent lines. Which one is
+    // further ahead depends on where the game is in its flush cycle, so both
+    // are read and the newer marker wins.
+    let mut newest: Option<f64> = None;
+    let mut found = 0;
+    let mut address = 0usize;
+    while let Some(mbi) = query(address) {
+        let base = mbi.BaseAddress as usize;
+        let size = mbi.RegionSize;
+        let Some(next) = base.checked_add(size).filter(|next| *next > address) else { break };
+        address = next;
+        if !readable(&mbi) || size > MAX_LOG_REGION {
+            continue;
+        }
+        let Some(read) = read_region(base, size, &mut buffer) else { continue };
+        let chunk = &buffer[..read];
+        if !looks_like_log_buffer(chunk) {
+            continue;
+        }
+        if found == 0 {
+            eprintln!("[sync] sync-marker buffer at 0x{base:012x} ({} KB)", read / 1000);
+            LAST_LOG_REGION.store(base as u64, std::sync::atomic::Ordering::Relaxed);
+        }
+        if let Some(stamp) = newest_sync_timestamp(chunk) {
+            newest = Some(newest.map_or(stamp, |best: f64| best.max(stamp)));
+        }
+        found += 1;
+        if found == 2 {
+            break;
+        }
+    }
+    if found == 0 {
+        eprintln!("[sync] no in-memory log buffer found; sync markers come from the EE.log tail only");
+        LOG_SEARCH_BACKOFF.store(LOG_SEARCH_BACKOFF_PROBES, std::sync::atomic::Ordering::Relaxed);
+    }
+    newest
+}
 
 // ─── Continuous raw memory string dump ───────────────────────────────────────
 //
@@ -1607,7 +1997,7 @@ mod seed_tests {
 
 #[cfg(test)]
 mod blob_digest_tests {
-    use super::{blob_unchanged, forget_blob_digest, reset_last_blob_region};
+    use super::{blob_unchanged, forget_blob_digest, reset_last_blob_region, steady_state_notice_due};
 
     // LAST_BLOB_DIGEST is a process-global static shared with every other test
     // in this binary. Resetting first is not enough on its own: these cases run
@@ -1664,6 +2054,120 @@ mod blob_digest_tests {
         assert!(!blob_unchanged(&garbage), "first sighting reports changed");
         forget_blob_digest();
         assert!(!blob_unchanged(&garbage), "same bytes report changed again after a failed parse");
+    }
+
+    /// Nearly every probe finds identical bytes, so the notice cannot be a
+    /// per-probe line, otherwise it drowns out everything else in the log.
+    #[test]
+    fn the_steady_state_notice_fires_once_per_settle() {
+        let _guard = DIGEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_last_blob_region();
+
+        let blob = b"{\"SubscribedToEmails\":1,\"RegularCredits\":100}".to_vec();
+        assert!(!blob_unchanged(&blob), "first sighting reports changed");
+        assert!(blob_unchanged(&blob), "second sighting is the steady state");
+        assert!(steady_state_notice_due(), "entering the steady state logs once");
+        assert!(!steady_state_notice_due(), "staying in it does not log again");
+
+        let mut mutated = blob.clone();
+        mutated[0] = b'[';
+        assert!(!blob_unchanged(&mutated), "the bytes changed");
+        assert!(blob_unchanged(&mutated), "and settled again");
+        assert!(steady_state_notice_due(), "the next settle logs again");
+
+        reset_last_blob_region();
+        assert!(steady_state_notice_due(), "a new game process starts the cycle over");
+    }
+}
+
+#[cfg(test)]
+mod sync_marker_tests {
+    use super::{
+        cold_log_search_due, looks_like_log_buffer, newest_sync_timestamp, reset_log_region,
+        sync_marker_is_new, LOG_SEARCH_BACKOFF, LOG_SEARCH_BACKOFF_PROBES,
+    };
+
+    // LAST_SYNC_TIMESTAMP and LOG_SEARCH_BACKOFF are process-global, and
+    // reset_log_region clears both at once, so a test calling it races any
+    // other test mid-sequence. Every test here that resets takes this lock.
+    static LOG_STATE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn a_failed_cold_search_sits_out_the_next_probes() {
+        let _guard = LOG_STATE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_log_region();
+        assert!(cold_log_search_due(), "the first search runs");
+
+        LOG_SEARCH_BACKOFF.store(LOG_SEARCH_BACKOFF_PROBES, std::sync::atomic::Ordering::Relaxed);
+        for probe in 0..LOG_SEARCH_BACKOFF_PROBES {
+            assert!(!cold_log_search_due(), "probe {probe} searched during the backoff");
+        }
+        assert!(cold_log_search_due(), "the search resumes once the backoff expires");
+
+        // A PID change clears it: the new client's buffers are worth looking for
+        // straight away.
+        LOG_SEARCH_BACKOFF.store(LOG_SEARCH_BACKOFF_PROBES, std::sync::atomic::Ordering::Relaxed);
+        reset_log_region();
+        assert!(cold_log_search_due());
+    }
+
+    /// The heap ring uses LF, the pending file-write buffer CRLF, and the
+    /// marker has to be found in either.
+    #[test]
+    fn marker_is_read_from_both_buffer_shapes() {
+        let ring = b"19760.121 Sys [Info]: SyncInventoryFromDB\n\
+                     19761.848 Sys [Info]: OnInventoryResults completed in 339ms\n";
+        assert_eq!(newest_sync_timestamp(ring), Some(19761.848));
+
+        let pending = b"19760.121 Sys [Info]: SyncInventoryFromDB\r\n\
+                        19761.848 Sys [Info]: OnInventoryResults completed in 339ms\r\n";
+        assert_eq!(newest_sync_timestamp(pending), Some(19761.848));
+    }
+
+    /// The ring wraps, so the newest line is not the one at the highest
+    /// address. Taking the last match would report an already-seen sync.
+    #[test]
+    fn newest_marker_wins_regardless_of_position() {
+        let wrapped = b"19999.500 Sys [Info]: OnInventoryResults completed in 41ms\n\
+                        11000.000 Sys [Info]: OnInventoryResults completed in 88ms\n";
+        assert_eq!(newest_sync_timestamp(wrapped), Some(19999.500));
+    }
+
+    /// `OnInventoryResults completed in` also exists as a read-only format
+    /// string, which carries no timestamp and must not be mistaken for a line
+    /// the game actually wrote.
+    #[test]
+    fn format_string_without_a_timestamp_is_not_a_marker() {
+        assert_eq!(newest_sync_timestamp(b"OnInventoryResults completed in %dms\0"), None);
+        assert!(!looks_like_log_buffer(b"Sys [Info]: %s\0 Sys [Info]: %s\0"));
+        assert!(looks_like_log_buffer(b"19761.848 Sys [Info]: Revive completed on KubrowPetAvatar14482\n"));
+    }
+
+    #[test]
+    fn baseline_reports_only_unseen_syncs() {
+        let _guard = LOG_STATE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_log_region();
+        assert!(sync_marker_is_new(Some(100.000)), "the first marker seen is not yet reported");
+        assert!(!sync_marker_is_new(Some(100.000)), "the same sync must not report twice");
+        assert!(sync_marker_is_new(Some(140.250)), "a later sync reports");
+        // Seconds since launch, so a stamp running backwards means the client
+        // restarted; ignoring it would swallow markers until the new session
+        // outran the old one.
+        assert!(sync_marker_is_new(Some(12.500)), "a restarted client reports again");
+        assert!(!sync_marker_is_new(None), "no marker in the buffer reports nothing");
+        reset_log_region();
+    }
+
+    /// The PID change that clears the baseline lands moments before the login
+    /// sync, which is the marker the gate is there to catch. Spending the
+    /// first observation on a baseline would drop it on every restart.
+    #[test]
+    fn login_sync_after_a_restart_is_reported() {
+        let _guard = LOG_STATE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_log_region();
+        assert!(sync_marker_is_new(Some(9821.400)), "a marker from the previous client");
+        reset_log_region();
+        assert!(sync_marker_is_new(Some(13.036)), "the new client's login sync must report");
     }
 }
 


### PR DESCRIPTION
# perf(monitor): probe the cached blob instead of walking every 10 s

Depends on #42. This branch is #42 plus one commit, so it will not apply cleanly
until that merges.

**The problem.** The monitor calls `capture_all_blobs` every 10 s. That function
walks every committed region in the game process, reads gigabytes, and drops the
player's framerate for seconds at a time. It runs on that fixed cadence whether or
not the inventory changed, and the inventory changes maybe once per mission.

`capture_all_blobs` already had a fast path for this: probe the address the last
successful scan found the blob at, and if it is still there, skip the walk. But the
fast path lives *inside* the walk function, so a miss means the walk runs anyway.
At a 10 s cadence with a stale address that is a full walk every 10 s for as long
as it stays stale.

**What lands.** One commit, three pieces.

1. `probe_tick`, the fast path pulled out into its own function, with no walk
   behind it. Returns `ScanOutcome::{Updated, Unchanged, CacheMiss}` and never
   escalates on its own. The monitor polls it every 2 s; a hit costs a few
   megabytes of reads.
2. `walk_is_due`, the escalation policy, pure and unit-tested. `Updated`
   never walks, since the probe already delivered the inventory. `CacheMiss` with a
   sync marker walks immediately. `CacheMiss` on a known blob keeps the old 10 s
   cadence. A client with no blob yet, meaning the login screen, waits 60 s. A
   settled inventory answering `Unchanged` waits 900 s, which covers the one case
   the probe genuinely cannot see: the game reallocated the blob but the old
   address still holds a parseable copy of the old bytes.
3. The inventory-sync marker, read out of process memory. Warframe logs
   `OnInventoryResults completed in 339ms` when it finishes fetching inventory.
   That line is the signal that a walk is worth doing. The obvious source is the
   EE.log tail you already run, and this adds that, one `buf.contains` in
   `start_log_watcher`. But the game buffers its log writes and flushes in
   bursts. Sampling a live client showed the newest in-memory log line running
   23 s ahead of the newest line on disk, so the tail alone would put that
   delay in front of every capture. `probe_tick` therefore also finds the line by
   content in the game's own log buffers, identified by ` Sys [Info]: ` preceded by
   a seconds-since-launch timestamp. No pointer chain, no per-build offsets; the
   buffer address caches like `LAST_BLOB_REGION` does, with a 30-probe backoff if
   it cannot be found at all.

**What this changes in behaviour.** In the common case, playing with the inventory
settled, the walk stops happening and the 2 s probe replaces it. When the
inventory does change, capture is *faster* than before, because the marker
escalates immediately instead of waiting out the remainder of the 10 s slot.

**The premise I could not verify on your platform.** The 23 s figure and the claim
that the marker is findable by content in the Windows client's memory both come
from my Linux fork against a Proton-hosted client, sampled with `process_vm_readv`.
The Windows arm here is re-authored against `ReadProcessMemory` / `VirtualQueryEx`
and has never been run. If the buffers are laid out differently on Windows and
the cold search never finds them, `LOG_SEARCH_BACKOFF` sits it out and the EE.log
tail carries the marker instead, so the degradation is latency, not breakage. But
you should expect to check that specifically.

**Verification.**

- `memory_scanner.rs`: the scanner tests run on Linux (26 pass, 7 of them new
  around the marker parsing and the steady-state notice) and the Windows arm
  type-checks under `--target x86_64-pc-windows-gnu`.
- `walk_is_due`: 7 tests, one per rule. They are in `lib.rs`, which does not
  compile here, so I ran them by extracting the function and its tests into a
  standalone file. They pass. The function is pure, four arguments in and a bool
  out, so that is a real check of the policy, but it is not a check that the
  surrounding `lib.rs` compiles.
- `lib.rs` is not compiled. No MSVC linker, and `--target x86_64-pc-windows-gnu`
  dies in `ring`'s build script for want of mingw. Expect to fix something.
- Never run against a live Warframe process on Windows.

**If you reimplement this rather than taking the commit, the load-bearing parts are:**

1. The probe must not fall back to a walk. That is the entire point of
   splitting it out of `capture_all_blobs`. A probe that walks on miss, polled at
   2 s, is strictly worse than the 10 s cadence it replaced.
2. `capture_all_blobs` must lose its inline fast path. The monitor already ran
   that scan and escalated *on its result*; running it again at the top of the walk
   answers the same and skips the walk that was just asked for.
3. Every rule in `walk_is_due` needs an interval that fires without a marker.
   The marker is an optimisation. If any branch depends on it for correctness, a
   client with no EE.log and unlocatable log buffers stops updating entirely.
4. `ScanOutcome::Unchanged` plus a sync marker must still walk. "The client
   fetched inventory and our copy did not move" is indistinguishable from "our
   address is stale and still holds the old bytes". The probe cannot tell them
   apart, so the marker has to win.
5. The marker flag must be held, not read live. The memory probe reports each
   marker exactly once. A marker that arrives on a tick which cannot act on it
   (rate limit, walk in flight) is lost unless it is folded into a sticky flag and
   cleared only when acted on.
6. Clear the marker baseline on PID change, and count the first observation.
   The timestamps are seconds since *that* client launched, so a baseline from the
   previous process swallows everything the new one writes. And the login sync,
   the one that populates the inventory, arrives moments after the PID change, so
   spending the first observation on establishing a baseline drops it on every
   restart.
7. Take the newest marker in the buffer, not the last one. The heap ring wraps,
   so the newest line is not at the highest address.
8. Reject marker matches with no timestamp in front of them. The format string
   `OnInventoryResults completed in %dms` lives in `.rdata` and matches the same
   bytes. Skipping executable pages catches most of it; the timestamp check catches
   the rest.
9. Back off the cold search after it fails. It reads every non-executable
   region under 16 MB. Without a backoff, a client whose buffers cannot be located
   pays that on the monitor thread every 2 s for the whole session.
