### PR TITLE
feat: apply UI scale to overlay windows

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { getVersion } from "@tauri-apps/api/app";
 import { listen } from "@tauri-apps/api/event";
 import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
+import { applyScale, overlayScale } from "./uiScale";
 
 // ── Riven overlay — module-level window management ────────────────────────────
 // Stored OUTSIDE React so StrictMode remounts don't destroy/recreate the window.
@@ -11,6 +12,16 @@ let _rivenRollCount = 0;
 let _rivenLastTriggerMs = 0;
 let _rivenManualTrigger: (() => void) | null = null;
 export function checkRivenNow() { _rivenManualTrigger?.(); }
+
+async function resizeRivenForScale() {
+  const win = _rivenWin;
+  if (!win) return;
+  try {
+    const factor = await win.scaleFactor();
+    const cur = (await win.innerSize()).toLogical(factor);
+    await win.setSize(new LogicalSize(Math.round(300 * overlayScale()), cur.height));
+  } catch {}
+}
 
 function rivenWinHide(reason = "rivenWinHide") {
   const win = _rivenWin;
@@ -41,7 +52,7 @@ async function ensureRivenWindow(wx: number, wy: number, wh: number): Promise<{ 
       alwaysOnTop: true, skipTaskbar: true,
       resizable: false, focus: false,
       x: wx + 10, y: wy + Math.round(wh * 0.20),
-      width: 300, height: Math.round(wh * 0.60),
+      width: Math.round(300 * overlayScale()), height: Math.round(wh * 0.60),
     });
     _rivenWin.once("tauri://destroyed", () => { _rivenWin = null; });
     return { win: _rivenWin, fresh: true };
@@ -50,7 +61,7 @@ async function ensureRivenWindow(wx: number, wy: number, wh: number): Promise<{ 
     return null;
   }
 }
-import { getCurrentWindow, availableMonitors } from "@tauri-apps/api/window";
+import { getCurrentWindow, availableMonitors, LogicalSize } from "@tauri-apps/api/window";
 
 import { ImgCacheDirContext } from "./ImgCacheDir";
 import Foundry, { FoundryFilters, FOUNDRY_FILTERS_DEFAULT } from "./Foundry";
@@ -81,6 +92,12 @@ const IS_MODULAR       = _params.has("modular")      || _hash === "#modular"    
 const IS_RIVEN_OVERLAY      = _params.has("rivenoverlay")      || _hash === "#rivenoverlay"      || _winLabel === "riven-overlay";
 const IS_RELIC_PICK_OVERLAY = _params.has("relicpickoverlay") || _hash === "#relicpickoverlay" || _winLabel === "relic-pick-overlay";
 const IS_OVERLAY_TEST       = _params.has("overlaytest")       || _hash === "#overlaytest"       || _winLabel === "overlay-test";
+const IS_ANY_OVERLAY = IS_OVERLAY || IS_MODULAR || IS_RIVEN_OVERLAY || IS_RELIC_PICK_OVERLAY;
+
+// Overlay windows return from the router before any hook can run, which rules
+// out applying the scale from an effect.
+applyScale(IS_ANY_OVERLAY);
+listen("settings-updated", () => applyScale(IS_ANY_OVERLAY));
 
 class ErrorBoundary extends Component<{ children: ReactNode }, { err: string | null }> {
   constructor(props: any) { super(props); this.state = { err: null }; }
@@ -1250,6 +1267,9 @@ if (typeof s.autoDiagEnabled === "boolean") {
             setModularSectionOrder(s.modularSectionOrder);
         } catch {}
       }).catch(() => {});
+      // The app creates the riven window once and caches it, so a scale change
+      // must resize it in place. Its height follows the game window, not the scale.
+      resizeRivenForScale();
     });
     return () => { unlisten.then(fn => fn()); };
   }, []); // eslint-disable-line
