### PR TITLE
feat: Fix dir open and add OCR log copy support

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7758,9 +7758,7 @@ fn open_debug_folder(state: State<AppState>, which: String) -> Result<(), String
         _ => return Err("Unknown debug folder".into()),
     };
     std::fs::create_dir_all(&path).ok();
-    std::process::Command::new("explorer")
-        .arg(path.to_string_lossy().as_ref())
-        .spawn()
+    tauri_plugin_opener::open_path(&path, None::<&str>)
         .map_err(|e| e.to_string())?;
     Ok(())
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -730,6 +730,7 @@ export default function App() {
   const [diagPath, setDiagPath] = useState<string | null>(null);
   const [autoDiagEnabled, setAutoDiagEnabled] = useState(false);
   const [diagFolderSize, setDiagFolderSize] = useState<number>(0);
+  const [overlayLogCopied, setOverlayLogCopied] = useState(false);
   const [companionApiEnabled] = useState(false);
   const [memoryScannerEnabled, setMemoryScannerEnabled] = useState(false);
 const [blobLogEnabled, setBlobLogEnabled] = useState(false);
@@ -2708,7 +2709,16 @@ if (typeof s.autoDiagEnabled === "boolean") {
                         try { alert(await invoke<string>("get_overlay_session_log")); }
                         catch (e) { alert(`Error: ${e}`); }
                       }}>View</button>
-                      <div />{/* Clear placeholder */}
+                      <button className="btn-secondary" onClick={async () => {
+                        try {
+                          const log = await invoke<string>("get_overlay_session_log");
+                          navigator.clipboard.writeText(log).then(() => {
+                            setOverlayLogCopied(true);
+                            setTimeout(() => setOverlayLogCopied(false), 1500);
+                          }).catch(() => {});
+                        }
+                        catch (e) { alert(`Error: ${e}`); }
+                      }}>{overlayLogCopied ? "✓ Copied" : "Copy"}</button>
 
                       {/* Auto-capture */}
                       <div className="settings-row-info">


### PR DESCRIPTION
contains two commits:
  1. Cross-platform, tauri-native support for opening paths (see also: https://v2.tauri.app/plugin/opener/)
  2. An additional "Copy" button for the OCR log so users don't have to find them on disk