### PR TITLE
refactor(scanner): put an OS-read adapter under the blob-stitch engine

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,6 +22,7 @@ use tauri::{Emitter, Manager, State};
 mod console_login; // [console-login feature] remove this line to drop the feature
 mod db;
 mod logging;
+mod mem_regions;
 mod memory_scanner;
 mod ocr;
 mod wfcd;
@@ -76,8 +77,7 @@ pub struct AppState {
     /// When true, save the raw DE API response to api_logs/ on each fetch.
     pub api_log_enabled: Arc<AtomicBool>,
     pub api_log_dir: PathBuf,
-    /// The warframe.market client: session, rate limiters, and the slug → price
-    /// cache all live behind this one seam, shared (Arc) with the prefetch thread.
+    /// The warframe.market client, shared (Arc) with the prefetch thread.
     pub wfm: Arc<Wfm>,
     /// Slugs waiting for a price fetch (normal priority). Drained by the WFM queue thread.
     pub wfm_price_queue: Arc<Mutex<std::collections::VecDeque<String>>>,
@@ -904,12 +904,7 @@ async fn fetch_warframe_inventory(account_id: String, nonce: String, steam_id: S
     Err(last_err)
 }
 
-// ─── Warframe.market ──────────────────────────────────────────────────────────
-
 // ─── Warframe.market trading ──────────────────────────────────────────────────
-// The WFM client lives in `wfm.rs`; the command handlers below are thin adapters
-// over `state.wfm`. Session acquisition (this login webview) and keyring
-// persistence stay here at the Tauri boundary.
 
 /// Open warframe.market signin in an embedded WebView.
 /// Emits `wfm-login-window-closed` if the window is closed before auth completes.
@@ -1217,12 +1212,10 @@ struct WfmTopDiskCache {
 async fn get_wfm_top_items(state: State<'_, AppState>) -> Result<Vec<WfmTopItem>, String> {
     const TOP_TTL: std::time::Duration = std::time::Duration::from_secs(3 * 3600);
 
-    // In-memory cache, fresh within the TTL — the client owns it.
     if let Some(items) = state.wfm.cached_top_items(TOP_TTL) {
         return Ok(items);
     }
 
-    // Disk cache — survives app restarts.
     let disk_cache_path = state.wfm_top_cache_path.clone();
     if let Ok(s) = std::fs::read_to_string(&disk_cache_path) {
         if let Ok(dc) = serde_json::from_str::<WfmTopDiskCache>(&s) {
@@ -1743,8 +1736,6 @@ fn get_weapon_dispositions(state: State<AppState>) -> HashMap<String, f32> {
 
 /// Guards against concurrent scans: only one get_wfm_top_items scan runs at a time.
 /// Concurrent callers wait (polling the cache) rather than starting a second scan.
-/// Scan orchestration is the command's concern; the cached result it produces
-/// lives in `Wfm`.
 static WFM_SCAN_RUNNING: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
@@ -2999,8 +2990,6 @@ fn record_new_auction_id(state: &State<AppState>, json: &serde_json::Value) {
 }
 
 /// Switch a riven auction between Auction and Direct Sale types.
-/// The close-and-recreate lives in `Wfm`; here we reconcile the stored auction
-/// ids — drop the closed one, record its replacement.
 #[tauri::command]
 fn wfm_switch_riven_type(
     state: State<AppState>,
@@ -3051,8 +3040,8 @@ fn fetch_wfm_items(state: State<AppState>) -> Result<Vec<WfmItem>, String> {
 /// removed — WFM is inconsistent about whether component blueprints include it.
 #[tauri::command]
 fn fetch_wfm_price(state: State<AppState>, url_name: String) -> Result<WfmPrice, String> {
-    // A lookup that errors and one that finds no listing both surface the same way
-    // to the UI — no price — so `price_with_fallback` collapsing both to None is fine.
+    // An error and a missing listing both show as "no price" in the UI, so both
+    // collapse to None.
     let sell_median = state.wfm.price_with_fallback(&url_name).map(|p| p as f64);
     Ok(WfmPrice { url_name, sell_median, buy_median: None })
 }

--- a/src-tauri/src/mem_regions.rs
+++ b/src-tauri/src/mem_regions.rs
@@ -1,0 +1,250 @@
+//! Memory-region sources for the blob-stitch engine.
+//!
+//! `WindowsRegionSource` reads regions from a running game.
+//! `RecordedRegions` replays recorded regions, so tests can run without the game.
+
+/// Streams a target's readable memory regions in ascending-address order.
+///
+/// Each `next_region` yields `(base_address, bytes)` for one region, and
+/// `None` ends the walk. The engine relies only on ascending addresses and
+/// on `bytes` starting at `base_address`. Filtering (protection, size, image
+/// sections), read caps, and skipping unreadable regions are the source's
+/// own policy.
+///
+/// `read_at` serves the cached-blob fast path. It returns the bytes starting
+/// at `addr` itself, not at the containing region's base, plus the address
+/// just past that region, so the caller can stitch forward. It skips the
+/// size and executable filters of `next_region`: a caller probing a known
+/// address only cares whether it is still readable. An unreadable-but-mapped
+/// address yields empty bytes rather than `None`.
+pub trait RegionSource {
+    fn next_region(&mut self) -> Option<(usize, Vec<u8>)>;
+    fn read_at(&self, addr: usize) -> Option<(usize, Vec<u8>)>;
+}
+
+#[cfg(test)]
+pub struct RecordedRegions {
+    regions: Vec<(usize, Vec<u8>)>,
+    pos: usize,
+}
+
+#[cfg(test)]
+impl RecordedRegions {
+    pub fn new(regions: Vec<(usize, Vec<u8>)>) -> Self {
+        Self { regions, pos: 0 }
+    }
+}
+
+#[cfg(test)]
+impl RegionSource for RecordedRegions {
+    fn next_region(&mut self) -> Option<(usize, Vec<u8>)> {
+        let r = self.regions.get(self.pos).cloned();
+        self.pos += 1;
+        r
+    }
+
+    fn read_at(&self, addr: usize) -> Option<(usize, Vec<u8>)> {
+        for (base, bytes) in &self.regions {
+            let end = base + bytes.len();
+            if (*base..end).contains(&addr) {
+                return Some((end, bytes[addr - base..].to_vec()));
+            }
+        }
+        None
+    }
+}
+
+/// Walks a live Warframe process with `VirtualQueryEx`/`ReadProcessMemory`.
+/// Closes the handle on drop.
+///
+/// `next_region` filters to committed, readable, non-code, non-image regions
+/// of at least `min_region` bytes. The filter drops PE image sections because
+/// they hold exe/DLL string constants that false-trigger the Lotus anchor
+/// check and cost tens of seconds.
+#[cfg(target_os = "windows")]
+pub struct WindowsRegionSource {
+    process: windows_sys::Win32::Foundation::HANDLE,
+    addr: usize,
+    min_region: usize,
+    read_cap: usize,
+    // Diagnostics for the capture-done log. `Cell`s because `query`/`read`
+    // run from both `&self` (`read_at`) and `&mut self` (`next_region`).
+    skipped: std::cell::Cell<usize>,
+    query_time: std::cell::Cell<std::time::Duration>,
+    read_time: std::cell::Cell<std::time::Duration>,
+}
+
+#[cfg(target_os = "windows")]
+impl WindowsRegionSource {
+    pub fn open(pid: u32, min_region: usize, read_cap: usize) -> Option<Self> {
+        use windows_sys::Win32::System::Threading::{
+            OpenProcess, PROCESS_QUERY_INFORMATION, PROCESS_VM_READ,
+        };
+        let process = unsafe {
+            OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, 0, pid)
+        };
+        if process == 0 {
+            return None;
+        }
+        Some(Self {
+            process,
+            addr: 0,
+            min_region,
+            read_cap,
+            skipped: Default::default(),
+            query_time: Default::default(),
+            read_time: Default::default(),
+        })
+    }
+
+    /// `(regions_skipped, vquery_ms, read_ms)` accumulated since `open`.
+    pub fn stats(&self) -> (usize, f64, f64) {
+        (
+            self.skipped.get(),
+            self.query_time.get().as_secs_f64() * 1000.0,
+            self.read_time.get().as_secs_f64() * 1000.0,
+        )
+    }
+
+    /// Queries the region containing `addr`. `None` when the query fails or
+    /// the region would not advance a walk past `addr` (loop/overflow guard).
+    fn query(
+        &self,
+        addr: usize,
+    ) -> Option<windows_sys::Win32::System::Memory::MEMORY_BASIC_INFORMATION> {
+        use std::ffi::c_void;
+        use std::mem;
+        use windows_sys::Win32::System::Memory::{VirtualQueryEx, MEMORY_BASIC_INFORMATION};
+
+        let t = std::time::Instant::now();
+        let mut mbi = unsafe { mem::zeroed::<MEMORY_BASIC_INFORMATION>() };
+        let ok = unsafe {
+            VirtualQueryEx(
+                self.process,
+                addr as *const c_void,
+                &mut mbi,
+                mem::size_of::<MEMORY_BASIC_INFORMATION>(),
+            )
+        } != 0;
+        self.query_time.set(self.query_time.get() + t.elapsed());
+        if !ok {
+            return None;
+        }
+        let next_addr = (mbi.BaseAddress as usize).saturating_add(mbi.RegionSize);
+        if next_addr <= addr {
+            return None;
+        }
+        Some(mbi)
+    }
+
+    fn unreadable(
+        mbi: &windows_sys::Win32::System::Memory::MEMORY_BASIC_INFORMATION,
+    ) -> bool {
+        use windows_sys::Win32::System::Memory::{MEM_COMMIT, PAGE_GUARD, PAGE_NOACCESS};
+        mbi.State != MEM_COMMIT
+            || mbi.Protect & PAGE_GUARD != 0
+            || mbi.Protect & PAGE_NOACCESS != 0
+    }
+
+    /// Reads up to `len.min(read_cap)` bytes at `addr`, truncated to the byte
+    /// count actually read. `None` when the read fails outright.
+    ///
+    /// The cap can leave a region's tail unread while the walk advances past
+    /// it. That is harmless while `read_cap` (64 MB) exceeds the engine's
+    /// scan limit (20 MB): a blob crossing the cap would be dropped anyway.
+    fn read(&self, addr: usize, len: usize) -> Option<Vec<u8>> {
+        use std::ffi::c_void;
+        use windows_sys::Win32::System::Diagnostics::Debug::ReadProcessMemory;
+
+        let t = std::time::Instant::now();
+        let len = len.min(self.read_cap);
+        let mut buf = vec![0u8; len];
+        let mut n = 0usize;
+        let ok = unsafe {
+            ReadProcessMemory(
+                self.process,
+                addr as *const c_void,
+                buf.as_mut_ptr() as *mut c_void,
+                len,
+                &mut n,
+            )
+        } != 0;
+        self.read_time.set(self.read_time.get() + t.elapsed());
+        if !ok {
+            return None;
+        }
+        buf.truncate(n);
+        Some(buf)
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl RegionSource for WindowsRegionSource {
+    fn next_region(&mut self) -> Option<(usize, Vec<u8>)> {
+        use windows_sys::Win32::System::Memory::MEM_IMAGE;
+
+        // Executable pages never contain heap data, so they are safe to skip.
+        const PAGE_EXECUTE: u32 = 0x10;
+        const PAGE_EXECUTE_READ: u32 = 0x20;
+        const PAGE_EXECUTE_RW: u32 = 0x40;
+        const PAGE_EXECUTE_WC: u32 = 0x80;
+        const EXEC_MASK: u32 =
+            PAGE_EXECUTE | PAGE_EXECUTE_READ | PAGE_EXECUTE_RW | PAGE_EXECUTE_WC;
+
+        loop {
+            let mbi = self.query(self.addr)?;
+            let region_addr = mbi.BaseAddress as usize;
+            let region_size = mbi.RegionSize;
+            self.addr = region_addr.saturating_add(region_size);
+
+            // ── Region filters ──────────────────────────────────────────────────
+            // Skip pages that can never hold heap JSON:
+            // • must be committed and readable
+            // • skip execute-only pages (code sections, JIT stubs)
+            // • skip PE image sections: their exe/DLL string constants
+            //   false-trigger the Lotus anchor check and cost ~40 s scanning
+            //   20 MB+ without ever finding the blob end
+            // • skip anything smaller than MIN_REGION
+            if Self::unreadable(&mbi)
+                || mbi.Protect & EXEC_MASK != 0
+                || mbi.Type == MEM_IMAGE
+                || region_size < self.min_region
+            {
+                self.skipped.set(self.skipped.get() + 1);
+                continue;
+            }
+
+            match self.read(region_addr, region_size) {
+                // Fewer than 8 bytes cannot hold any marker, so treat this as a failed read.
+                Some(buf) if buf.len() >= 8 => return Some((region_addr, buf)),
+                _ => continue,
+            }
+        }
+    }
+
+    fn read_at(&self, addr: usize) -> Option<(usize, Vec<u8>)> {
+        use windows_sys::Win32::System::Memory::MEM_IMAGE;
+
+        let mbi = self.query(addr)?;
+        let next_addr = (mbi.BaseAddress as usize).saturating_add(mbi.RegionSize);
+        // Image sections get the empty-bytes treatment too: a stale cached
+        // address can land in a remapped DLL, whose string constants can only
+        // false-trigger the anchor checks.
+        if Self::unreadable(&mbi) || mbi.Type == MEM_IMAGE {
+            return Some((next_addr, Vec::new()));
+        }
+        // Read from the requested address, not the region base: the cached
+        // blob-start address sits mid-region, and the caller checks that the
+        // returned bytes begin with the blob's opening `{"`.
+        let bytes = self.read(addr, next_addr - addr).unwrap_or_default();
+        Some((next_addr, bytes))
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl Drop for WindowsRegionSource {
+    fn drop(&mut self) {
+        use windows_sys::Win32::Foundation::CloseHandle;
+        unsafe { CloseHandle(self.process) };
+    }
+}

--- a/src-tauri/src/memory_scanner.rs
+++ b/src-tauri/src/memory_scanner.rs
@@ -835,13 +835,9 @@ pub fn reset_last_blob_region() {
 
 #[cfg(target_os = "windows")]
 const MAX_READ: usize = 64 * 1024 * 1024;
-#[cfg(target_os = "windows")]
 const MAX_SCAN: usize = 20 * 1024 * 1024;
-#[cfg(target_os = "windows")]
 const MISSION_DELTA: &[u8] = b"\"InventoryChanges\":";
-#[cfg(target_os = "windows")]
 const LOTUS_KEY: &[u8] = b"/Lotus/";
-#[cfg(target_os = "windows")]
 const ANCHORS: &[&[u8]] = &[
     b"\"SubscribedToEmails\"",
     b"\"MiscItems\":[",
@@ -877,97 +873,92 @@ const ANCHORS: &[&[u8]] = &[
 #[cfg(target_os = "windows")]
 #[tracing::instrument(level = "debug", skip_all, fields(save = save))]
 pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::sync::mpsc::Sender<BlobInventory>, save: bool) -> usize {
-    use std::ffi::c_void;
-    use std::mem;
-    use windows_sys::Win32::{
-        Foundation::{CloseHandle, FALSE},
-        System::{
-            Diagnostics::Debug::ReadProcessMemory,
-            Memory::{VirtualQueryEx, MEMORY_BASIC_INFORMATION, MEM_COMMIT, MEM_IMAGE, PAGE_GUARD, PAGE_NOACCESS},
-            Threading::{OpenProcess, PROCESS_QUERY_INFORMATION, PROCESS_VM_READ},
-        },
-    };
+    const MIN_REGION: usize = 64_000;
 
     let pid = match find_warframe_pid_pub() { Some(p) => p, None => return 0 };
-    let process = unsafe { OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, pid) };
-    if process == 0 { return 0; }
-
-    const MIN_REGION:    usize = 64_000;   // skip regions smaller than 64 KB
-    const MAX_BLOBS:     usize = 25;
-
-    // Executable pages never contain heap data — safe to skip.
-    const PAGE_EXECUTE:      u32 = 0x10;
-    const PAGE_EXECUTE_READ: u32 = 0x20;
-    const PAGE_EXECUTE_RW:   u32 = 0x40;
-    const PAGE_EXECUTE_WC:   u32 = 0x80;
-    const EXEC_MASK: u32 = PAGE_EXECUTE | PAGE_EXECUTE_READ | PAGE_EXECUTE_RW | PAGE_EXECUTE_WC;
-
-    // Fast path: try the cached region from last successful scan.
+    let mut src = match crate::mem_regions::WindowsRegionSource::open(pid, MIN_REGION, MAX_READ) {
+        Some(s) => s,
+        None => return 0,
+    };
+    // A debug capture wants every blob in memory, so it always takes the cold walk.
     let cached_addr = LAST_BLOB_REGION.load(std::sync::atomic::Ordering::Relaxed) as usize;
-    if cached_addr != 0 && !save {
-        let mut mbi = unsafe { mem::zeroed::<MEMORY_BASIC_INFORMATION>() };
-        let ok = unsafe { VirtualQueryEx(process, cached_addr as *const c_void, &mut mbi,
-            mem::size_of::<MEMORY_BASIC_INFORMATION>()) } != 0;
-        if ok && mbi.State == MEM_COMMIT
-            && mbi.Protect & PAGE_GUARD == 0
-            && mbi.Protect & PAGE_NOACCESS == 0
-        {
-            let read_cap = mbi.RegionSize.min(MAX_READ);
-            let mut buf = vec![0u8; read_cap];
-            let mut n = 0usize;
-            let read_ok = unsafe { ReadProcessMemory(process, cached_addr as *const c_void,
-                buf.as_mut_ptr() as *mut c_void, read_cap, &mut n) } != 0 && n >= 8;
-            if read_ok {
-                let chunk = &buf[..n];
-                let is_mission = memchr::memmem::find(chunk, MISSION_DELTA).is_some();
-                let has_anchor = ANCHORS.iter().any(|a| memchr::memmem::find(chunk, a).is_some());
-                let has_lotus  = memchr::memmem::find(chunk, LOTUS_KEY).is_some();
-                if !is_mission && (has_anchor || has_lotus) && chunk.starts_with(b"{\"") {
-                    let mut stitched = chunk.to_vec();
-                    let mut walk = cached_addr + n;
-                    while stitched.len() < MAX_SCAN && find_blob_end(&stitched).is_none() {
-                        let mut nmbi = unsafe { mem::zeroed::<MEMORY_BASIC_INFORMATION>() };
-                        if unsafe { VirtualQueryEx(process, walk as *const c_void, &mut nmbi,
-                            mem::size_of::<MEMORY_BASIC_INFORMATION>()) } == 0 { break; }
-                        let nr = nmbi.BaseAddress as usize;
-                        let ns = nmbi.RegionSize;
-                        walk = nr + ns;
-                        if nmbi.State != MEM_COMMIT
-                            || nmbi.Protect & PAGE_GUARD != 0
-                            || nmbi.Protect & PAGE_NOACCESS != 0
-                            || ns == 0 { continue; }
-                        let cap = ns.min(MAX_READ);
-                        let mut nb = vec![0u8; cap];
-                        let mut nn = 0usize;
-                        if unsafe { ReadProcessMemory(process, nr as *const c_void,
-                            nb.as_mut_ptr() as *mut c_void, cap, &mut nn) } == 0 { continue; }
-                        stitched.extend_from_slice(&nb[..nn]);
-                    }
-                    // Require the FULL_ACCOUNT start marker — mission-context blobs
-                    // at the cached address pass the anchor check but lack this field.
-                    if memchr::memmem::find(&stitched, START_MARKER).is_some() {
-                        if let Some(inv) = parse_full_account_blob(&stitched) {
-                            info!(addr = format_args!("0x{cached_addr:012x}"),
-                                unique = inv.unique_items.len(),
-                                stackable = inv.stackable_items.len(),
-                                "fast-path hit");
-                            blob_tx.send(inv).ok();
-                            unsafe { CloseHandle(process); }
-                            return 0;
-                        }
-                    }
+    if !save && cached_addr != 0 && try_cached_blob(&src, cached_addr, &blob_tx) {
+        return 0;
+    }
+    let saved = stitch_blobs(&mut src, blob_dir, ts, blob_tx, save);
+    let (regions_skipped, vquery_ms, read_ms) = src.stats();
+    debug!(
+        target: "frameforge::blob_capture",
+        regions_skipped, vquery_ms, read_ms,
+        "source stats"
+    );
+    saved
+}
+
+/// Re-read the region that produced the last successful scan and stitch forward
+/// from it. Returns true once that yields an inventory.
+///
+/// Warframe usually keeps the blob at the same address between scans, so the
+/// common case costs one probe instead of walking every region in the process.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))] // only tests call this off-Windows
+fn try_cached_blob(
+    src: &dyn crate::mem_regions::RegionSource,
+    cached_addr: usize,
+    blob_tx: &std::sync::mpsc::Sender<BlobInventory>,
+) -> bool {
+    if let Some((mut walk, chunk)) = src.read_at(cached_addr) {
+        let is_mission = memchr::memmem::find(&chunk, MISSION_DELTA).is_some();
+        let has_anchor = ANCHORS.iter().any(|a| memchr::memmem::find(&chunk, a).is_some());
+        let has_lotus  = memchr::memmem::find(&chunk, LOTUS_KEY).is_some();
+        if chunk.len() >= 8 && !is_mission && (has_anchor || has_lotus) && chunk.starts_with(b"{\"") {
+            let mut stitched = chunk;
+            while stitched.len() < MAX_SCAN && find_blob_end(&stitched).is_none() {
+                let Some((next_addr, bytes)) = src.read_at(walk) else { break };
+                // An empty read means an unreadable hole, and the blob cannot
+                // span one. Stopping here also bounds the walk: the byte-length
+                // condition alone never advances across empty results.
+                if bytes.is_empty() { break }
+                walk = next_addr;
+                stitched.extend_from_slice(&bytes);
+            }
+            // Require the FULL_ACCOUNT start marker: mission-context blobs
+            // at the cached address pass the anchor check but lack this field.
+            if memchr::memmem::find(&stitched, START_MARKER).is_some() {
+                if let Some(inv) = parse_full_account_blob(&stitched) {
+                    info!(addr = format_args!("0x{cached_addr:012x}"),
+                        unique = inv.unique_items.len(),
+                        stackable = inv.stackable_items.len(),
+                        "fast-path hit");
+                    blob_tx.send(inv).ok();
+                    return true;
                 }
             }
         }
-        debug!(addr = format_args!("0x{cached_addr:012x}"), "fast-path miss — falling through to cold walk");
     }
+
+    debug!(addr = format_args!("0x{cached_addr:012x}"), "fast-path miss — falling through to cold walk");
+    false
+}
+
+/// Stitch FULL_ACCOUNT blobs out of a stream of memory regions.
+///
+/// `save=true` also writes the raw JSON to `blob_dir`.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))] // only tests call this off-Windows
+fn stitch_blobs(
+    src: &mut dyn crate::mem_regions::RegionSource,
+    blob_dir: &std::path::Path,
+    ts: &str,
+    blob_tx: std::sync::mpsc::Sender<BlobInventory>,
+    save: bool,
+) -> usize {
+    const MAX_BLOBS: usize = 25;
 
     struct ActiveScan {
         data: Vec<u8>,
         id: usize,
-        /// Base address of the region where this scan was seeded (JSON start).
-        /// Used to update LAST_BLOB_REGION correctly for multi-region blobs.
-        start_region_addr: usize,
+        /// Absolute address of the JSON opening brace this scan was seeded at
+        /// (mid-region, not a region base). Cached in LAST_BLOB_REGION on success.
+        seed_addr: usize,
         /// Minimum offset at which the end-marker search should start next append.
         /// Avoids rescanning already-checked data on every region append (O(n²) → O(n)).
         search_from: usize,
@@ -983,13 +974,9 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
     let mut pre_buf: std::collections::VecDeque<PreChunk> = std::collections::VecDeque::new();
     const PRE_BUF_BYTES: usize = 8 * 1024 * 1024; // keep ≤8 MB of prefix history
 
-    let mut addr: usize = 0;
     let mut saved = 0usize;
-    let mut regions_skipped = 0usize;
     let mut regions_read    = 0usize;
     let mut starts_found    = 0usize;
-    let mut t_vquery = std::time::Duration::ZERO;
-    let mut t_read   = std::time::Duration::ZERO;
     let mut t_search = std::time::Duration::ZERO;
     let mut bytes_read: u64 = 0;
     // Once we have at least one successful parse we stop opening new scans.
@@ -1002,46 +989,13 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
         // Early exit: we have a result and no active scans left to finish.
         if found_result && scans.is_empty() && !save { break; }
 
-        let t0 = std::time::Instant::now();
-        let mut mbi = unsafe { mem::zeroed::<MEMORY_BASIC_INFORMATION>() };
-        if unsafe { VirtualQueryEx(process, addr as *const c_void, &mut mbi,
-            mem::size_of::<MEMORY_BASIC_INFORMATION>()) } == 0 { break; }
-        t_vquery += t0.elapsed();
-
-        let region_addr = mbi.BaseAddress as usize;
-        let region_size = mbi.RegionSize;
-        let next_addr   = region_addr.saturating_add(region_size);
-        if next_addr <= addr { break; }
-        addr = next_addr;
-
-        // ── Region filters ──────────────────────────────────────────────────
-        // Skip pages that can never hold heap JSON:
-        // • must be committed and readable
-        // • skip execute-only pages (code sections, JIT stubs)
-        // • skip PE image sections — those hold string constants in the exe/DLLs,
-        //   not live heap data; they false-trigger the Lotus anchor check and
-        //   cost ~40 s scanning 20 MB+ without ever finding the blob end
-        // • skip anything smaller than MIN_REGION
-        if mbi.State   != MEM_COMMIT
-            || mbi.Protect &  PAGE_GUARD    != 0
-            || mbi.Protect &  PAGE_NOACCESS != 0
-            || mbi.Protect &  EXEC_MASK     != 0
-            || mbi.Type    == MEM_IMAGE
-            || region_size  < MIN_REGION
-        { regions_skipped += 1; continue; }
-
-        let read_cap = region_size.min(MAX_READ);
-
-        let t1 = std::time::Instant::now();
-        let mut buf = vec![0u8; read_cap];
-        let mut n = 0usize;
-        if unsafe { ReadProcessMemory(process, region_addr as *const c_void,
-            buf.as_mut_ptr() as *mut c_void, read_cap, &mut n) } == 0 || n < 8 {
-            regions_skipped += 1; continue;
-        }
-        t_read += t1.elapsed();
+        let (region_addr, buf) = match src.next_region() {
+            Some(r) => r,
+            None => break,
+        };
+        let n = buf.len();
         bytes_read += n as u64;
-        let chunk = &buf[..n];
+        let chunk = &buf[..];
         regions_read += 1;
 
         // ── Step 1: append this chunk to every active scan and check for completion ──
@@ -1068,13 +1022,13 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
                     Some(inv) => {
                         info!(
                             scan_id = scan.id,
-                            addr = format_args!("0x{region_addr:012x}"),
+                            addr = format_args!("0x{:012x}", scan.seed_addr),
                             unique = inv.unique_items.len(),
                             stackable = inv.stackable_items.len(),
                             mods = inv.mods.len(),
                             "scan SUCCESS"
                         );
-                        LAST_BLOB_REGION.store(scan.start_region_addr as u64, std::sync::atomic::Ordering::Relaxed);
+                        LAST_BLOB_REGION.store(scan.seed_addr as u64, std::sync::atomic::Ordering::Relaxed);
                         if save {
                             let name = format!("Actual_inventory_FULL_ACCOUNT_{}_{:02}.txt", ts, saved + 1);
                             let path = blob_dir.join(&name);
@@ -1113,12 +1067,20 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
         // contiguous pre-buffer regions so that the backward {"  search finds the true
         // outermost JSON opening rather than a nested {"$oid":…} inside the blob.
         if !has_start && !is_mission && (has_anchor || has_lotus) {
-            while pre_buf.iter().map(|p| p.data.len()).sum::<usize>() + n > PRE_BUF_BYTES
+            // A chunk larger than the cap would be retained whole (eviction only
+            // drops earlier entries): keep just its tail, the part contiguous
+            // with the region that follows.
+            let keep = n.min(PRE_BUF_BYTES);
+            while pre_buf.iter().map(|p| p.data.len()).sum::<usize>() + keep > PRE_BUF_BYTES
                 && !pre_buf.is_empty()
             {
                 pre_buf.pop_front();
             }
-            pre_buf.push_back(PreChunk { addr: region_addr, end_addr: region_addr + n, data: chunk.to_vec() });
+            pre_buf.push_back(PreChunk {
+                addr: region_addr + (n - keep),
+                end_addr: region_addr + n,
+                data: chunk[n - keep..].to_vec(),
+            });
         }
 
         if qualifies {
@@ -1194,7 +1156,7 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
                     }
                 }
             } else {
-                scans.push(ActiveScan { data: seed, id, start_region_addr: seed_addr, search_from: 0 });
+                scans.push(ActiveScan { data: seed, id, seed_addr, search_from: 0 });
             }
         }
     }
@@ -1202,19 +1164,15 @@ pub fn capture_all_blobs(blob_dir: &std::path::Path, ts: &str, blob_tx: std::syn
     debug!(
         target: "frameforge::blob_capture",
         regions_read,
-        regions_skipped,
         starts_found,
         saved,
         bytes_mb = bytes_read / 1_000_000,
-        vquery_ms = t_vquery.as_secs_f64() * 1000.0,
-        read_ms = t_read.as_secs_f64() * 1000.0,
         search_ms = t_search.as_secs_f64() * 1000.0,
         "capture done"
     );
     if starts_found == 0 {
         warn!(target: "frameforge::blob_capture", "no start-marker found — FULL_ACCOUNT not in memory (game in mission, on login screen, or Arsenal not open?)");
     }
-    unsafe { CloseHandle(process); }
     saved
 }
 
@@ -1688,5 +1646,106 @@ mod credential_scan_tests {
     fn steam_id_none_on_no_match() {
         let buf = b"steamId=short";
         assert_eq!(scan_steam_id(buf), None);
+    }
+}
+
+#[cfg(test)]
+mod stitch_engine_tests {
+    use super::*;
+    use crate::mem_regions::RecordedRegions;
+
+    /// Build a minimal but valid FULL_ACCOUNT blob: every section in
+    /// `parse_full_account_blob`'s REQUIRED_SECTIONS list, plus filler to push
+    /// it past the parser's 50 KB floor.
+    fn synthetic_blob(credits: i64) -> Vec<u8> {
+        let pad = "A".repeat(60_000);
+        format!(
+            concat!(
+                "{{\"SubscribedToEmails\":0,\"RegularCredits\":{credits},\"FusionPoints\":5,",
+                "\"PremiumCredits\":10,\"PlayerLevel\":3,",
+                "\"MiscItems\":[],\"XPInfo\":[],",
+                "\"Suits\":[{{\"ItemType\":\"/Lotus/Powersuits/Excalibur/Excalibur\",\"XP\":0}}],",
+                "\"Pad\":\"{pad}\",\"DeathSquadable\":false}}"
+            ),
+            credits = credits,
+            pad = pad,
+        )
+        .into_bytes()
+    }
+
+    #[test]
+    fn stitches_a_blob_split_across_two_regions() {
+        let blob = synthetic_blob(100);
+        // Cut inside the filler so the start marker + Lotus anchor land in the
+        // first region and the end marker only arrives with the second.
+        let split = 30_000;
+        assert!(!blob[..split].windows(b"\"DeathSquadable\":".len())
+            .any(|w| w == b"\"DeathSquadable\":"), "end marker must fall in the second region");
+
+        let regions = vec![
+            (0x1000_usize, blob[..split].to_vec()),
+            (0x1000 + split, blob[split..].to_vec()),
+        ];
+        let mut src = RecordedRegions::new(regions);
+
+        let (tx, rx) = std::sync::mpsc::channel::<BlobInventory>();
+        stitch_blobs(&mut src, std::path::Path::new(""), "test", tx, false);
+
+        let inv = rx.try_recv().expect("engine should deliver one stitched inventory");
+        assert_eq!(inv.credits, 100);
+        assert_eq!(inv.mastery_level, 3);
+        assert!(
+            inv.unique_items.iter().any(|u| u.item_type.ends_with("/Excalibur")),
+            "the warframe from the first region survives the stitch: {:?}",
+            inv.unique_items,
+        );
+    }
+
+    /// A whole blob in one region hits the immediate-parse (`seed_ends`) path.
+    #[test]
+    fn parses_a_single_region_blob() {
+        let blob = synthetic_blob(200);
+        let mut src = RecordedRegions::new(vec![(0x2000, blob)]);
+        let (tx, rx) = std::sync::mpsc::channel::<BlobInventory>();
+        stitch_blobs(&mut src, std::path::Path::new(""), "test", tx, false);
+        let inv = rx.try_recv().expect("single-region blob should parse");
+        assert_eq!(inv.credits, 200);
+    }
+
+    /// A blob missing a REQUIRED_SECTIONS entry must be rejected, not sent:
+    /// it would wipe the displayed inventory with a partial mid-write copy.
+    #[test]
+    fn rejects_a_blob_missing_a_required_section() {
+        let blob = String::from_utf8(synthetic_blob(400))
+            .expect("synthetic blob is ASCII")
+            .replace("\"MiscItems\":[],", "");
+        let mut src = RecordedRegions::new(vec![(0x3000, blob.into_bytes())]);
+        let (tx, rx) = std::sync::mpsc::channel::<BlobInventory>();
+        stitch_blobs(&mut src, std::path::Path::new(""), "test", tx, false);
+        assert!(rx.try_recv().is_err(), "incomplete blob must not be delivered");
+    }
+
+    /// The fast path probes a cached mid-region address: the returned bytes
+    /// must start at that address (the blob's `{"`), not at the region base,
+    /// and stitching must continue into the following region.
+    #[test]
+    fn fast_path_hits_a_cached_mid_region_blob() {
+        let blob = synthetic_blob(300);
+        let prefix = 0x500;
+        let split = 30_000;
+        let mut first = vec![b'x'; prefix];
+        first.extend_from_slice(&blob[..split]);
+        let src = RecordedRegions::new(vec![
+            (0x1000, first),
+            (0x1000 + prefix + split, blob[split..].to_vec()),
+        ]);
+
+        let (tx, rx) = std::sync::mpsc::channel::<BlobInventory>();
+        assert!(
+            try_cached_blob(&src, 0x1000 + prefix, &tx),
+            "cached mid-region address should hit the fast path"
+        );
+        let inv = rx.try_recv().expect("fast path should deliver the inventory");
+        assert_eq!(inv.credits, 300);
     }
 }

--- a/src-tauri/src/ocr.rs
+++ b/src-tauri/src/ocr.rs
@@ -1396,11 +1396,9 @@ pub fn extract_reward_items_twophase(
 
 /// Post-OCR reward matching: rarity bars → card columns → catalog match → fill.
 ///
-/// Split out from `extract_reward_items_twophase` so the pure text logic can be
-/// driven with recorded OCR lines, independent of the platform-specific capture
-/// and OCR path. `pixels` is still needed for the rarity-bar and card-icon
-/// probes; pass the captured frame, or an empty slice when replaying recorded
-/// lines (bar detection then returns no bars and the text path is exercised).
+/// `pixels` feeds the rarity-bar and card-icon probes. Pass the captured frame,
+/// or an empty slice when replaying recorded OCR lines (bar detection then
+/// finds no bars and the text path runs).
 fn match_reward_items(
     pixels: &[u8], pix_w: u32, pix_h: u32,
     raw_full: &str,
@@ -1756,21 +1754,14 @@ fn match_reward_items(
         .max(if bars_trusted { card_centers.len() } else { 0 })
         .max(1);
 
-    // The fill may only recover cards the OCR actually saw. Every real card
-    // leaves text in its column, so the number of columns that carried text is
-    // the ceiling on how many items can exist. estimated_cards can exceed it when
-    // a signal over-counts — a hovered card's description tooltip adds a stray
-    // "Prime" token, or item artwork trips a phantom rarity bar — and the fill was
-    // padding that surplus with a catalog item assembled from the other cards'
-    // shared "prime"/"chassis"/"blueprint" words (fuzzy matching even lets an
-    // absent model name like "trinity" register), inventing a reward for a column
-    // that showed nothing. Cap the fill at the columns with text; estimated_cards
-    // is left untouched so is_complete still waits for every card to be read
-    // across retries rather than locking on a partial frame.
+    // Every real card leaves text in its column, so columns with text cap the
+    // fill. estimated_cards can over-count (a tooltip's stray "Prime" token, a
+    // phantom rarity bar) and an uncapped fill invents a reward for an empty
+    // column. estimated_cards stays untouched so is_complete still waits for
+    // every card across retries.
     //
-    // Trade-off: a card whose text collapsed into a neighbour's column is no
-    // longer recovered by guessing from the whole frame. That is rare once the
-    // columns are spread apart, and a fabricated reward is the worse outcome.
+    // Known limit: a card whose text collapsed into a neighbour's column is not
+    // recovered.
     let fill_limit = estimated_cards.min(
         columns.iter().filter(|(t, _)| !build_word_set(t).is_empty()).count()
     );
@@ -2012,15 +2003,11 @@ mod tests {
         assert!(bar_centers_are_valid(&[0.24, 0.41, 0.59, 0.76]));
     }
 
-    /// Hovering a reward card makes the game render its description tooltip
-    /// ("A prime weapon-crafting component.") and repeat the card title in caps.
-    /// Those lines add stray "Prime" tokens that push the card-count estimate to
-    /// four on a three-card screen, and the full-frame fill then fabricates a
-    /// catalog item — a reward that was never on screen — to reach that count.
-    ///
-    /// The OCR lines below are the exact ones the live pipeline read from a
-    /// three-player run whose overlay showed a phantom "Trinity Prime Chassis
-    /// Blueprint" alongside the three real rewards.
+    /// A hovered card's tooltip and caps-repeated title add stray "Prime"
+    /// tokens. They push the card-count estimate to four on a three-card
+    /// screen, and an uncapped fill fabricates a fourth reward. The OCR lines
+    /// are from a live run that showed a phantom "Trinity Prime Chassis
+    /// Blueprint".
     #[test]
     fn a_hovered_card_tooltip_does_not_fabricate_a_fourth_reward() {
         let lines: &[(&str, f32, f32)] = &[
@@ -2055,10 +2042,8 @@ mod tests {
         // prime_count scans the whole-frame text, so raw_full must carry every token.
         let raw_full = lines.iter().map(|(t, _, _)| *t).collect::<Vec<_>>().join(" ");
 
-        // The three real rewards, plus the sibling and look-alike families that
-        // share their component words — enough for the full-frame fill to prefer a
-        // fabricated fourth (as the live catalog did). Each name doubles as its own
-        // key, matching the live catalog shape.
+        // The three real rewards plus look-alike families that share their
+        // component words, so the fill has a fabricated fourth to prefer.
         let catalog: Vec<(String, String)> = [
             "Lex Prime Barrel", "Lex Prime Blueprint", "Lex Prime Receiver",
             "Lavos Prime Blueprint", "Lavos Prime Chassis Blueprint",
@@ -2081,9 +2066,9 @@ mod tests {
         .map(|s| s.to_string())
         .collect();
 
-        // A small black frame yields no rarity bars, so matching takes the same
-        // hardcoded-column path the live capture used after its (bunched) bars
-        // were rejected. The phantom is produced by the text fill, not the bars.
+        // A black frame yields no rarity bars, so matching takes the
+        // hardcoded-column path. The phantom comes from the text fill, not the
+        // bars.
         let pixels = vec![0u8; 8 * 8 * 4];
 
         let (_complete, _skip, items, _positions, diag) = match_reward_items(

--- a/src-tauri/src/wfm.rs
+++ b/src-tauri/src/wfm.rs
@@ -1,17 +1,9 @@
-// ==============================================================================
-// warframe.market client
-// ==============================================================================
-//
-// `Wfm` is the single seam to warframe.market. A caller names an endpoint and
-// gets a result; the rate limits, the Bearer-vs-`JWT` auth scheme, the CSRF
-// dance and the blueprint-slug retry quirk all live behind the interface rather
-// than in the ~40 command handlers that used to reach for them by hand.
-//
-// What stays *outside* this module, at the Tauri boundary: acquiring a session
-// (the login webview + injected token scrape needs an `AppHandle`), persisting
-// it to the OS keyring, the price-prefetch queue and its event emission, and the
-// multi-source pricing glue. Those speak to the OS or to the app; `Wfm` speaks
-// only WFM.
+//! warframe.market client.
+//!
+//! `Wfm` holds the session, the rate limiters, the Bearer-vs-`JWT` auth scheme,
+//! the CSRF token, and the blueprint-slug retry quirk. Session acquisition (the
+//! login webview needs an `AppHandle`), keyring persistence, the price-prefetch
+//! queue, and the multi-source pricing glue stay in `lib.rs`.
 
 use std::collections::VecDeque;
 use std::sync::Mutex;
@@ -22,9 +14,7 @@ use tracing::{debug, info, warn};
 const API_BASE: &str = "https://api.warframe.market";
 const USER_AGENT: &str = "FrameForge/3.2.0";
 
-// ==============================================================================
-// Wire types
-// ==============================================================================
+// ─── Wire types ───────────────────────────────────────────────────────────────
 
 /// The warframe.market login state — a token bundle, never the credentials that
 /// produced it. Held in memory only; the boundary persists it to the keyring.
@@ -91,14 +81,11 @@ pub struct WfmPrice {
     pub buy_median: Option<f64>,
 }
 
-// ==============================================================================
-// Rate limiter
-// ==============================================================================
-//
-// A sliding-window limiter. `try_acquire` records a slot or reports how long to
-// sleep; the caller sleeps *after* the lock is released so no request blocks
-// another while merely waiting its turn.
+// ─── Rate limiter ─────────────────────────────────────────────────────────────
 
+// Sliding-window rate limiter. `try_acquire` records a slot or reports how
+// long to sleep. The caller sleeps after it releases the lock, so a waiting
+// request does not block the others.
 struct RateLimiter {
     times: VecDeque<Instant>,
     limit: usize,
@@ -131,9 +118,7 @@ impl RateLimiter {
     }
 }
 
-// ==============================================================================
-// The client
-// ==============================================================================
+// ─── The client ───────────────────────────────────────────────────────────────
 
 pub struct Wfm {
     session: Mutex<Option<WfmSession>>,
@@ -169,7 +154,6 @@ impl Wfm {
 
     // ── Rate limiting (internal) ──────────────────────────────────────────────
 
-    /// Block until the general 3/sec budget allows another request.
     fn wait(&self) {
         loop {
             let sleep_dur = self.limiter.lock().unwrap_or_else(|e| e.into_inner()).try_acquire();
@@ -311,17 +295,15 @@ impl Wfm {
             })
     }
 
-    /// Overwrite the in-memory status so `identity()` reflects a status change.
     fn set_cached_status(&self, status: String) {
         if let Some(s) = self.session.lock().unwrap_or_else(|e| e.into_inner()).as_mut() {
             s.status = status;
         }
     }
 
-    /// GET /v2/me with a Bearer token and return the parsed body. The three
-    /// callers that validate a token *before* it lives in the session can't route
-    /// through `self.call` (which reads the token from the session), so they share
-    /// this instead. `err_ctx` prefixes the failure string each caller wants.
+    /// GET /v2/me with an explicit Bearer token, for validating a token before
+    /// it is in the session (`self.call` reads its token from the session).
+    /// `err_ctx` prefixes the failure string.
     fn me(&self, access_token: &str, err_ctx: &str) -> Result<serde_json::Value, String> {
         self.wait();
         ureq::get(&format!("{}/v2/me", API_BASE))
@@ -737,7 +719,6 @@ impl Wfm {
             .map(|j| j["data"].clone())
     }
 
-    /// Update an order's price, quantity, or visibility.
     pub fn update_order(
         &self,
         order_id: &str,
@@ -755,7 +736,6 @@ impl Wfm {
             .map(|j| j["data"].clone())
     }
 
-    /// Delete an order.
     pub fn delete_order(&self, order_id: &str) -> Result<(), String> {
         let auth = self.auth()?;
         self.wait();
@@ -860,7 +840,7 @@ impl Wfm {
     ) -> Result<serde_json::Value, String> {
         let auth = self.v1_auth()?;
 
-        // Fetch the full detail so every field (attributes, polarity, ...) carries over.
+        // Fetch the full entry so every field carries over to the replacement.
         self.auction_wait();
         let entry: serde_json::Value = self
             .call("GET", &format!("/v1/auctions/entry/{}", auction_id), &auth)
@@ -883,12 +863,10 @@ impl Wfm {
         let note = auction["note"].as_str().unwrap_or("").to_string();
         let minimal_reputation = auction["minimal_reputation"].as_u64().unwrap_or(0) as u32;
 
-        // Close the old auction.
         self.auction_wait();
         self.call("PUT", &format!("/v1/auctions/entry/{}/close", auction_id), &auth)
             .map_err(auction_error("Delete auction"))?;
 
-        // Create the replacement with the chosen type.
         let mut payload = serde_json::json!({
             "item":               item_payload,
             "starting_price":     starting_price,
@@ -933,7 +911,6 @@ impl Wfm {
         Ok(())
     }
 
-    /// Toggle an auction's visibility.
     pub fn set_auction_visible(&self, auction_id: &str, visible: bool) -> Result<(), String> {
         let auth = self.v1_auth()?;
         self.auction_wait();
@@ -1144,7 +1121,6 @@ impl Wfm {
         self.price_cache.lock().unwrap_or_else(|e| e.into_inner()).remove(slug);
     }
 
-    /// A clone of the whole slug → price cache.
     pub fn cached_prices(&self) -> std::collections::HashMap<String, Option<u32>> {
         self.price_cache.lock().unwrap_or_else(|e| e.into_inner()).clone()
     }
@@ -1167,9 +1143,7 @@ impl Wfm {
     }
 }
 
-// ==============================================================================
-// Pure helpers (no session, no network) — the tested core
-// ==============================================================================
+// ─── Pure helpers (no session, no network) ────────────────────────────────────
 
 /// Convert a display name to a warframe.market URL slug.
 /// E.g. "Ash Prime Neuroptics Blueprint" → "ash_prime_neuroptics_blueprint"
@@ -1211,7 +1185,7 @@ fn jwt_payload_field(jwt: &str, field: &str) -> Option<String> {
     json[field].as_str().map(|s| s.to_string())
 }
 
-/// Minimal base64url decoder (no external crate). Tolerates missing padding.
+/// Hand-rolled to avoid a base64 dependency. Tolerates missing padding.
 fn base64_decode_url(s: &str) -> Option<Vec<u8>> {
     let s = s.replace('-', "+").replace('_', "/");
     let chars: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
@@ -1275,9 +1249,7 @@ fn auction_error(action: &'static str) -> impl Fn(ureq::Error) -> String {
     }
 }
 
-// ==============================================================================
-// Tests — the pure core, no network
-// ==============================================================================
+// ─── Tests ────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
The multi-region blob-stitch engine had its VirtualQueryEx/ReadProcessMemory walk inlined, so it sat behind #[cfg(windows)] and could only run against a live game.

Move the OS reads behind a RegionSource adapter that the engine consumes. The live walk is one implementation and a recorded-region fixture is another, so the stitch path (including a blob split across two regions) can be tested without a running game.