@@ -1776,8 +1796,13 @@ if (typeof s.autoDiagEnabled === "boolean") {
       wx: number, wy: number, ww: number, wh: number,
       yFrac: number, hFrac: number,
     ): Promise<boolean> => {
-      const stripY = wy + Math.round(wh * yFrac);
-      const stripH = Math.round(wh * hFrac);
+      // The strip's top edge aligns with the reward row in the game, so the scale
+      // may only extend the strip downwards. Moving that edge would break the
+      // alignment. The space below it is the limit, and past that the content is
+      // clipped.
+      const offsetY = Math.round(wh * yFrac);
+      const stripH  = Math.min(Math.round(wh * hFrac * overlayScale()), wh - offsetY);
+      const stripY  = wy + offsetY;
       try {
         await invoke("show_overlay_window", { x: wx, y: stripY, w: ww, h: stripH });
         overlayVisible = true;

--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/core";
 
+import { overlayScale } from "./uiScale";
 import "./Overlay.css";
 
 export type PickPriority = "completion" | "plat" | "ducat" | "setPlat";
@@ -153,6 +154,22 @@ function DucatIcon({ size = 14 }: { size?: number }) {
   return <img src="/ducats.webp" alt="d" width={size} height={size} style={{ objectFit: "contain", flexShrink: 0, verticalAlign: "middle" }} />;
 }
 
+// ─── Column layout ────────────────────────────────────────────────────────────
+// Fixed column layout symmetric around screen center.
+// Column spacing ≈ 12.7 % of screen width (measured from game at multiple resolutions).
+export const COL_SPACING_FRAC = 0.127;
+
+// For N cards, columns map to the game's actual slot positions:
+//   N=1: center; N=2: cols 2&3 (±0.5s); N=3: cols 1, 2.5, 4 (±1.5s and 0);
+//   N=4: cols 1-4 (±0.5s and ±1.5s).
+export function columnCenters(layoutW: number, n: number): number[] {
+  const s = layoutW * COL_SPACING_FRAC, c = layoutW / 2;
+  if (n === 1) return [c];
+  if (n === 2) return [c - 0.5 * s, c + 0.5 * s];
+  if (n === 3) return [c - s, c, c + s];
+  return [c - 1.5 * s, c - 0.5 * s, c + 0.5 * s, c + 1.5 * s];
+}
+
 // ─── Pick arrow ───────────────────────────────────────────────────────────────
 function PickArrow({ slotX, winW }: { slotX: number; winW: number }) {
   const cx = Math.round(winW * slotX);
@@ -233,7 +250,11 @@ export default function Overlay() {
   const [rewards, setRewards] = useState<RewardItem[]>([]);
   // winW = the overlay window's own pixel width, which equals the Warframe client
   // width (App.tsx creates the window with width: ww). No URL param needed.
-  const winW     = window.innerWidth || 1920;
+  //
+  // Divide by the scale because the cards sit inside #root, which is 1/scale of
+  // the window width and then scaled back up. The scale applies twice to any
+  // coordinate measured against the window itself.
+  const winW     = (window.innerWidth || 1920) / overlayScale();
   // priority comes from localStorage (shared origin with main window).
   const priority = (localStorage.getItem("ff-overlay-priority") ?? "completion") as PickPriority;
 
@@ -563,21 +584,9 @@ export default function Overlay() {
   const bestIdx = bestPickIndex(rewards, priority);
 
   const n  = rewards.length;
-  // Fixed column layout symmetric around screen center.
-  // Column spacing ≈ 12.7 % of screen width (measured from game at multiple resolutions).
-  // For N cards, columns map to the game's actual slot positions:
-  //   N=1: center; N=2: cols 2&3 (±0.5s); N=3: cols 1, 2.5, 4 (±1.5s and 0);
-  //   N=4: cols 1-4 (±0.5s and ±1.5s).
-  const colSpacing    = winW * 0.127;
-  const screenCenter  = winW / 2;
-  const cardW = Math.max(80, Math.round(colSpacing - 10));
-  const colCenters: number[] = (() => {
-    const s = colSpacing, c = screenCenter;
-    if (n === 1) return [c];
-    if (n === 2) return [c - 0.5 * s, c + 0.5 * s];
-    if (n === 3) return [c - s, c, c + s];
-    return [c - 1.5 * s, c - 0.5 * s, c + 0.5 * s, c + 1.5 * s];
-  })();
+  const screenCenter = winW / 2;
+  const colCenters   = columnCenters(winW, n);
+  const cardW = Math.max(80, Math.round(winW * COL_SPACING_FRAC - 10));
   const cardLeft = (idx: number) => Math.round((colCenters[idx] ?? screenCenter) - cardW / 2);
 
   return (

--- a/src/RelicPickOverlay.tsx
+++ b/src/RelicPickOverlay.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow, LogicalSize } from "@tauri-apps/api/window";
+import { clampToMonitor, overlayScale } from "./uiScale";
 import "./RelicPickOverlay.css";
 
 type Priority = "unowned" | "ducat" | "platinum";
@@ -93,18 +94,27 @@ export default function RelicPickOverlay() {
   // Use a callback ref so the ResizeObserver is set up each time the root div
   // mounts (payload goes null→non-null). A plain useRef+useEffect misses this
   // because the root div doesn't exist yet when the effect runs at mount time.
-  const roRef = useRef<ResizeObserver | null>(null);
+  const roRef   = useRef<ResizeObserver | null>(null);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  // The scale is a CSS transform, so it does not change the measured layout size.
+  // The window must grow by the same factor that the content is drawn at.
+  const syncSize = useCallback((layoutHeight: number) => {
+    if (layoutHeight <= 0) return;
+    const s = overlayScale();
+    clampToMonitor(340 * s, layoutHeight * s)
+      .then(([w, h]) => getCurrentWindow().setSize(new LogicalSize(Math.round(w), Math.round(h))))
+      .catch(() => {});
+  }, []);
+
   const rootCallback = useCallback((el: HTMLDivElement | null) => {
     if (roRef.current) { roRef.current.disconnect(); roRef.current = null; }
+    rootRef.current = el;
     if (!el) return;
-    const win = getCurrentWindow();
-    const ro = new ResizeObserver(entries => {
-      const h = Math.ceil(entries[0].contentRect.height);
-      if (h > 0) win.setSize(new LogicalSize(340, h)).catch(() => {});
-    });
+    const ro = new ResizeObserver(entries => syncSize(Math.ceil(entries[0].contentRect.height)));
     ro.observe(el);
     roRef.current = ro;
-  }, []);
+  }, [syncSize]);
 
   const hide = () => {
     setPayload(null);
@@ -126,8 +136,14 @@ export default function RelicPickOverlay() {
       setPayload(e.payload);
     });
     const unClose = listen("relic-pick-close", () => hide());
-    return () => { unOpen.then(f => f()); unClose.then(f => f()); };
-  }, []);
+    // A scale change does not alter the layout size, so the ResizeObserver never
+    // fires. Measure again to resize a window that is already open.
+    const unScale = listen("settings-updated", () => {
+      const el = rootRef.current;
+      if (el) syncSize(Math.ceil(el.getBoundingClientRect().height / overlayScale()));
+    });
+    return () => { unOpen.then(f => f()); unClose.then(f => f()); unScale.then(f => f()); };
+  }, [syncSize]);
 
   if (!payload) return null;
 

