### PR TITLE
feat(timers): notify when a watched fissure appears

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-notification": "^2",
     "@tauri-apps/plugin-opener": "^2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2
         version: 2.10.1
+      '@tauri-apps/plugin-notification':
+        specifier: ^2
+        version: 2.3.3
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.5.3
@@ -522,6 +525,9 @@ packages:
     resolution: {integrity: sha512-jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-notification@2.3.3':
+    resolution: {integrity: sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg==}
 
   '@tauri-apps/plugin-opener@2.5.3':
     resolution: {integrity: sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==}
@@ -1102,6 +1108,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.10.1
       '@tauri-apps/cli-win32-ia32-msvc': 2.10.1
       '@tauri-apps/cli-win32-x64-msvc': 2.10.1
+
+  '@tauri-apps/plugin-notification@2.3.3':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
 
   '@tauri-apps/plugin-opener@2.5.3':
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2158,6 +2158,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
+dependencies = [
+ "cc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2341,6 +2355,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "notify-rust"
+version = "4.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2456,6 +2484,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -4160,6 +4189,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-notification"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4279,6 +4327,17 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
+dependencies = [
+ "thiserror 2.0.18",
+ "windows 0.61.3",
+ "windows-version",
 ]
 
 [[package]]
@@ -4922,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "warframe-companion"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "aho-corasick",
  "chrono",
@@ -4936,6 +4995,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tokio",
  "tracing",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,6 +33,7 @@ tracing = "0.1"
 tracing-appender = "0.2"
 tracing-log = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tauri-plugin-notification = "2"
 
 [profile.dev]
 opt-level = 1

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "opener:default",
+    "notification:default",
     "core:webview:allow-create-webview-window",
     "core:window:allow-set-ignore-cursor-events",
     "core:window:allow-close",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -119,6 +119,13 @@ pub struct AppState {
     /// relics.run daily bulk price cache: item display name (lowercase) → median sell price.
     pub relics_run_prices: Mutex<HashMap<String, u32>>,
     pub relics_run_prices_cache_path: PathBuf,
+    /// Raw worldstate + Steam news from the last upstream fetch, with the time it
+    /// was taken. Every window polls worldstate on its own timer, so without this
+    /// two open windows mean two fetch pairs a minute against DE and Steam.
+    /// Only the network payload is cached — parsing still runs per call, so
+    /// activation/expiry filtering stays anchored to the current time. Held
+    /// behind `Arc` so serving a hit shares the ~1MB tree instead of cloning it.
+    pub worldstate_cache: Mutex<Option<(std::time::Instant, Arc<serde_json::Value>, Arc<serde_json::Value>)>>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone)]
@@ -7299,13 +7306,36 @@ async fn fetch_worldstate(state: State<'_, AppState>) -> Result<serde_json::Valu
         let items = state.wfcd_items.lock().unwrap_or_else(|e| e.into_inner());
         items.iter().map(|i| (i.unique_name.clone(), i.name.clone())).collect()
     };
-    tokio::task::spawn_blocking(move || -> Result<serde_json::Value, String> {
+    // Slightly under the 60s frontend poll, so a window's own next tick always
+    // refetches while a second window polling on a different offset is served
+    // from here. Two racing callers can both miss and fetch once each; the
+    // window is small enough that a lock held across the network call is the
+    // worse trade.
+    const WORLDSTATE_TTL: std::time::Duration = std::time::Duration::from_secs(55);
+    let started_at = std::time::Instant::now();
+    let cached = {
+        let cache = state.worldstate_cache.lock().unwrap_or_else(|e| e.into_inner());
+        cache.as_ref()
+            .filter(|(fetched_at, _, _)| fetched_at.elapsed() < WORLDSTATE_TTL)
+            .map(|(_, raw, news)| (Arc::clone(raw), Arc::clone(news)))
+    };
+
+    type CachedPayload = (Arc<serde_json::Value>, Arc<serde_json::Value>);
+    let (result, fetched) = tokio::task::spawn_blocking(move || -> Result<(serde_json::Value, Option<CachedPayload>), String> {
         let now_ms = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_millis() as i64)
             .unwrap_or(0);
+        if let Some((raw, news)) = cached {
+            let mut result = parse_worldstate_value(&raw, now_ms, &catalog);
+            if let Some(obj) = result.as_object_mut() {
+                obj.insert("news".to_string(), news.as_ref().clone());
+            }
+            return Ok((result, None));
+        }
         let raw = ureq::get("https://api.warframe.com/cdn/worldState.php")
             .set("User-Agent", "FrameForge/3.1.0")
+            .timeout(std::time::Duration::from_secs(20))
             .call()
             .map_err(|e| format!("worldstate fetch failed: {}", e))?
             .into_json::<serde_json::Value>()
@@ -7340,13 +7370,25 @@ async fn fetch_worldstate(state: State<'_, AppState>) -> Result<serde_json::Valu
                 })
             })
             .collect();
+        let news_value = serde_json::json!(news);
         if let Some(obj) = result.as_object_mut() {
-            obj.insert("news".to_string(), serde_json::json!(news));
+            obj.insert("news".to_string(), news_value.clone());
         }
-        Ok(result)
+        Ok((result, Some((Arc::new(raw), Arc::new(news_value)))))
     })
     .await