--- a/src/RivenOverlayWindow.css
+++ b/src/RivenOverlayWindow.css
@@ -3,8 +3,10 @@
 body { background: transparent; overflow: hidden; }
 
 .rov-root {
-  width: 100vw;
-  height: 100vh;
+  /* Percentages, not vw/vh: viewport units skip #root's 1/scale shrink, so the
+     UI scale would apply to them twice and push the card past the window edge. */
+  width: 100%;
+  height: 100%;
   display: flex;
   align-items: flex-start;
   justify-content: center;

--- a/src/uiScale.ts
+++ b/src/uiScale.ts
@@ -1,0 +1,30 @@
+import { currentMonitor } from "@tauri-apps/api/window";
+
+function read(key: string, fallback: number): number {
+  const v = parseFloat(localStorage.getItem(key) ?? "");
+  return Number.isFinite(v) && v > 0 ? v : fallback;
+}
+
+export const appScale = () => read("ff-text-scale", 1);
+
+// Overlays read their own key, so they can scale independently of the app
+// window. Nothing writes that key yet, so for now they follow the app text size.
+export const overlayScale = () => read("ff-overlay-scale", appScale());
+
+export function applyScale(isOverlay: boolean) {
+  const s = isOverlay ? overlayScale() : appScale();
+  document.documentElement.style.setProperty("--ff-scale", s.toString());
+}
+
+// Limit a logical (CSS pixel) window size to the monitor that shows it. Monitor
+// sizes are physical pixels, so divide them by the scale factor first.
+export async function clampToMonitor(w: number, h: number): Promise<[number, number]> {
+  try {
+    const m = await currentMonitor();
+    if (!m) return [w, h];
+    const f = m.scaleFactor || 1;
+    return [Math.min(w, m.size.width / f), Math.min(h, m.size.height / f)];
+  } catch {
+    return [w, h];
+  }
+}


### PR DESCRIPTION
## Summary

The overlay windows (reward pick, riven, relic pick) ignored the UI scale setting and always drew at 1x.
This applies the scale to each and resizes the native window so scaled content is not clipped.

## Notes

Overlays read their own scale key `ff-overlay-scale`, which nothing sets yet, so they follow the app text scale for now.
This is added for forward-compatibility reasons, so we can scale them independently in the future (for example by introducing another scaling slider only for the overlays).

The scale is applied before the overlay router returns, since those paths return before any hook runs.

The riven window is cached, so a scale change resizes it in place.
Its width scales, while its height still follows the game window.

The reward strip only grows downward, since its top edge is aligned with the in-game reward row, and is clamped to the space below that edge.

In `Overlay.tsx`, `winW` is divided by the scale: the cards live inside the transform-scaled `#root`, so the scale would otherwise apply twice to any window-relative coordinate.

`RelicPickOverlay` grows its window by the scale factor and clamps to the monitor.
A scale change does not resize the content, so the `ResizeObserver` never fires; a `settings-updated` listener re-measures an already-open window.