-    .map_err(|e| format!("task error: {}", e))?
+    .map_err(|e| format!("task error: {}", e))??;
+
+    if let Some((raw, news)) = fetched {
+        let mut cache = state.worldstate_cache.lock().unwrap_or_else(|e| e.into_inner());
+        // Two callers that both missed can finish out of order, so a response
+        // that started before what is already stored must not replace it.
+        let stored_is_newer = cache.as_ref().is_some_and(|(fetched_at, _, _)| *fetched_at > started_at);
+        if !stored_is_newer {
+            *cache = Some((std::time::Instant::now(), raw, news));
+        }
+    }
+    Ok(result)
 }
 
 /// Read the riven overlay session log.
@@ -8535,6 +8577,7 @@ pub fn run() {
     tauri::Builder::default()
         .register_uri_scheme_protocol("ffauth", |ctx, req| console_login::handle_ffauth(ctx.app_handle(), &req)) // [console-login feature]
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_notification::init())
         .manage(AppState {
             db_path,
             items_cache_path,
@@ -8585,6 +8628,7 @@ pub fn run() {
             pending_relic_rewards: Mutex::new(None),
             relics_run_prices: Mutex::new(initial_relics_run_prices),
             relics_run_prices_cache_path,
+            worldstate_cache: Mutex::new(None),
         })
         .setup(|app| {
             use tauri::Manager;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,7 +58,10 @@ import MarketHelper, { MARKET_FILTERS_DEFAULT } from "./MarketHelper";
 import RelicHelper, { RELIC_FILTERS_DEFAULT } from "./RelicHelper";
 import RivenAnalyzer from "./RivenAnalyzer";
 import RivenOverlayWindow from "./RivenOverlayWindow";
-import TimerHelper, { FissureWatch } from "./TimerHelper";
+import TimerHelper, { FissureWatch, fmtMs } from "./TimerHelper";
+import { useWorldState } from "./worldstate";
+import { notify, ensurePermission } from "./notify";
+import { collectNewMatches, type SeenFissures } from "./fissureAlerts";
 import Statistics from "./Statistics";
 import Syndicates from "./Syndicates";
 import Overlay from "./Overlay";
@@ -709,6 +712,7 @@ export default function App() {
   const [memoryProbing, setMemoryProbing] = useState(false);
   const [rawScanning, setRawScanning] = useState(false);
   const [diagCapturing, setDiagCapturing] = useState(false);
+  const [notifyTestResult, setNotifyTestResult] = useState("");
   const [diagPath, setDiagPath] = useState<string | null>(null);
   const [autoDiagEnabled, setAutoDiagEnabled] = useState(false);
   const [diagFolderSize, setDiagFolderSize] = useState<number>(0);
@@ -806,6 +810,7 @@ const [blobLogEnabled, setBlobLogEnabled] = useState(false);
   const [favorites, setFavorites] = useState<string[]>([]);
   const [timerFavorites, setTimerFavorites] = useState<string[]>([]);
   const [fissureWatches, setFissureWatches] = useState<FissureWatch[]>([]);
+  const [fissureNotifications, setFissureNotifications] = useState(true);
   const [modularWidth, setModularWidth] = useState(240);
   const [modularSectionOrder, setModularSectionOrder] = useState<string[]>(["tracking", "favorites", "timers", "fissures"]);
   const [modularPopout, setModularPopout] = useState(false);
@@ -822,11 +827,11 @@ const [blobLogEnabled, setBlobLogEnabled] = useState(false);
   const settingsLoadedRef = useRef(false);
   const settingsRef = useRef({
     overlayEnabled: true, overlayPriority: "completion", textScale: 1, colorblindMode: false, clockFormat: "auto" as "auto" | "12h" | "24h", companionApiEnabled: false, memoryScannerEnabled: false, blobLogEnabled: false, apiLogEnabled: false, autoDiagEnabled: false,
-    tracked: [] as string[], favorites: [] as string[], timerFavorites: [] as string[], fissureWatches: [] as FissureWatch[], modularWidth: 240,
+    tracked: [] as string[], favorites: [] as string[], timerFavorites: [] as string[], fissureWatches: [] as FissureWatch[], fissureNotifications: true, modularWidth: 240,
     modularSectionOrder: ["tracking", "favorites", "timers"] as string[], modularPopout: false,
     wfmInvisibleOnStart: false, wfmInvisibleOnClose: false, wfmAutoInvisible: false, wfmAutoInvisibleMins: 30,
   });
-  settingsRef.current = { overlayEnabled, overlayPriority, textScale, colorblindMode, clockFormat, companionApiEnabled, memoryScannerEnabled, blobLogEnabled, apiLogEnabled, autoDiagEnabled, tracked, favorites, timerFavorites, fissureWatches, modularWidth, modularSectionOrder, modularPopout, wfmInvisibleOnStart, wfmInvisibleOnClose, wfmAutoInvisible, wfmAutoInvisibleMins };
+  settingsRef.current = { overlayEnabled, overlayPriority, textScale, colorblindMode, clockFormat, companionApiEnabled, memoryScannerEnabled, blobLogEnabled, apiLogEnabled, autoDiagEnabled, tracked, favorites, timerFavorites, fissureWatches, fissureNotifications, modularWidth, modularSectionOrder, modularPopout, wfmInvisibleOnStart, wfmInvisibleOnClose, wfmAutoInvisible, wfmAutoInvisibleMins };
 
   const saveAllSettings = useCallback(() => {
     // Until the on-disk settings have been applied, settingsRef still holds
@@ -981,7 +986,11 @@ if (typeof s.autoDiagEnabled === "boolean") {
         if (Array.isArray(s.tracked)) setTracked(s.tracked);
         if (Array.isArray(s.favorites)) setFavorites(s.favorites);
         if (Array.isArray(s.timerFavorites)) setTimerFavorites(s.timerFavorites);
-        if (Array.isArray(s.fissureWatches)) setFissureWatches(s.fissureWatches);
+        if (Array.isArray(s.fissureWatches)) {
+          setFissureWatches(s.fissureWatches);
+          restoredWatchIdsRef.current = new Set((s.fissureWatches as FissureWatch[]).map(w => w.id));
+        }
+        if (typeof s.fissureNotifications === "boolean") setFissureNotifications(s.fissureNotifications);
         if (typeof s.modularWidth === "number") setModularWidth(s.modularWidth);
         if (Array.isArray(s.modularSectionOrder)) {
           const order: string[] = s.modularSectionOrder;
@@ -1452,7 +1461,51 @@ if (typeof s.autoDiagEnabled === "boolean") {
 
   useEffect(() => {
     if (settingsLoadedRef.current) saveAllSettings();
-  }, [tracked, favorites, timerFavorites, fissureWatches, modularWidth, memoryScannerEnabled, companionApiEnabled, blobLogEnabled, apiLogEnabled, autoDiagEnabled, modularSectionOrder, modularPopout]); // eslint-disable-line
+  }, [tracked, favorites, timerFavorites, fissureWatches, fissureNotifications, modularWidth, memoryScannerEnabled, companionApiEnabled, blobLogEnabled, apiLogEnabled, autoDiagEnabled, modularSectionOrder, modularPopout]); // eslint-disable-line
+
+  // ── Watched fissure notifications ──────────────────────────────────────────
+  //
+  // Lives here rather than in TimerHelper because TimerHelper only mounts while
+  // its tab is open, and the whole point is to hear about a fissure while
+  // looking at something else. The pop-out window deliberately does not run
+  // this — two windows would otherwise notify twice for the same fissure.
+
+  const { worldState } = useWorldState();
+
+  const seenFissuresRef = useRef<SeenFissures>(new Map());
+  // Watches restored from settings, as opposed to added during this run.
+  const restoredWatchIdsRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!worldState) return;
+
+    const { fresh, live } = collectNewMatches(worldState, fissureWatches, seenFissuresRef.current, restoredWatchIdsRef.current);
+    // Tracked even while notifications are off, so switching them back on does
+    // not announce everything that rotated in during the quiet period.
+    seenFissuresRef.current = live;
+    if (!fissureNotifications || fresh.length === 0) return;
+
+    const suffix = (variant: string, sep: string) =>
+      variant === "hard" ? `${sep}Steel Path` : variant === "storm" ? `${sep}Void Storm` : "";
+
+    if (fresh.length === 1) {
+      const { f, variant } = fresh[0];
+      // fmtMs renders a dash once the clock runs out, which would read as
+      // "Tessera (Void) — — left" for a fissure that expired mid-poll.
+      const remaining = new Date(f.expiry).getTime() - Date.now();
+      void notify(
+        `${f.tier} ${f.missionType}${suffix(variant, " · ")}`,
+        remaining > 0 ? `${f.node} — ${fmtMs(remaining)} left` : f.node,
+      );
+    } else {
+      // A rotation can bring up a dozen matches at once, and a toast each is
+      // enough to make anyone turn the feature off.
+      const shown = fresh.slice(0, 5).map(({ f, variant }) =>
+        `${f.tier} ${f.missionType}${suffix(variant, " ")} — ${f.node}`);
+      if (fresh.length > shown.length) shown.push(`+${fresh.length - shown.length} more`);
+      void notify(`${fresh.length} new fissures`, shown.join("\n"));
+    }
+  }, [worldState, fissureWatches, fissureNotifications]);
 
   // ── Modular pop-out window ─────────────────────────────────────────────────
   useEffect(() => {
@@ -2484,6 +2537,26 @@ if (typeof s.autoDiagEnabled === "boolean") {
                     <div className="settings-section-title">Diagnostics</div>
                     <div className="debug-table">
 
+                      {/* Test Notification */}
+                      <div className="settings-row-info">
+                        <span className="settings-row-label">Test Notification</span>
+                        <span className="settings-row-desc">
+                          Send a desktop notification now, to check the OS delivers them at all.
+                          {notifyTestResult && <span style={{ display: "block", marginTop: 2, color: notifyTestResult.startsWith("Sent") ? "var(--green)" : "var(--red)", fontSize: 11 }}>{notifyTestResult}</span>}
+                        </span>
+                      </div>
+                      <div />{/* Go To Folder placeholder */}
+                      <button className="btn-secondary" onClick={async () => {
+                        setNotifyTestResult("");
+                        if (!(await ensurePermission())) {
+                          setNotifyTestResult("Permission denied — notifications are blocked for FrameForge in your system settings.");
+                          return;
+                        }
+                        await notify("FrameForge", "Test notification — watched fissure alerts will look like this.");
+                        setNotifyTestResult("Sent. If nothing appeared, the OS notification daemon is dropping it.");
+                      }}>Send</button>
+                      <div />{/* Clear placeholder */}
+
                       {/* Overlay Log */}
                       <div className="settings-row-info">
                         <span className="settings-row-label">Overlay Log</span>
@@ -2880,6 +2953,8 @@ if (typeof s.autoDiagEnabled === "boolean") {
               fissureWatches={fissureWatches}
               onAddWatch={w => setFissureWatches(prev => [...prev, w])}
               onRemoveWatch={id => setFissureWatches(prev => prev.filter(w => w.id !== id))}
+              fissureNotifications={fissureNotifications}
+              onFissureNotificationsChange={setFissureNotifications}
               inventory={inventory}
             />
           </ErrorBoundary>

--- a/src/ModularWindow.tsx
+++ b/src/ModularWindow.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import "./ModularWindow.css";
-import { WorldState, TIMER_LABELS, getTimerInfo, fmtMs, FissureWatch, matchesWatch, WsFissure, WsStorm } from "./TimerHelper";
+import { TIMER_LABELS, getTimerInfo, fmtMs, FissureWatch, matchesWatch, WsFissure, WsStorm } from "./TimerHelper";
 import type { InventoryItem } from "./App";
+import { useWorldState } from "./worldstate";
 
 interface CatalogItem {
   unique_name: string;
@@ -93,7 +94,7 @@ export default function ModularWindow({
   const [trackedRecipes, setTrackedRecipes] = useState<Map<string, RecipeComponent[]>>(new Map());
   const [trackingView, setTrackingView] = useState<"need" | "all">("need");
   const [collapsedReqs, setCollapsedReqs] = useState<Set<string>>(new Set());
-  const [worldState, setWorldState] = useState<WorldState | null>(null);
+  const { worldState } = useWorldState();
   const [timerNow, setTimerNow] = useState(Date.now());
 
   const toggleCollapsedReqs = useCallback((id: string) => {
@@ -135,14 +136,6 @@ export default function ModularWindow({
       });
     });
   }, [tracked]); // eslint-disable-line
-
-  useEffect(() => {
-    if (!sectionOrder.includes("timers")) return;
-    const fetch_ = () => invoke<WorldState>("fetch_worldstate").then(setWorldState).catch(() => {});
-    fetch_();
-    const iv = setInterval(fetch_, 60000);
-    return () => clearInterval(iv);
-  }, [sectionOrder]);
 
   useEffect(() => {
     const iv = setInterval(() => setTimerNow(Date.now()), 1000);

--- a/src/TimerHelper.css
+++ b/src/TimerHelper.css
@@ -738,6 +738,25 @@
 }
 .watch-add-btn:hover { background: rgba(56,139,253,.3); }
 
+.watch-notify {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid rgba(48,54,61,.5);
+  color: var(--muted);
+  font-size: 11px;
+  cursor: pointer;
+}
+.watch-notify input { margin: 0; cursor: pointer; }
+
+.watch-notify-denied {
+  margin-top: 4px;
+  color: var(--red);
+  font-size: 10px;
+}
+
 /* ── Watched fissure highlight ── */
 .fissure-watched {
   background: rgba(56,139,253,.08);

--- a/src/TimerHelper.tsx
+++ b/src/TimerHelper.tsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect, useCallback } from "react";
-import { invoke } from "@tauri-apps/api/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import "./TimerHelper.css";
 import type { InventoryItem } from "./App";
+import { useWorldState } from "./worldstate";
+import { ensurePermission } from "./notify";
+import { matchesWatch, type FissureWatch } from "./fissureAlerts";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -31,41 +33,11 @@ interface WsBounty   { expiry: string; jobCount: number; }
 interface WsEvent    { expiry: string; label: string; }
 interface WsNews     { message: string; link: string; date: string | number; stream: boolean; primeAccess: boolean; update: boolean; }
 
-export interface FissureWatch {
-  id: string;
-  tier: string;        // "Any" | "Omnia" | "Lith" | "Meso" | "Neo" | "Axi" | "Requiem"
-  missionType: string; // "Any" | "Rescue" | "Capture" | ...
-  variant: "any" | "normal" | "hard" | "storm";
-}
-
-// actualVariant is passed explicitly from the caller who knows which array the fissure came from
-export function matchesWatch(
-  watch: FissureWatch,
-  fissure: WsFissure | WsStorm,
-  actualVariant: "normal" | "hard" | "storm",
-): boolean {
-  // Variant — checked first; quickest way to exit
-  if (watch.variant !== "any" && watch.variant !== actualVariant) return false;
-
-  // Tier — bidirectional Omnia:
-  // • Watch "Omnia" matches any non-Requiem tier
-  // • Fissure tier "Omnia" matches any watch except "Requiem"
-  const fTier = fissure.tier;
-  if (watch.tier !== "Any") {
-    if (watch.tier === "Omnia") {
-      if (fTier === "Requiem") return false;
-    } else if (fTier === "Omnia") {
-      if (watch.tier === "Requiem") return false;
-    } else if (watch.tier !== fTier) {
-      return false;
-    }
-  }
-
-  // Mission type
-  if (watch.missionType !== "Any" && fissure.missionType !== watch.missionType) return false;
-
-  return true;
-}
+// Fissure watches and their matching rules live in fissureAlerts, which stays
+// free of React so the rules can be exercised on their own. Re-exported here
+// so the rest of the app keeps importing them from where it always has.
+export type { FissureWatch };
+export { matchesWatch };
 
 export interface WorldState {
   cetus?:          WsCetus;
@@ -209,18 +181,20 @@ interface Props {
   fissureWatches: FissureWatch[];
   onAddWatch: (w: FissureWatch) => void;
   onRemoveWatch: (id: string) => void;
+  fissureNotifications: boolean;
+  onFissureNotificationsChange: (enabled: boolean) => void;
   inventory: Record<string, InventoryItem>;
 }
 
 type FissureTab = "normal" | "hard" | "storm";
 
-export default function TimerHelper({ favorites, onFavoriteToggle, fissureWatches, onAddWatch, onRemoveWatch, inventory }: Props) {
-  const [ws, setWs] = useState<WorldState | null>(null);
+export default function TimerHelper({ favorites, onFavoriteToggle, fissureWatches, onAddWatch, onRemoveWatch, fissureNotifications, onFissureNotificationsChange, inventory }: Props) {
+  const { worldState: ws, error, refresh: fetchWS } = useWorldState();
   const [now, setNow] = useState(Date.now());
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState("");
+  const loading = !ws && !error;
   const [fissureTab, setFissureTab] = useState<FissureTab>("normal");
   const [showWatchForm, setShowWatchForm] = useState(false);
+  const [permissionDenied, setPermissionDenied] = useState(false);
   const [openInventory, setOpenInventory] = useState<Set<string>>(new Set());
   const toggleInventory = (id: string) => setOpenInventory(prev => {
     const next = new Set(prev);
@@ -237,14 +211,15 @@ export default function TimerHelper({ favorites, onFavoriteToggle, fissureWatche
     setWMission(m => MISSION_TYPES_BY_VARIANT[v].includes(m) ? m : "Any");
   }, []);
 
-  const fetchWS = useCallback(() => {
-    invoke<WorldState>("fetch_worldstate")
-      .then(data => { setWs(data); setLoading(false); setError(""); })
-      .catch(e => { setError(String(e)); setLoading(false); });
-  }, []);
-
-  useEffect(() => { fetchWS(); const iv = setInterval(fetchWS, 60000); return () => clearInterval(iv); }, [fetchWS]);
   useEffect(() => { const iv = setInterval(() => setNow(Date.now()), 1000); return () => clearInterval(iv); }, []);
+
+  // Watches loaded from settings never went through the add-watch button, so
+  // without this nothing would ever ask the OS and every alert would silently
+  // no-op. Opening the tab is the closest thing to a gesture we get for them.
+  useEffect(() => {
+    if (!fissureNotifications || fissureWatches.length === 0) return;
+    ensurePermission().then(granted => setPermissionDenied(!granted));
+  }, []); // eslint-disable-line
 
   const isFav = (id: string) => favorites.includes(id);
   const cd = (expiry: string) => fmtMs(new Date(expiry).getTime() - now);
@@ -633,10 +608,27 @@ export default function TimerHelper({ favorites, onFavoriteToggle, fissureWatche
                       ))}
                     </div>
                   </div>
-                  <button className="watch-add-btn" onClick={() => {
+                  <button className="watch-add-btn" onClick={async () => {
                     onAddWatch({ id: `${Date.now()}`, tier: wTier, missionType: wMission, variant: wVariant });
                     setWTier("Any"); setWMission("Any"); setVariant("any");
+                    // Prompt here rather than from the poll loop, so the OS dialog
+                    // arrives while the user is thinking about fissure alerts.
+                    if (fissureNotifications && !(await ensurePermission())) setPermissionDenied(true);
                   }}>+ Add Watch</button>
+                  <label className="watch-notify">
+                    <input type="checkbox" checked={fissureNotifications} onChange={async e => {
+                      if (!e.target.checked) { onFissureNotificationsChange(false); return; }
+                      // Turn the setting back off when the OS refuses, rather than
+                      // leaving a ticked box promising alerts that cannot arrive.
+                      const granted = await ensurePermission();
+                      onFissureNotificationsChange(granted);
+                      if (!granted) setPermissionDenied(true);
+                    }} />
+                    Notify me when a watched fissure appears
+                  </label>
+                  {permissionDenied && (
+                    <div className="watch-notify-denied">Notifications are blocked for FrameForge in your system settings.</div>
+                  )}
                 </div>
               </div>
             )}

--- a/src/fissureAlerts.test.ts
+++ b/src/fissureAlerts.test.ts
@@ -1,0 +1,128 @@
+// Run with: node --experimental-strip-types --test src/fissureAlerts.test.ts
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { collectNewMatches, matchesWatch, type FissureWatch, type SeenFissures } from "./fissureAlerts.ts";
+import type { WorldState, WsFissure } from "./TimerHelper.tsx";
+
+const fissure = (id: string, tier = "Lith", missionType = "Capture"): WsFissure => ({
+  id, tier, missionType, expiry: "2030-01-01T00:00:00Z", node: "Tessera (Void)",
+  enemy: "Corpus", tierNum: 1, isStorm: false, isHard: false, active: true,
+});
+
+const watch = (id: string, tier = "Any", missionType = "Any"): FissureWatch =>
+  ({ id, tier, missionType, variant: "any" });
+
+const ws = (fissures: WsFissure[]): WorldState => ({ fissures } as WorldState);
+
+test("watches restored from settings seed silently at launch", () => {
+  const restored = new Set(["w1"]);
+  const { fresh, live } = collectNewMatches(ws([fissure("a"), fissure("b")]), [watch("w1")], new Map(), restored);
+  assert.deepEqual(fresh, []);
+  assert.deepEqual([...live.get("w1")!], ["a", "b"]);
+});
+
+test("a restored watch still reports fissures that arrive after launch", () => {
+  const restored = new Set(["w1"]);
+  const { live } = collectNewMatches(ws([fissure("a")]), [watch("w1")], new Map(), restored);
+  const { fresh } = collectNewMatches(ws([fissure("a"), fissure("b")]), [watch("w1")], live, restored);
+  assert.deepEqual(fresh.map(m => m.f.id), ["b"]);
+});
+
+test("a watch absent from the restored set announces on its first poll", () => {
+  const { fresh } = collectNewMatches(ws([fissure("a")]), [watch("w1")], new Map(), new Set(["other"]));
+  assert.deepEqual(fresh.map(m => m.f.id), ["a"]);
+});
+
+test("only fissures unseen by that watch are reported", () => {
+  const seen: SeenFissures = new Map([["w1", new Set(["a"])]]);
+  const { fresh } = collectNewMatches(ws([fissure("a"), fissure("b")]), [watch("w1")], seen);
+  assert.deepEqual(fresh.map(m => m.f.id), ["b"]);
+});
+
+test("a fissure matching two watches is reported once", () => {
+  const seen: SeenFissures = new Map([["w1", new Set()], ["w2", new Set()]]);
+  const { fresh } = collectNewMatches(ws([fissure("a")]), [watch("w1"), watch("w2", "Lith")], seen);
+  assert.deepEqual(fresh.map(m => m.f.id), ["a"]);
+});
+
+test("a watch added at runtime announces what is already live", () => {
+  const seen: SeenFissures = new Map([["w1", new Set(["a"])]]);
+  const { fresh } = collectNewMatches(ws([fissure("a")]), [watch("w1"), watch("w2")], seen);
+  assert.deepEqual(fresh.map(m => m.f.id), ["a"]);
+});
+
+test("the same fissure is never announced twice for one watch", () => {
+  const watches = [watch("w1")];
+  const worldState = ws([fissure("a")]);
+
+  const first = collectNewMatches(worldState, watches, new Map());
+  assert.deepEqual(first.fresh.map(m => m.f.id), ["a"]);
+
+  // Every later poll still matches it, and must stay quiet for as long as it lives.
+  let seen = first.live;
+  for (let poll = 0; poll < 3; poll++) {
+    const next = collectNewMatches(worldState, watches, seen);
+    assert.deepEqual(next.fresh, []);
+    seen = next.live;
+  }
+});
+
+test("a fissure that expires and returns under a new id announces again", () => {
+  const watches = [watch("w1")];
+  const { live } = collectNewMatches(ws([fissure("a")]), watches, new Map());
+  const { fresh } = collectNewMatches(ws([fissure("b")]), watches, live);
+  assert.deepEqual(fresh.map(m => m.f.id), ["b"]);
+});
+
+test("expired fissures and removed watches drop out of the returned state", () => {
+  const seen: SeenFissures = new Map([["w1", new Set(["a", "gone"])], ["removed", new Set(["a"])]]);
+  const { live } = collectNewMatches(ws([fissure("a")]), [watch("w1")], seen);
+  assert.deepEqual([...live.keys()], ["w1"]);
+  assert.deepEqual([...live.get("w1")!], ["a"]);
+});
+
+test("entries with no id are ignored rather than sharing one key", () => {
+  const seen: SeenFissures = new Map([["w1", new Set()]]);
+  const { fresh, live } = collectNewMatches(ws([fissure(""), fissure("")]), [watch("w1")], seen);
+  assert.deepEqual(fresh, []);
+  assert.equal(live.get("w1")!.size, 0);
+});
+
+test("Omnia matches both ways except against Requiem", () => {
+  const omniaWatch = watch("w", "Omnia");
+  assert.equal(matchesWatch(omniaWatch, fissure("a", "Axi"), "normal"), true);
+  assert.equal(matchesWatch(omniaWatch, fissure("a", "Requiem"), "normal"), false);
+  assert.equal(matchesWatch(watch("w", "Axi"), fissure("a", "Omnia"), "normal"), true);
+  assert.equal(matchesWatch(watch("w", "Requiem"), fissure("a", "Omnia"), "normal"), false);
+});
+
+test("a variant-specific watch ignores the other variants", () => {
+  const hardWatch: FissureWatch = { id: "w", tier: "Any", missionType: "Any", variant: "hard" };
+  assert.equal(matchesWatch(hardWatch, fissure("a"), "hard"), true);
+  assert.equal(matchesWatch(hardWatch, fissure("a"), "normal"), false);
+  assert.equal(matchesWatch(hardWatch, fissure("a"), "storm"), false);
+});
+
+test("mission type must match exactly unless the watch says Any", () => {
+  assert.equal(matchesWatch(watch("w", "Any", "Capture"), fissure("a", "Lith", "Capture"), "normal"), true);
+  assert.equal(matchesWatch(watch("w", "Any", "Capture"), fissure("a", "Lith", "Rescue"), "normal"), false);
+  assert.equal(matchesWatch(watch("w"), fissure("a", "Lith", "Rescue"), "normal"), true);
+});
+
+test("a Steel Path fissure only reaches a watch that accepts hard", () => {
+  const seen: SeenFissures = new Map([["w1", new Set()]]);
+  const worldState = { spFissures: [fissure("sp")] } as unknown as WorldState;
+  const hardWatch: FissureWatch = { id: "w1", tier: "Any", missionType: "Any", variant: "hard" };
+  assert.deepEqual(collectNewMatches(worldState, [hardWatch], seen).fresh.map(m => m.variant), ["hard"]);
+
+  const stormWatch: FissureWatch = { id: "w1", tier: "Any", missionType: "Any", variant: "storm" };
+  assert.deepEqual(collectNewMatches(worldState, [stormWatch], seen).fresh, []);
+});
+
+test("an empty worldstate notifies nothing and seeds an empty set", () => {
+  const seen: SeenFissures = new Map([["w1", new Set(["a"])]]);
+  const { fresh, live } = collectNewMatches({} as WorldState, [watch("w1")], seen);
+  assert.deepEqual(fresh, []);
+  assert.equal(live.get("w1")!.size, 0);
+});

--- a/src/fissureAlerts.ts
+++ b/src/fissureAlerts.ts
@@ -1,0 +1,87 @@
+import type { WorldState, WsFissure, WsStorm } from "./TimerHelper";
+
+export type FissureVariant = "normal" | "hard" | "storm";
+
+export interface FissureWatch {
+  id: string;
+  tier: string;        // "Any" | "Omnia" | "Lith" | "Meso" | "Neo" | "Axi" | "Requiem"
+  missionType: string; // "Any" | "Rescue" | "Capture" | ...
+  variant: "any" | FissureVariant;
+}
+
+// actualVariant is passed explicitly from the caller who knows which array the fissure came from
+export function matchesWatch(
+  watch: FissureWatch,
+  fissure: WsFissure | WsStorm,
+  actualVariant: FissureVariant,
+): boolean {
+  // Variant — checked first; quickest way to exit
+  if (watch.variant !== "any" && watch.variant !== actualVariant) return false;
+
+  // Tier — bidirectional Omnia:
+  // • Watch "Omnia" matches any non-Requiem tier
+  // • Fissure tier "Omnia" matches any watch except "Requiem"
+  const fTier = fissure.tier;
+  if (watch.tier !== "Any") {
+    if (watch.tier === "Omnia") {
+      if (fTier === "Requiem") return false;
+    } else if (fTier === "Omnia") {
+      if (watch.tier === "Requiem") return false;
+    } else if (watch.tier !== fTier) {
+      return false;
+    }
+  }
+
+  // Mission type
+  if (watch.missionType !== "Any" && fissure.missionType !== watch.missionType) return false;
+
+  return true;
+}
+export type MatchedFissure = { f: WsFissure | WsStorm; variant: FissureVariant };
+
+export type SeenFissures = Map<string, Set<string>>;
+
+// A watch with no entry in `seen` yet is new, and everything it matches right
+// now is announced: someone adding a watch wants to know what is live, and
+// should not have to wait for the next rotation to find out. `restoredIds`
+// names the exception, the watches loaded from settings at startup, which are
+// seeded in silence so launching the app is not a wall of notifications about
+// fissures the user has been watching for days.
+//
+// The caller replaces its seen-state with `live` wholesale. That is what drops
+// expired fissures and removed watches, so nothing accumulates for as long as
+// the app runs.
+export function collectNewMatches(
+  worldState: WorldState,
+  watches: FissureWatch[],
+  seen: SeenFissures,
+  restoredIds: ReadonlySet<string> = new Set(),
+): { fresh: MatchedFissure[]; live: SeenFissures } {
+  const byVariant: [(WsFissure | WsStorm)[], FissureVariant][] = [
+    [worldState.fissures   ?? [], "normal"],
+    [worldState.spFissures ?? [], "hard"],
+    [worldState.voidStorms ?? [], "storm"],
+  ];
+
+  const live: SeenFissures = new Map();
+  // Keyed by fissure id so a fissure covered by two watches is announced once.
+  const fresh = new Map<string, MatchedFissure>();
+
+  for (const watch of watches) {
+    const matched = new Set<string>();
+    const previous = seen.get(watch.id);
+    const announces = previous !== undefined || !restoredIds.has(watch.id);
+    for (const [list, variant] of byVariant) {
+      for (const f of list) {
+        // An id is only missing when DE's payload is malformed; without this
+        // every such entry would collapse onto the same empty-string key.
+        if (!f.id || !matchesWatch(watch, f, variant)) continue;
+        matched.add(f.id);
+        if (announces && !previous?.has(f.id)) fresh.set(f.id, { f, variant });
+      }
+    }
+    live.set(watch.id, matched);
+  }
+
+  return { fresh: [...fresh.values()], live };
+}

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -1,0 +1,34 @@
+import { isPermissionGranted, requestPermission, sendNotification } from "@tauri-apps/plugin-notification";
+
+// Only an in-flight prompt is memoised, so concurrent callers share one dialog
+// without the answer being cached for the run: permission can change in OS
+// settings at any point, and a remembered "denied" would outlive the change.
+let pending: Promise<boolean> | null = null;
+
+// Call from a user gesture, never from a timer: an OS prompt raised by a
+// background poll arrives minutes after anything the user did, with nothing
+// on screen to explain it.
+export function ensurePermission(): Promise<boolean> {
+  pending ??= (async () => {
+    try {
+      return (await isPermissionGranted()) || (await requestPermission()) === "granted";
+    } catch (e) {
+      console.error("notification permission request failed", e);
+      return false;
+    } finally {
+      pending = null;
+    }
+  })();
+  return pending;
+}
+
+// Never prompts and never throws: a missing notification daemon or a denied
+// permission must not break the caller's poll loop.
+export async function notify(title: string, body: string): Promise<void> {
+  try {
+    if (!(await isPermissionGranted())) return;
+    sendNotification({ title, body });
+  } catch (e) {
+    console.error("notification failed", e);
+  }
+}

--- a/src/worldstate.ts
+++ b/src/worldstate.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import type { WorldState } from "./TimerHelper";
+
+// One poll per window, shared by every consumer. A timer per component would
+// give the Timers tab and the modular sidebar unsynchronised views of the same
+// data, and each fetch crosses the IPC boundary and re-parses ~1MB of JSON even
+// when the backend serves it from cache.
+
+const POLL_MS = 60_000;
+
+type Snapshot = { worldState: WorldState | null; error: string };
+
+let current: Snapshot = { worldState: null, error: "" };
+let inFlight: Promise<void> | null = null;
+let timer: ReturnType<typeof setInterval> | null = null;
+const subscribers = new Set<(s: Snapshot) => void>();
+
+function publish(next: Snapshot) {
+  current = next;
+  for (const notify of subscribers) notify(next);
+}
+
+function fetchOnce(): Promise<void> {
+  inFlight ??= invoke<WorldState>("fetch_worldstate")
+    .then(ws => publish({ worldState: ws, error: "" }))
+    .catch(e => publish({ ...current, error: String(e) }))
+    .finally(() => { inFlight = null; });
+  return inFlight;
+}
+
+export function useWorldState(): Snapshot & { refresh: () => void } {
+  const [snapshot, setSnapshot] = useState(current);
+
+  useEffect(() => {
+    subscribers.add(setSnapshot);
+    if (subscribers.size === 1) {
+      fetchOnce();
+      timer = setInterval(fetchOnce, POLL_MS);
+    } else {
+      setSnapshot(current);
+    }
+    return () => {
+      subscribers.delete(setSnapshot);
+      if (subscribers.size === 0 && timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+    };
+  }, []);
+
+  return { ...snapshot, refresh: fetchOnce };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,8 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src"],
+  // Tests run under `node --experimental-strip-types`, not through the bundler,
+  // so they use node: imports the app build has no types for.
+  "exclude": ["src/**/*.test.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
Fissure watches only filtered the display, so a fissure the user was waiting for turned up silently unless the Timers tab happened to be on screen. Each worldstate poll is now diffed per watch, and a match that was not live on the previous poll raises an OS notification. A checkbox next to the watch list turns the alerts off.

Polling moved behind a shared hook and the backend keeps the upstream payload between calls, because every window used to fetch on its own timer against DE and Steam. That also fixes the modular sidebar's fissure section going stale for anyone who dropped the timers section.