### PR TITLE
feat: Rebuild caching on stale-while-revalidate and platform-standard directories

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5103,7 +5103,7 @@ dependencies = [
 
 [[package]]
 name = "warframe-companion"
-version = "3.8.1"
+version = "3.9.0"
 dependencies = [
  "aho-corasick",
  "chrono",

--- a/src-tauri/src/cache.rs
+++ b/src-tauri/src/cache.rs
@@ -138,6 +138,7 @@ pub fn store<T: Serialize>(name: &str, etag: Option<String>, data: &T) -> std::i
 /// `fetch` receives the cached ETag so it can ask the server whether anything
 /// changed. Returns the data, the rung that supplied it, and, when the answer
 /// is not current, what went wrong, for the caller to surface.
+#[tracing::instrument(level = "debug", skip_all, fields(cache = %name, ttl_secs = ttl.as_secs()))]
 pub fn get_or_refresh<T>(
     name: &str,
     ttl: Duration,
@@ -226,6 +227,7 @@ fn report<T>(
             warning: warning.clone(),
         },
     );
+    tracing::debug!(cache = name, rung = ?source, warning = warning.as_deref(), "cache served");
     (data, source, warning)
 }
 
@@ -234,7 +236,9 @@ fn report<T>(
 const MAX_BODY_BYTES: u64 = 256 * 1024 * 1024;
 
 /// GET `url`, asking the server to skip the body when `etag` still matches.
+#[tracing::instrument(level = "debug", skip_all, fields(url = %url, revalidated = etag.is_some(), status, bytes))]
 pub fn get_conditional(url: &str, etag: Option<&str>) -> Result<Fetched<String>, String> {
+    let span = tracing::Span::current();
     let mut req = ureq::get(url)
         .set(
             "User-Agent",
@@ -250,8 +254,12 @@ pub fn get_conditional(url: &str, etag: Option<&str>) -> Result<Fetched<String>,
     match req.call() {
         // ureq hands back 3xx it did not follow as a success, so a confirmed
         // copy arrives here rather than in the error arm below.
-        Ok(resp) if resp.status() == 304 => Ok(Fetched::NotModified),
+        Ok(resp) if resp.status() == 304 => {
+            span.record("status", 304);
+            Ok(Fetched::NotModified)
+        }
         Ok(resp) => {
+            span.record("status", resp.status());
             let etag = resp.header("etag").map(str::to_string);
             // Not `into_string()`: ureq caps that at 10 MB.
             use std::io::Read;
@@ -275,6 +283,7 @@ pub fn get_conditional(url: &str, etag: Option<&str>) -> Result<Fetched<String>,
                 ));
             }
             let body = String::from_utf8(body).map_err(|e| e.to_string())?;
+            span.record("bytes", body.len());
             Ok(Fetched::New(body, etag))
         }
         Err(ureq::Error::Status(304, _)) => Ok(Fetched::NotModified),

--- a/src-tauri/src/cache.rs
+++ b/src-tauri/src/cache.rs
@@ -197,6 +197,10 @@ fn report<T>(
     (data, source, warning)
 }
 
+/// Bodies past this are refused as runaway responses. The catalogue sources are
+/// the largest bodies we pull, and All.json alone is ~30 MB.
+const MAX_BODY_BYTES: u64 = 256 * 1024 * 1024;
+
 /// GET `url`, asking the server to skip the body when `etag` still matches.
 pub fn get_conditional(url: &str, etag: Option<&str>) -> Result<Fetched<String>, String> {
     let mut req = ureq::get(url)
@@ -211,7 +215,26 @@ pub fn get_conditional(url: &str, etag: Option<&str>) -> Result<Fetched<String>,
     match req.call() {
         Ok(resp) => {
             let etag = resp.header("etag").map(str::to_string);
-            let body = resp.into_string().map_err(|e| e.to_string())?;
+            // Not `into_string()`: ureq caps that at 10 MB.
+            use std::io::Read;
+            // Capped so a lying Content-Length cannot make us allocate the
+            // whole cap up front.
+            let hint = resp
+                .header("content-length")
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(0)
+                .min(64 * 1024 * 1024);
+            let mut body = Vec::with_capacity(hint);
+            // One byte past the cap so a body of exactly the cap's size is
+            // distinguishable from a truncated one.
+            resp.into_reader()
+                .take(MAX_BODY_BYTES + 1)
+                .read_to_end(&mut body)
+                .map_err(|e| e.to_string())?;
+            if body.len() as u64 > MAX_BODY_BYTES {
+                return Err(format!("{url}: response body exceeds {MAX_BODY_BYTES} bytes"));
+            }
+            let body = String::from_utf8(body).map_err(|e| e.to_string())?;
             Ok(Fetched::New(body, etag))
         }
         Err(ureq::Error::Status(304, _)) => Ok(Fetched::NotModified),

--- a/src-tauri/src/cache.rs
+++ b/src-tauri/src/cache.rs
@@ -26,9 +26,11 @@ pub fn atomic_write(path: &std::path::Path, data: &[u8]) -> std::io::Result<()> 
     std::fs::write(&tmp, data)?;
     // Without this the rename can hit the platter before the data does, and a
     // power loss leaves a complete-looking file full of zeroes.
-    std::fs::File::open(&tmp).and_then(|f| f.sync_all()).inspect_err(|_| {
-        let _ = std::fs::remove_file(&tmp);
-    })?;
+    std::fs::File::open(&tmp)
+        .and_then(|f| f.sync_all())
+        .inspect_err(|_| {
+            let _ = std::fs::remove_file(&tmp);
+        })?;
     std::fs::rename(&tmp, path).inspect_err(|_| {
         let _ = std::fs::remove_file(&tmp);
     })
@@ -84,7 +86,9 @@ fn refresh_lock(name: &str) -> Arc<Mutex<()>> {
 
 pub fn set_status(name: &str, status: CacheStatus) {
     if let Ok(mut guard) = STATUSES.lock() {
-        guard.get_or_insert_with(HashMap::new).insert(name.to_string(), status);
+        guard
+            .get_or_insert_with(HashMap::new)
+            .insert(name.to_string(), status);
     }
 }
 
@@ -119,7 +123,11 @@ pub fn load<T: DeserializeOwned>(name: &str) -> Option<Cached<T>> {
 }
 
 pub fn store<T: Serialize>(name: &str, etag: Option<String>, data: &T) -> std::io::Result<()> {
-    let cached = Cached { retrieved_at_unix: now_unix(), etag, data };
+    let cached = Cached {
+        retrieved_at_unix: now_unix(),
+        etag,
+        data,
+    };
     let body = serde_json::to_vec(&cached)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
     atomic_write(&path_of(name), &body)
@@ -152,7 +160,13 @@ where
         .is_some_and(|c| now.saturating_sub(c.retrieved_at_unix) < ttl.as_secs());
     if still_fresh {
         let c = cached.expect("still_fresh is only true for a loaded cache");
-        return report(name, Some(c.retrieved_at_unix), Source::Fresh, None, Some(c.data));
+        return report(
+            name,
+            Some(c.retrieved_at_unix),
+            Source::Fresh,
+            None,
+            Some(c.data),
+        );
     }
 
     let result = fetch(cached.as_ref().and_then(|c| c.etag.as_deref()));
@@ -181,7 +195,13 @@ where
         Err(e) => match cached {
             Some(c) => {
                 let warning = format!("{name}: showing cached data, refresh failed: {e}");
-                report(name, Some(c.retrieved_at_unix), Source::Stale, Some(warning), Some(c.data))
+                report(
+                    name,
+                    Some(c.retrieved_at_unix),
+                    Source::Stale,
+                    Some(warning),
+                    Some(c.data),
+                )
             }
             None => {
                 let warning = format!("{name}: no cached data and refresh failed: {e}");
@@ -198,7 +218,14 @@ fn report<T>(
     warning: Option<String>,
     data: Option<T>,
 ) -> (Option<T>, Source, Option<String>) {
-    set_status(name, CacheStatus { source, last_updated, warning: warning.clone() });
+    set_status(
+        name,
+        CacheStatus {
+            source,
+            last_updated,
+            warning: warning.clone(),
+        },
+    );
     (data, source, warning)
 }
 
@@ -209,7 +236,10 @@ const MAX_BODY_BYTES: u64 = 256 * 1024 * 1024;
 /// GET `url`, asking the server to skip the body when `etag` still matches.
 pub fn get_conditional(url: &str, etag: Option<&str>) -> Result<Fetched<String>, String> {
     let mut req = ureq::get(url)
-        .set("User-Agent", concat!("FrameForge/", env!("CARGO_PKG_VERSION")))
+        .set(
+            "User-Agent",
+            concat!("FrameForge/", env!("CARGO_PKG_VERSION")),
+        )
         // Generous because of the body sizes, but bounded: ureq has no default
         // timeout, and a black-holed connection here would otherwise hang the
         // caller, and with it the refresh lock, forever.
@@ -237,7 +267,9 @@ pub fn get_conditional(url: &str, etag: Option<&str>) -> Result<Fetched<String>,
                 .read_to_end(&mut body)
                 .map_err(|e| e.to_string())?;
             if body.len() as u64 > MAX_BODY_BYTES {
-                return Err(format!("{url}: response body exceeds {MAX_BODY_BYTES} bytes"));
+                return Err(format!(
+                    "{url}: response body exceeds {MAX_BODY_BYTES} bytes"
+                ));
             }
             let body = String::from_utf8(body).map_err(|e| e.to_string())?;
             Ok(Fetched::New(body, etag))
@@ -344,7 +376,8 @@ mod tests {
         let v2 = scratch("schema-v2");
         store(&v1, None, &"old shape".to_string()).unwrap();
 
-        let (data, source, _) = get_or_refresh(&v2, Duration::from_secs(3600), fetches("new shape"));
+        let (data, source, _) =
+            get_or_refresh(&v2, Duration::from_secs(3600), fetches("new shape"));
 
         assert_eq!(data.as_deref(), Some("new shape"));
         assert_eq!(source, Source::Refreshed);

--- a/src-tauri/src/cache.rs
+++ b/src-tauri/src/cache.rs
@@ -248,6 +248,9 @@ pub fn get_conditional(url: &str, etag: Option<&str>) -> Result<Fetched<String>,
         req = req.set("If-None-Match", tag);
     }
     match req.call() {
+        // ureq hands back 3xx it did not follow as a success, so a confirmed
+        // copy arrives here rather than in the error arm below.
+        Ok(resp) if resp.status() == 304 => Ok(Fetched::NotModified),
         Ok(resp) => {
             let etag = resp.header("etag").map(str::to_string);
             // Not `into_string()`: ureq caps that at 10 MB.

--- a/src-tauri/src/cache.rs
+++ b/src-tauri/src/cache.rs
@@ -1,0 +1,355 @@
+//! Disk cache with a stale-while-revalidate ladder.
+//!
+//! Every cached payload carries the time it was retrieved and the ETag it came
+//! with, so freshness is a property of the file rather than of its mtime, and a
+//! conditional GET can be built from it. `get_or_refresh` walks four rungs in
+//! order (fresh copy, successful refetch, stale copy, nothing) and reports
+//! which one answered so the UI can say how old what it shows is.
+//!
+//! The schema version belongs in the file name ("catalogue-v1.json"): a payload
+//! whose shape changed simply misses instead of deserializing into the wrong
+//! thing.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+use crate::paths;
+
+pub fn atomic_write(path: &std::path::Path, data: &[u8]) -> std::io::Result<()> {
+    let tmp = path.with_extension("tmp");
+    std::fs::write(&tmp, data)?;
+    std::fs::rename(&tmp, path).inspect_err(|_| {
+        let _ = std::fs::remove_file(&tmp);
+    })
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Cached<T> {
+    pub retrieved_at_unix: u64,
+    pub etag: Option<String>,
+    pub data: T,
+}
+
+/// Which rung of the ladder produced the data the caller is holding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Source {
+    /// Cache was inside its TTL, or the server confirmed it with a 304.
+    Fresh,
+    Refreshed,
+    /// Cache is past its TTL and the refetch failed.
+    Stale,
+    /// Nothing on disk and the fetch failed. The caller has to invent something.
+    Fallback,
+}
+
+pub enum Fetched<T> {
+    New(T, Option<String>),
+    NotModified,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CacheStatus {
+    pub source: Source,
+    pub last_updated: Option<u64>,
+    pub warning: Option<String>,
+}
+
+static STATUSES: Mutex<Option<HashMap<String, CacheStatus>>> = Mutex::new(None);
+
+/// One lock per cache name, held for the length of a `get_or_refresh`. Two
+/// callers after the same cache take turns, and the second one finds what the
+/// first stored. A slow download of one cache never blocks another.
+static REFRESHING: Mutex<Option<HashMap<String, Arc<Mutex<()>>>>> = Mutex::new(None);
+
+fn refresh_lock(name: &str) -> Arc<Mutex<()>> {
+    let mut guard = REFRESHING.lock().unwrap_or_else(|e| e.into_inner());
+    guard
+        .get_or_insert_with(HashMap::new)
+        .entry(name.to_string())
+        .or_default()
+        .clone()
+}
+
+pub fn set_status(name: &str, status: CacheStatus) {
+    if let Ok(mut guard) = STATUSES.lock() {
+        guard.get_or_insert_with(HashMap::new).insert(name.to_string(), status);
+    }
+}
+
+pub fn statuses() -> HashMap<String, CacheStatus> {
+    STATUSES
+        .lock()
+        .ok()
+        .and_then(|g| g.clone())
+        .unwrap_or_default()
+}
+
+fn path_of(name: &str) -> PathBuf {
+    paths::cache_dir().join(name)
+}
+
+pub fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+pub fn load<T: DeserializeOwned>(name: &str) -> Option<Cached<T>> {
+    let body = std::fs::read_to_string(path_of(name)).ok()?;
+    match serde_json::from_str(&body) {
+        Ok(cached) => Some(cached),
+        Err(e) => {
+            warn!("discarding unreadable cache {name}: {e}");
+            None
+        }
+    }
+}
+
+pub fn store<T: Serialize>(name: &str, etag: Option<String>, data: &T) -> std::io::Result<()> {
+    let cached = Cached { retrieved_at_unix: now_unix(), etag, data };
+    let body = serde_json::to_vec(&cached)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    atomic_write(&path_of(name), &body)
+}
+
+/// Serve `name`, refetching when it is older than `ttl`.
+///
+/// `fetch` receives the cached ETag so it can ask the server whether anything
+/// changed. Returns the data, the rung that supplied it, and, when the answer
+/// is not current, what went wrong, for the caller to surface.
+pub fn get_or_refresh<T>(
+    name: &str,
+    ttl: Duration,
+    fetch: impl FnOnce(Option<&str>) -> Result<Fetched<T>, String>,
+) -> (Option<T>, Source, Option<String>)
+where
+    T: Serialize + DeserializeOwned,
+{
+    // The frontend and the background scheduler both ask for the same caches at
+    // launch. Without this they download the catalogue twice and race each other
+    // writing the same temporary file.
+    let lock = refresh_lock(name);
+    let _refreshing = lock.lock().unwrap_or_else(|e| e.into_inner());
+
+    let cached = load::<T>(name);
+    let now = now_unix();
+
+    let still_fresh = cached
+        .as_ref()
+        .is_some_and(|c| now.saturating_sub(c.retrieved_at_unix) < ttl.as_secs());
+    if still_fresh {
+        let c = cached.expect("still_fresh is only true for a loaded cache");
+        return report(name, Some(c.retrieved_at_unix), Source::Fresh, None, Some(c.data));
+    }
+
+    let result = fetch(cached.as_ref().and_then(|c| c.etag.as_deref()));
+    match result {
+        Ok(Fetched::New(data, etag)) => {
+            if let Err(e) = store(name, etag, &data) {
+                warn!("cannot write cache {name}: {e}");
+            }
+            report(name, Some(now), Source::Refreshed, None, Some(data))
+        }
+        // 304 only means anything against a cached copy; without one there is
+        // nothing to confirm, and the fetcher had no ETag to send in the first
+        // place.
+        Ok(Fetched::NotModified) => match cached {
+            Some(c) => {
+                if let Err(e) = store(name, c.etag, &c.data) {
+                    warn!("cannot refresh cache timestamp {name}: {e}");
+                }
+                report(name, Some(now), Source::Fresh, None, Some(c.data))
+            }
+            None => {
+                let warning = format!("{name}: server reported not-modified with no cached copy");
+                report(name, None, Source::Fallback, Some(warning), None)
+            }
+        },
+        Err(e) => match cached {
+            Some(c) => {
+                let warning = format!("{name}: showing cached data, refresh failed: {e}");
+                report(name, Some(c.retrieved_at_unix), Source::Stale, Some(warning), Some(c.data))
+            }
+            None => {
+                let warning = format!("{name}: no cached data and refresh failed: {e}");
+                report(name, None, Source::Fallback, Some(warning), None)
+            }
+        },
+    }
+}
+
+fn report<T>(
+    name: &str,
+    last_updated: Option<u64>,
+    source: Source,
+    warning: Option<String>,
+    data: Option<T>,
+) -> (Option<T>, Source, Option<String>) {
+    set_status(name, CacheStatus { source, last_updated, warning: warning.clone() });
+    (data, source, warning)
+}
+
+/// GET `url`, asking the server to skip the body when `etag` still matches.
+pub fn get_conditional(url: &str, etag: Option<&str>) -> Result<Fetched<String>, String> {
+    let mut req = ureq::get(url)
+        .set("User-Agent", concat!("FrameForge/", env!("CARGO_PKG_VERSION")))
+        // Generous because of the body sizes, but bounded: ureq has no default
+        // timeout, and a black-holed connection here would otherwise hang the
+        // caller, and with it the refresh lock, forever.
+        .timeout(std::time::Duration::from_secs(300));
+    if let Some(tag) = etag {
+        req = req.set("If-None-Match", tag);
+    }
+    match req.call() {
+        Ok(resp) => {
+            let etag = resp.header("etag").map(str::to_string);
+            let body = resp.into_string().map_err(|e| e.to_string())?;
+            Ok(Fetched::New(body, etag))
+        }
+        Err(ureq::Error::Status(304, _)) => Ok(Fetched::NotModified),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One process, one root: every test names its own cache file instead.
+    fn scratch(name: &str) -> String {
+        let root = std::env::temp_dir().join("frameforge-cache-tests");
+        let _ = paths::set_root_override(root);
+        let file = format!("{name}.json");
+        let _ = std::fs::remove_file(paths::cache_dir().join(&file));
+        file
+    }
+
+    fn fetches(body: &str) -> impl FnOnce(Option<&str>) -> Result<Fetched<String>, String> + '_ {
+        move |_| Ok(Fetched::New(body.to_string(), None))
+    }
+
+    fn fails(_: Option<&str>) -> Result<Fetched<String>, String> {
+        Err("offline".to_string())
+    }
+
+    #[test]
+    fn fresh_cache_skips_the_fetch() {
+        let name = scratch("fresh");
+        store(&name, None, &"cached".to_string()).unwrap();
+
+        let (data, source, warning) =
+            get_or_refresh::<String>(&name, Duration::from_secs(3600), |_| {
+                panic!("a fresh cache must not be refetched")
+            });
+
+        assert_eq!(data.as_deref(), Some("cached"));
+        assert_eq!(source, Source::Fresh);
+        assert!(warning.is_none());
+    }
+
+    #[test]
+    fn expired_cache_is_replaced_by_the_fetch() {
+        let name = scratch("refreshed");
+        store(&name, None, &"old".to_string()).unwrap();
+
+        let (data, source, _) = get_or_refresh(&name, Duration::ZERO, fetches("new"));
+
+        assert_eq!(data.as_deref(), Some("new"));
+        assert_eq!(source, Source::Refreshed);
+        assert_eq!(load::<String>(&name).unwrap().data, "new");
+    }
+
+    #[test]
+    fn a_failed_refresh_still_serves_the_stale_copy() {
+        let name = scratch("stale");
+        store(&name, None, &"old".to_string()).unwrap();
+
+        let (data, source, warning) = get_or_refresh(&name, Duration::ZERO, fails);
+
+        assert_eq!(data.as_deref(), Some("old"));
+        assert_eq!(source, Source::Stale);
+        assert!(warning.unwrap().contains("offline"));
+    }
+
+    #[test]
+    fn nothing_cached_and_no_network_leaves_the_caller_empty() {
+        let name = scratch("fallback");
+
+        let (data, source, warning) = get_or_refresh::<String>(&name, Duration::ZERO, fails);
+
+        assert!(data.is_none());
+        assert_eq!(source, Source::Fallback);
+        assert!(warning.is_some());
+    }
+
+    #[test]
+    fn not_modified_keeps_the_payload_and_clears_the_staleness() {
+        let name = scratch("not-modified");
+        store(&name, Some("abc".to_string()), &"body".to_string()).unwrap();
+        let before = load::<String>(&name).unwrap().retrieved_at_unix;
+
+        let seen_etag = Mutex::new(None);
+        let (data, source, _) = get_or_refresh(&name, Duration::ZERO, |etag| {
+            *seen_etag.lock().unwrap() = etag.map(str::to_string);
+            Ok(Fetched::<String>::NotModified)
+        });
+
+        assert_eq!(seen_etag.into_inner().unwrap().as_deref(), Some("abc"));
+        assert_eq!(data.as_deref(), Some("body"));
+        assert_eq!(source, Source::Fresh);
+        let after = load::<String>(&name).unwrap();
+        assert_eq!(after.etag.as_deref(), Some("abc"));
+        assert!(after.retrieved_at_unix >= before);
+    }
+
+    #[test]
+    fn a_new_schema_version_misses_the_old_file() {
+        let v1 = scratch("schema-v1");
+        let v2 = scratch("schema-v2");
+        store(&v1, None, &"old shape".to_string()).unwrap();
+
+        let (data, source, _) = get_or_refresh(&v2, Duration::from_secs(3600), fetches("new shape"));
+
+        assert_eq!(data.as_deref(), Some("new shape"));
+        assert_eq!(source, Source::Refreshed);
+    }
+
+    #[test]
+    fn two_callers_after_a_cold_cache_fetch_once() {
+        let name = scratch("concurrent");
+        static FETCHES: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+        std::thread::scope(|s| {
+            for _ in 0..2 {
+                s.spawn(|| {
+                    get_or_refresh(&name, Duration::from_secs(3600), |_| {
+                        FETCHES.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                        std::thread::sleep(Duration::from_millis(50));
+                        Ok(Fetched::New("body".to_string(), None))
+                    })
+                });
+            }
+        });
+
+        assert_eq!(FETCHES.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn status_records_the_last_rung_taken() {
+        let name = scratch("status");
+
+        let _ = get_or_refresh::<String>(&name, Duration::ZERO, fails);
+
+        let status = statuses().remove(&name).expect("status recorded");
+        assert_eq!(status.source, Source::Fallback);
+        assert!(status.warning.is_some());
+    }
+}

--- a/src-tauri/src/cache.rs
+++ b/src-tauri/src/cache.rs
@@ -24,6 +24,11 @@ use crate::paths;
 pub fn atomic_write(path: &std::path::Path, data: &[u8]) -> std::io::Result<()> {
     let tmp = path.with_extension("tmp");
     std::fs::write(&tmp, data)?;
+    // Without this the rename can hit the platter before the data does, and a
+    // power loss leaves a complete-looking file full of zeroes.
+    std::fs::File::open(&tmp).and_then(|f| f.sync_all()).inspect_err(|_| {
+        let _ = std::fs::remove_file(&tmp);
+    })?;
     std::fs::rename(&tmp, path).inspect_err(|_| {
         let _ = std::fs::remove_file(&tmp);
     })

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1755,21 +1755,18 @@ async fn get_wfm_top_items(state: State<'_, AppState>) -> Result<Vec<WfmTopItem>
 
     // Only one scan at a time: a second one would compete for the same rate-limiter
     // budget and take twice as long for both.
-    let claimed_scan =
-        WFM_SCAN_RUNNING.compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst).is_ok();
+    let scan_slot = WfmScanSlot::claim();
 
     // An expired copy beats an empty tab for the minute and a half a scan takes,
     // so hand it over and rescan behind it.
     if let Some(cached) = disk {
-        if claimed_scan {
+        if let Some(slot) = scan_slot {
             let wfm = state.wfm.clone();
             std::thread::spawn(move || {
-                // Release the scan slot even on a panic, or every later scan
-                // is blocked for the rest of the session.
+                let _slot = slot;
                 let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                     finish_wfm_top_scan(&wfm, scan_wfm_top_items(&wfm, &arcane_candidates));
                 }));
-                WFM_SCAN_RUNNING.store(false, Ordering::SeqCst);
             });
         }
         cache::set_status(WFM_TOP_CACHE, cache::CacheStatus {
@@ -1781,7 +1778,7 @@ async fn get_wfm_top_items(state: State<'_, AppState>) -> Result<Vec<WfmTopItem>
     }
 
     // Nothing to show, so the caller has to wait for a scan either way.
-    if !claimed_scan {
+    let Some(_slot) = scan_slot else {
         for _ in 0..120u32 {  // poll every 5 s, max 10 minutes
             tokio::time::sleep(std::time::Duration::from_secs(5)).await;
             if let Some(items) = state.wfm.cached_top_items(WFM_TOP_TTL) {
@@ -1789,15 +1786,11 @@ async fn get_wfm_top_items(state: State<'_, AppState>) -> Result<Vec<WfmTopItem>
             }
         }
         return Err("WFM top items scan timed out".to_string());
-    }
+    };
 
-    // Run blocking ureq calls on the thread pool — keeps the async runtime free
     let wfm = state.wfm.clone();
     let scan_result =
         tokio::task::spawn_blocking(move || scan_wfm_top_items(&wfm, &arcane_candidates)).await;
-
-    // Release the scan slot before propagating any error
-    WFM_SCAN_RUNNING.store(false, Ordering::SeqCst);
 
     let results = scan_result.map_err(|e| e.to_string())?;
     finish_wfm_top_scan(&state.wfm, results.clone());
@@ -1823,9 +1816,9 @@ pub(crate) fn refresh_wfm_top(app: &tauri::AppHandle, force: bool) -> Result<(),
     if !force && state.wfm.cached_top_items(WFM_TOP_TTL).is_some() {
         return Ok(());
     }
-    if WFM_SCAN_RUNNING.compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst).is_err() {
+    let Some(slot) = WfmScanSlot::claim() else {
         return Ok(());
-    }
+    };
     let arcane_candidates: Vec<ArcaneCandidate> = {
         let items = state.wfcd_items.lock().unwrap_or_else(|e| e.into_inner());
         items.iter()
@@ -1835,12 +1828,10 @@ pub(crate) fn refresh_wfm_top(app: &tauri::AppHandle, force: bool) -> Result<(),
     };
     let wfm = state.wfm.clone();
     std::thread::spawn(move || {
-        // Release the scan slot even on a panic, or every later scan is
-        // blocked for the rest of the session.
+        let _slot = slot;
         let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             finish_wfm_top_scan(&wfm, scan_wfm_top_items(&wfm, &arcane_candidates));
         }));
-        WFM_SCAN_RUNNING.store(false, Ordering::SeqCst);
     });
     Ok(())
 }
@@ -2340,6 +2331,27 @@ fn get_weapon_dispositions(state: State<AppState>) -> HashMap<String, f32> {
 /// lives in `Wfm`.
 static WFM_SCAN_RUNNING: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
+
+/// Holds the one scan slot. Dropping it releases the slot. Tying the release to
+/// `Drop` frees it on every exit (error, panic, or a cancelled future), where
+/// a manual `store(false)` after an `.await` would leak the slot for the rest
+/// of the session and time out every later scan.
+struct WfmScanSlot;
+
+impl WfmScanSlot {
+    fn claim() -> Option<Self> {
+        WFM_SCAN_RUNNING
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+            .then_some(WfmScanSlot)
+    }
+}
+
+impl Drop for WfmScanSlot {
+    fn drop(&mut self) {
+        WFM_SCAN_RUNNING.store(false, Ordering::SeqCst);
+    }
+}
 
 /// Cache: (warframe_pid, Option<flag_va>). None inner = scanned this PID, pattern not found.
 /// Re-scanned only when PID changes (game restart). Prevents 200ms re-scan storm.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,20 +5,12 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
-/// Write `data` to `path` atomically: write to a `.tmp` sibling, then rename over the target.
-/// Prevents zero-byte corruption if the process or OS crashes mid-write.
-fn atomic_write(path: &std::path::Path, data: &[u8]) -> std::io::Result<()> {
-    let tmp = path.with_extension("tmp");
-    std::fs::write(&tmp, data)?;
-    std::fs::rename(&tmp, path).inspect_err(|_| {
-        let _ = std::fs::remove_file(&tmp);
-    })
-}
 fn truncate_chars(s: &str, n: usize) -> String {
     s.chars().take(n).collect()
 }
 use tauri::{Emitter, Manager, State};
 
+mod cache;
 mod console_login; // [console-login feature] remove this line to drop the feature
 mod db;
 mod logging;
@@ -28,10 +20,13 @@ mod ocr;
 // ── BEGIN ocrs fallback ─────────────────────────────────────────────────────
 mod ocr_fallback;
 // ── END ocrs fallback ───────────────────────────────────────────────────────
+mod paths;
+mod refresh;
 mod resolver;
 mod wfcd;
 mod wfm;
 
+use cache::atomic_write;
 use db::{QuantityChange, SnapshotPoint, TrackedItem, Trade};
 use resolver::ItemResolver;
 use wfcd::{RecipeComponent, SyndicateOffer, WfcdItem};
@@ -73,10 +68,6 @@ pub struct CorrectionEntry {
 
 pub struct AppState {
     pub db_path: PathBuf,
-    pub items_cache_path: PathBuf,
-    pub recipes_cache_path: PathBuf,
-    pub relic_drops_cache_path: PathBuf,
-    pub relic_rewards_cache_path: PathBuf,
     pub quantities_cache_path: PathBuf,
     pub inventory_state_cache_path: PathBuf,
     pub settings_path: PathBuf,
@@ -125,11 +116,8 @@ pub struct AppState {
     pub wfm_priority_queue: Arc<Mutex<std::collections::VecDeque<String>>>,
     /// Set to true once the WFM queue drain thread has been started.
     pub wfm_queue_started: Arc<AtomicBool>,
-    /// Path to the persisted top-WFM-items cache (survives restarts).
-    pub wfm_top_cache_path: PathBuf,
     /// syndicate name → purchasable items (all known syndicates)
     pub syndicate_catalog: Mutex<HashMap<String, Vec<SyndicateOffer>>>,
-    pub syndicate_catalog_path: PathBuf,
     /// IDs of riven auctions created via FrameForge — persisted so hidden auctions survive restarts.
     pub auction_ids: Mutex<Vec<String>>,
     pub auction_ids_path: PathBuf,
@@ -154,7 +142,6 @@ pub struct AppState {
     pub pending_relic_rewards: Mutex<Option<serde_json::Value>>,
     /// relics.run daily bulk price cache: item display name (lowercase) → median sell price.
     pub relics_run_prices: Mutex<HashMap<String, u32>>,
-    pub relics_run_prices_cache_path: PathBuf,
     /// Raw worldstate + Steam news from the last upstream fetch, with the time it
     /// was taken. Every window polls worldstate on its own timer, so without this
     /// two open windows mean two fetch pairs a minute against DE and Steam.
@@ -164,7 +151,7 @@ pub struct AppState {
     pub worldstate_cache: Mutex<Option<(std::time::Instant, Arc<serde_json::Value>, Arc<serde_json::Value>)>>,
     /// When true, unmatched inventory paths are written to the Unmatched Paths debug folder.
     pub debug_cat_enabled: Arc<AtomicBool>,
-    /// Subfolders under %LOCALAPPDATA%\warframe-companion\Debugging\
+    /// Subfolders of `Debugging/` in the state directory.
     pub auto_capture_dir: PathBuf,
     pub manual_capture_dir: PathBuf,
     pub memory_probe_path: PathBuf,
@@ -741,43 +728,69 @@ fn get_item_list_status(state: State<AppState>) -> serde_json::Value {
     })
 }
 
+/// Name of the on-disk catalogue. The `-v1` is the payload's schema version: a
+/// change of shape means a miss rather than a bad deserialization.
+const CATALOGUE_CACHE: &str = "catalogue-v1.json";
+
+/// Game updates land far more slowly than once a day, and a conditional GET
+/// makes an unchanged catalogue nearly free anyway.
+const CATALOGUE_TTL: std::time::Duration = std::time::Duration::from_secs(24 * 3600);
+
+/// Corrections that live in the code rather than the payload. They are
+/// reapplied on every load, so a new build never needs the cache cleared.
+fn patch_catalogue_items(items: Vec<WfcdItem>) -> Vec<WfcdItem> {
+    dedup_known_aliases(
+        items
+            .into_iter()
+            .map(|mut i| {
+                i.name = patch_item_name(&i.unique_name, &i.name);
+                i.category = patch_item_category(&i.name, &i.category, &i.unique_name);
+                i
+            })
+            .collect(),
+    )
+}
+
 #[tauri::command]
-async fn fetch_item_list(state: State<'_, AppState>) -> Result<usize, String> {
-    let result = tauri::async_runtime::spawn_blocking(wfcd::fetch_items)
-        .await
-        .map_err(|e| e.to_string())?
-        .map_err(|e| e)?;
+async fn fetch_item_list(state: State<'_, AppState>, force: Option<bool>) -> Result<usize, String> {
+    let force = force.unwrap_or(false);
+    let ttl = if force { std::time::Duration::ZERO } else { CATALOGUE_TTL };
+    let (result, source, warning) = tauri::async_runtime::spawn_blocking(move || {
+        cache::get_or_refresh(CATALOGUE_CACHE, ttl, |etag| wfcd::fetch_items(etag, force))
+    })
+    .await
+    .map_err(|e| e.to_string())?;
 
+    let result = result.ok_or_else(|| warning.unwrap_or_else(|| "catalogue unavailable".into()))?;
+    // A fresh cache is the same payload `run()` already seeded the state with;
+    // re-patching ~30k items and rewriting the inventory cache would be a no-op.
+    if source == cache::Source::Fresh {
+        return Ok(result.items.len());
+    }
+    Ok(apply_catalogue(&state, result))
+}
+
+/// Background-refresh entry point. `force` ignores both the cached copy's age
+/// and its ETags, so the sources have to answer with a body.
+pub(crate) fn refresh_catalogue(app: &tauri::AppHandle, force: bool) -> Result<(), String> {
+    let ttl = if force { std::time::Duration::ZERO } else { CATALOGUE_TTL };
+    let (result, source, warning) =
+        cache::get_or_refresh(CATALOGUE_CACHE, ttl, |etag| wfcd::fetch_items(etag, force));
+    match result {
+        // The state already holds a fresh cache's payload (seeded by `run()` or
+        // by whichever refresh stored it), so only new data is worth applying.
+        Some(_) if warning.is_none() && source == cache::Source::Fresh => Ok(()),
+        Some(result) if warning.is_none() => {
+            apply_catalogue(&app.state::<AppState>(), result);
+            Ok(())
+        }
+        _ => Err(warning.unwrap_or_else(|| "catalogue unavailable".into())),
+    }
+}
+
+fn apply_catalogue(state: &AppState, result: wfcd::FetchResult) -> usize {
     let count = result.items.len();
-
-    // Persist items cache
-    if let Ok(json) = serde_json::to_string(&result.items.iter().map(|i| serde_json::json!({
-        "unique_name": i.unique_name, "name": i.name, "category": i.category,
-        "item_type": i.item_type, "product_category": i.product_category,
-        "image_name": i.image_name, "vaulted": i.vaulted, "ducats": i.ducats,
-        "mastery_req": i.mastery_req, "omega_attenuation": i.omega_attenuation,
-        "fusion_limit": i.fusion_limit, "max_level_cap": i.max_level_cap
-    })).collect::<Vec<_>>()) {
-        let _ = std::fs::write(&state.items_cache_path, json);
-    }
-
-    // Persist recipes cache
-    if let Ok(json) = serde_json::to_string(&result.recipes) {
-        let _ = std::fs::write(&state.recipes_cache_path, json);
-    }
-
-    let patched_items: Vec<WfcdItem> = result.items.into_iter().map(|mut i| {
-        i.name = patch_item_name(&i.unique_name, &i.name);
-        i.category = patch_item_category(&i.name, &i.category, &i.unique_name);
-        i
-    }).collect();
-    if let Ok(json) = serde_json::to_string(&result.relic_drops) {
-        let _ = std::fs::write(&state.relic_drops_cache_path, json);
-    }
-    if let Ok(json) = serde_json::to_string(&result.relic_rewards) {
-        let _ = std::fs::write(&state.relic_rewards_cache_path, json);
-    }
-    let deduped = dedup_known_aliases(patched_items);
+    let deduped = patch_catalogue_items(result.items);
 
     // Write mod_max_rank into inventory_state_cache.json for every mod/arcane so it is
     // available at startup without requiring wfcd_items to be loaded first.
@@ -810,24 +823,21 @@ async fn fetch_item_list(state: State<'_, AppState>) -> Result<usize, String> {
         }
     }
 
-    *state.wfcd_items.lock().map_err(|e| e.to_string())? = deduped;
-    *state.recipes.lock().map_err(|e| e.to_string())? = result.recipes;
-    *state.relic_drops.lock().map_err(|e| e.to_string())? = result.relic_drops;
-    *state.relic_rewards.lock().map_err(|e| e.to_string())? = result.relic_rewards;
-    *state.blueprint_to_result.lock().map_err(|e| e.to_string())? = result.blueprint_names;
+    *state.wfcd_items.lock().unwrap_or_else(|e| e.into_inner()) = deduped;
+    *state.recipes.lock().unwrap_or_else(|e| e.into_inner()) = result.recipes;
+    *state.relic_drops.lock().unwrap_or_else(|e| e.into_inner()) = result.relic_drops;
+    *state.relic_rewards.lock().unwrap_or_else(|e| e.into_inner()) = result.relic_rewards;
+    *state.blueprint_to_result.lock().unwrap_or_else(|e| e.into_inner()) = result.blueprint_names;
     if !result.weapon_dispositions.is_empty() {
-        *state.weapon_dispositions.lock().map_err(|e| e.to_string())? = result.weapon_dispositions;
+        *state.weapon_dispositions.lock().unwrap_or_else(|e| e.into_inner()) = result.weapon_dispositions;
     }
     if !result.wiki_reward_names.is_empty() {
-        *state.wiki_reward_names.lock().map_err(|e| e.to_string())? = result.wiki_reward_names;
+        *state.wiki_reward_names.lock().unwrap_or_else(|e| e.into_inner()) = result.wiki_reward_names;
     }
     if !result.syndicate_catalog.is_empty() {
-        if let Ok(json) = serde_json::to_string(&result.syndicate_catalog) {
-            let _ = std::fs::write(&state.syndicate_catalog_path, json);
-        }
-        *state.syndicate_catalog.lock().map_err(|e| e.to_string())? = result.syndicate_catalog;
+        *state.syndicate_catalog.lock().unwrap_or_else(|e| e.into_inner()) = result.syndicate_catalog;
     }
-    Ok(count)
+    count
 }
 
 // ─── Foundry / Recipes ────────────────────────────────────────────────────────
@@ -1290,8 +1300,7 @@ fn save_api_inventory(
 async fn warframe_login(email: String, password: String) -> Result<(String, String), String> {
     use whirlpool::{Whirlpool, Digest};
     let hash = format!("{:x}", Whirlpool::digest(password.as_bytes()));
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_secs();
+    let now = cache::now_unix();
 
     // Try multiple endpoint + body format variants.
     // mobile=true prevents clobbering an active game session.
@@ -1701,54 +1710,42 @@ fn wfm_get_item_statistics(state: State<AppState>, url_name: String) -> Result<s
 
 // ── Top WFM items by 7-day trade volume ───────────────────────────────────────
 
-#[derive(serde::Serialize, serde::Deserialize)]
-struct WfmTopDiskCache {
-    saved_at: u64,          // Unix seconds
-    items: Vec<WfmTopItem>,
-}
+const WFM_TOP_CACHE: &str = "wfm-top-v1.json";
+const WFM_TOP_TTL: std::time::Duration = std::time::Duration::from_secs(3 * 3600);
+
+/// Arcane name, WFM slug and image, as handed to a scan.
+type ArcaneCandidate = (String, String, Option<String>);
 
 /// Return the top 10 most-traded items on warframe.market by 7-day total value.
 /// Queries Prime Sets and Arcanes from the local WFCD catalog (already loaded).
 /// Results are cached for 3 hours so repeated tab opens are instant.
 #[tauri::command]
 async fn get_wfm_top_items(state: State<'_, AppState>) -> Result<Vec<WfmTopItem>, String> {
-    const TOP_TTL: std::time::Duration = std::time::Duration::from_secs(3 * 3600);
-
     // In-memory cache, fresh within the TTL — the client owns it.
-    if let Some(items) = state.wfm.cached_top_items(TOP_TTL) {
+    if let Some(items) = state.wfm.cached_top_items(WFM_TOP_TTL) {
         return Ok(items);
     }
 
-    // Disk cache — survives app restarts.
-    let disk_cache_path = state.wfm_top_cache_path.clone();
-    if let Ok(s) = std::fs::read_to_string(&disk_cache_path) {
-        if let Ok(dc) = serde_json::from_str::<WfmTopDiskCache>(&s) {
-            let now_secs = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_secs();
-            if now_secs.saturating_sub(dc.saved_at) < TOP_TTL.as_secs() && !dc.items.is_empty() {
-                state.wfm.set_top_items(dc.items.clone());
-                return Ok(dc.items);
-            }
+    // The disk cache survives app restarts. An empty list is a scan that found
+    // nothing, which is never worth serving.
+    let now_secs = cache::now_unix();
+    let disk = cache::load::<Vec<WfmTopItem>>(WFM_TOP_CACHE).filter(|c| !c.data.is_empty());
+    if let Some(cached) = &disk {
+        if now_secs.saturating_sub(cached.retrieved_at_unix) < WFM_TOP_TTL.as_secs() {
+            state.wfm.set_top_items(cached.data.clone());
+            cache::set_status(WFM_TOP_CACHE, cache::CacheStatus {
+                source:       cache::Source::Fresh,
+                last_updated: Some(cached.retrieved_at_unix),
+                warning:      None,
+            });
+            return Ok(cached.data.clone());
         }
-    }
-
-    // Only one scan at a time. If another is already running, wait for it to populate
-    // the cache rather than starting a second 90-second scan that would compete for the
-    // rate-limiter budget and double the total time.
-    if WFM_SCAN_RUNNING.compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst).is_err() {
-        for _ in 0..120u32 {  // poll every 5 s, max 10 minutes
-            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-            if let Some(items) = state.wfm.cached_top_items(TOP_TTL) {
-                return Ok(items);
-            }
-        }
-        return Err("WFM top items scan timed out".to_string());
     }
 
     // Collect arcane candidates from WFCD without holding the lock across await points.
-    // Prime Sets come from WFM's own item list (fetched inside spawn_blocking below) so
-    // that we get canonical slugs — WFCD doesn't have set-level entries.
-    let arcane_candidates: Vec<(String, String, Option<String>)> = {
+    // Prime Sets come from WFM's own item list (fetched inside the scan) so that we get
+    // canonical slugs; WFCD doesn't have set-level entries.
+    let arcane_candidates: Vec<ArcaneCandidate> = {
         let items = state.wfcd_items.lock().map_err(|e| e.to_string())?;
         items.iter()
             .filter(|i| i.category == "Arcanes")
@@ -1756,57 +1753,154 @@ async fn get_wfm_top_items(state: State<'_, AppState>) -> Result<Vec<WfmTopItem>
             .collect()
     };
 
+    // Only one scan at a time: a second one would compete for the same rate-limiter
+    // budget and take twice as long for both.
+    let claimed_scan =
+        WFM_SCAN_RUNNING.compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst).is_ok();
+
+    // An expired copy beats an empty tab for the minute and a half a scan takes,
+    // so hand it over and rescan behind it.
+    if let Some(cached) = disk {
+        if claimed_scan {
+            let wfm = state.wfm.clone();
+            std::thread::spawn(move || {
+                // Release the scan slot even on a panic, or every later scan
+                // is blocked for the rest of the session.
+                let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    finish_wfm_top_scan(&wfm, scan_wfm_top_items(&wfm, &arcane_candidates));
+                }));
+                WFM_SCAN_RUNNING.store(false, Ordering::SeqCst);
+            });
+        }
+        cache::set_status(WFM_TOP_CACHE, cache::CacheStatus {
+            source:       cache::Source::Stale,
+            last_updated: Some(cached.retrieved_at_unix),
+            warning:      Some("warframe.market top items are being rescanned".to_string()),
+        });
+        return Ok(cached.data);
+    }
+
+    // Nothing to show, so the caller has to wait for a scan either way.
+    if !claimed_scan {
+        for _ in 0..120u32 {  // poll every 5 s, max 10 minutes
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            if let Some(items) = state.wfm.cached_top_items(WFM_TOP_TTL) {
+                return Ok(items);
+            }
+        }
+        return Err("WFM top items scan timed out".to_string());
+    }
+
     // Run blocking ureq calls on the thread pool — keeps the async runtime free
     let wfm = state.wfm.clone();
-    let scan_result = tokio::task::spawn_blocking(move || {
-        let prime_sets = wfm.prime_sets();
-        let mut out: Vec<WfmTopItem> = Vec::new();
-
-        for (name, url_name) in &prime_sets {
-            if let Some((price, daily_vol)) = wfm.stats_7day(url_name) {
-                out.push(WfmTopItem {
-                    name:           name.clone(),
-                    url_name:       url_name.clone(),
-                    image_name:     None,
-                    unit_price:     price,
-                    daily_volume:   daily_vol,
-                    total_value_7d: (price as f64 * daily_vol * 7.0) as u64,
-                });
-            }
-        }
-
-        for (name, slug, image_name) in &arcane_candidates {
-            if let Some((price, daily_vol)) = wfm.stats_7day(slug) {
-                out.push(WfmTopItem {
-                    name:           name.clone(),
-                    url_name:       slug.clone(),
-                    image_name:     image_name.clone(),
-                    unit_price:     price,
-                    daily_volume:   daily_vol,
-                    total_value_7d: (price as f64 * daily_vol * 7.0) as u64,
-                });
-            }
-        }
-
-        out.sort_by(|a, b| b.total_value_7d.cmp(&a.total_value_7d));
-        out.truncate(10);
-        out
-    }).await;
+    let scan_result =
+        tokio::task::spawn_blocking(move || scan_wfm_top_items(&wfm, &arcane_candidates)).await;
 
     // Release the scan slot before propagating any error
     WFM_SCAN_RUNNING.store(false, Ordering::SeqCst);
 
     let results = scan_result.map_err(|e| e.to_string())?;
+    finish_wfm_top_scan(&state.wfm, results.clone());
+    Ok(results)
+}
 
-    // Write to disk so the results survive an app restart
-    let now_secs = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_secs();
-    if let Ok(json) = serde_json::to_string(&WfmTopDiskCache { saved_at: now_secs, items: results.clone() }) {
-        let _ = std::fs::write(&disk_cache_path, json);
+/// Background-refresh entry point. A scan walks the whole WFM item list under a
+/// rate limiter and takes minutes. It runs on its own thread rather than
+/// holding up every other refresh. The schedule, not a backoff, retries it.
+pub(crate) fn refresh_wfm_top(app: &tauri::AppHandle, force: bool) -> Result<(), String> {
+    let state = app.state::<AppState>();
+    if !force && state.wfm.cached_top_items(WFM_TOP_TTL).is_none() {
+        // A restart empties the in-memory copy while the disk one is still
+        // good; adopting it is what keeps a launch from scanning.
+        let now_secs = cache::now_unix();
+        if let Some(cached) = cache::load::<Vec<WfmTopItem>>(WFM_TOP_CACHE)
+            .filter(|c| !c.data.is_empty()
+                && now_secs.saturating_sub(c.retrieved_at_unix) < WFM_TOP_TTL.as_secs())
+        {
+            state.wfm.set_top_items(cached.data);
+        }
+    }
+    if !force && state.wfm.cached_top_items(WFM_TOP_TTL).is_some() {
+        return Ok(());
+    }
+    if WFM_SCAN_RUNNING.compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst).is_err() {
+        return Ok(());
+    }
+    let arcane_candidates: Vec<ArcaneCandidate> = {
+        let items = state.wfcd_items.lock().unwrap_or_else(|e| e.into_inner());
+        items.iter()
+            .filter(|i| i.category == "Arcanes")
+            .map(|i| (i.name.clone(), to_wfm_slug(&i.name), i.image_name.clone()))
+            .collect()
+    };
+    let wfm = state.wfm.clone();
+    std::thread::spawn(move || {
+        // Release the scan slot even on a panic, or every later scan is
+        // blocked for the rest of the session.
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            finish_wfm_top_scan(&wfm, scan_wfm_top_items(&wfm, &arcane_candidates));
+        }));
+        WFM_SCAN_RUNNING.store(false, Ordering::SeqCst);
+    });
+    Ok(())
+}
+
+fn scan_wfm_top_items(wfm: &Wfm, arcane_candidates: &[ArcaneCandidate]) -> Vec<WfmTopItem> {
+    let prime_sets = wfm.prime_sets();
+    let mut out: Vec<WfmTopItem> = Vec::new();
+
+    for (name, url_name) in &prime_sets {
+        if let Some((price, daily_vol)) = wfm.stats_7day(url_name) {
+            out.push(WfmTopItem {
+                name:           name.clone(),
+                url_name:       url_name.clone(),
+                image_name:     None,
+                unit_price:     price,
+                daily_volume:   daily_vol,
+                total_value_7d: (price as f64 * daily_vol * 7.0) as u64,
+            });
+        }
     }
 
-    state.wfm.set_top_items(results.clone());
-    Ok(results)
+    for (name, slug, image_name) in arcane_candidates {
+        if let Some((price, daily_vol)) = wfm.stats_7day(slug) {
+            out.push(WfmTopItem {
+                name:           name.clone(),
+                url_name:       slug.clone(),
+                image_name:     image_name.clone(),
+                unit_price:     price,
+                daily_volume:   daily_vol,
+                total_value_7d: (price as f64 * daily_vol * 7.0) as u64,
+            });
+        }
+    }
+
+    out.sort_by(|a, b| b.total_value_7d.cmp(&a.total_value_7d));
+    out.truncate(10);
+    out
+}
+
+fn finish_wfm_top_scan(wfm: &Wfm, results: Vec<WfmTopItem>) {
+    // A scan that priced nothing means warframe.market was unreachable, not that
+    // nothing trades. Both readers skip an empty list anyway, so storing one only
+    // throws away the copy that still has items in it.
+    if results.is_empty() {
+        cache::set_status(WFM_TOP_CACHE, cache::CacheStatus {
+            source:       cache::Source::Stale,
+            last_updated: cache::load::<Vec<WfmTopItem>>(WFM_TOP_CACHE).map(|c| c.retrieved_at_unix),
+            warning:      Some("warframe.market top items: scan returned nothing".into()),
+        });
+        return;
+    }
+    if let Err(e) = cache::store(WFM_TOP_CACHE, None, &results) {
+        tracing::warn!("cannot write WFM top items cache: {e}");
+    }
+    cache::set_status(WFM_TOP_CACHE, cache::CacheStatus {
+        source:       cache::Source::Refreshed,
+        last_updated: Some(cache::now_unix()),
+        warning:      None,
+    });
+    wfm.set_top_items(results);
 }
 
 /// Save the WFM access token to Windows Credential Manager (encrypted by the OS).
@@ -2228,8 +2322,10 @@ pub struct RivenAnalysis {
     pub alternatives: Vec<AlternativeResult>, // one per "or" path
 }
 
-static RIVEN_DB: std::sync::OnceLock<std::sync::Mutex<HashMap<String, RivenEntry>>> =
-    std::sync::OnceLock::new();
+/// `None` until the first successful load fills it. A failed load leaves it
+/// unset, so the next lookup fetches again.
+static RIVEN_DB: std::sync::RwLock<Option<HashMap<String, RivenEntry>>> =
+    std::sync::RwLock::new(None);
 
 /// Returns a map of weapon unique_name → riven disposition (omegaAttenuation).
 /// Data comes from All.json (fetched during item load) — no extra HTTP request.
@@ -2254,10 +2350,63 @@ static RIVEN_FLAG_VA: std::sync::OnceLock<std::sync::Mutex<Option<(u32, Option<u
 static RIVEN_WATCHER_RUNNING: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
-fn get_riven_db() -> &'static std::sync::Mutex<HashMap<String, RivenEntry>> {
-    RIVEN_DB.get_or_init(|| {
-        std::sync::Mutex::new(load_riven_csv_from_url().unwrap_or_default())
-    })
+const RIVEN_DB_CACHE: &str = "riven-db-v1.json";
+
+/// The community sheet is edited by hand and rarely more than once a day.
+const RIVEN_DB_TTL: std::time::Duration = std::time::Duration::from_secs(24 * 3600);
+
+/// Run `f` against the riven database, loading it first if this is the first
+/// lookup of the session.
+fn with_riven_db<R>(f: impl FnOnce(&HashMap<String, RivenEntry>) -> R) -> R {
+    {
+        let guard = RIVEN_DB.read().unwrap_or_else(|e| e.into_inner());
+        if let Some(db) = guard.as_ref() {
+            return f(db);
+        }
+    }
+
+    // Two first-lookups racing here both fetch; the loser's result is dropped.
+    // Take the write lock across the fetch if that ever matters.
+    let (fresh, _, warning) = fetch_riven_db(false);
+    if let Some(w) = warning {
+        warn!("{w}");
+    }
+    let mut guard = RIVEN_DB.write().unwrap_or_else(|e| e.into_inner());
+    // A failed load must not be latched: leaving the slot empty is what makes
+    // the next lookup fetch again instead of serving nothing for the rest of
+    // the session. A concurrent load that won the race is likewise kept.
+    if guard.is_none() && !fresh.is_empty() {
+        *guard = Some(fresh);
+    }
+    match guard.as_ref() {
+        Some(db) => f(db),
+        None => f(&HashMap::new()),
+    }
+}
+
+/// Walk the cache ladder for the riven database: a fresh copy on disk, else the
+/// sheet, else the stale copy, else nothing. `force` skips the first rung.
+fn fetch_riven_db(force: bool) -> (HashMap<String, RivenEntry>, cache::Source, Option<String>) {
+    let ttl = if force { std::time::Duration::ZERO } else { RIVEN_DB_TTL };
+    let (data, source, warning) = cache::get_or_refresh(RIVEN_DB_CACHE, ttl, |_etag| {
+        // Google's CSV export carries no usable validator, so every refresh
+        // pulls all five tabs.
+        load_riven_csv_from_url().map(|db| cache::Fetched::New(db, None))
+    });
+    (data.unwrap_or_default(), source, warning)
+}
+
+/// Background-refresh entry point. A refetch that came back empty leaves the
+/// database that is already loaded in place.
+pub(crate) fn refresh_riven_db_task(_app: &tauri::AppHandle, force: bool) -> Result<(), String> {
+    let (fresh, _, warning) = fetch_riven_db(force);
+    if !fresh.is_empty() {
+        *RIVEN_DB.write().unwrap_or_else(|e| e.into_inner()) = Some(fresh);
+    }
+    match warning {
+        Some(w) => Err(w),
+        None => Ok(()),
+    }
 }
 
 const RIVEN_SHEET_ID: &str = "1zbaeJBuBn44cbVKzJins_E3hTDpnmvOk8heYN-G8yy8";
@@ -2427,7 +2576,7 @@ fn parse_original_stats(text: Option<&str>) -> Vec<serde_json::Value> {
 /// Returns (weapon_name, positives, negatives).
 #[tauri::command]
 async fn ocr_riven_screen() -> Result<serde_json::Value, String> {
-    let riven_log = std::env::temp_dir().join("frameforge_riven_session.txt");
+    let riven_log = paths::state_dir().join("frameforge_riven_session.txt");
     let ts1 = chrono::Local::now().format("%H:%M:%S%.3f").to_string();
 
     let _ = append_to_file(&riven_log, &format!(
@@ -2577,16 +2726,16 @@ async fn ocr_riven_screen() -> Result<serde_json::Value, String> {
     // Helper: try to match a candidate string against the riven DB, trying word-prefix
     // substrings from longest to shortest (handles "Dual Cleavers Cronitron" → "dual cleavers").
     let find_in_db = |candidate: &str| -> Option<String> {
-        let db = get_riven_db().lock().unwrap_or_else(|e| e.into_inner());
-        let words: Vec<&str> = candidate.split_whitespace().collect();
-        // Try 4-word prefix, then 3, 2, 1
-        for len in (1..=words.len().min(4)).rev() {
-            let prefix = words[..len].join(" ");
-            if db.contains_key(&prefix) {
-                return Some(prefix);
+        with_riven_db(|db| {
+            let words: Vec<&str> = candidate.split_whitespace().collect();
+            for len in (1..=words.len().min(4)).rev() {
+                let prefix = words[..len].join(" ");
+                if db.contains_key(&prefix) {
+                    return Some(prefix);
+                }
             }
-        }
-        None
+            None
+        })
     };
 
     // The "FITS IN" panel is the only place the game states the weapon outright,
@@ -2913,7 +3062,7 @@ fn start_log_watcher(app: tauri::AppHandle) -> Result<(), String> {
                 });
                 if riven_active {
                     last_riven_fire = None;
-                    let riven_log = std::env::temp_dir().join("frameforge_riven_session.txt");
+                    let riven_log = paths::state_dir().join("frameforge_riven_session.txt");
                     let ts = chrono::Local::now().format("%H:%M:%S%.3f").to_string();
                     let _ = append_to_file(&riven_log, &format!(
                         "[STEP 4] CLOSE (DiegeticArtifactCards HudVis 0) — {}\n\n", ts
@@ -2933,7 +3082,7 @@ fn start_log_watcher(app: tauri::AppHandle) -> Result<(), String> {
                 });
                 if riven_active {
                     last_riven_fire = None;
-                    let riven_log = std::env::temp_dir().join("frameforge_riven_session.txt");
+                    let riven_log = paths::state_dir().join("frameforge_riven_session.txt");
                     let ts = chrono::Local::now().format("%H:%M:%S%.3f").to_string();
                     let _ = append_to_file(&riven_log, &format!(
                         "[STEP 4] CLOSE (VolumetricFog render target = orbiter loaded) — {}\n\n", ts
@@ -3034,7 +3183,7 @@ fn start_log_watcher(app: tauri::AppHandle) -> Result<(), String> {
 ///  "unknown" = inventory header not visible (alt-tabbed, or left inventory entirely)
 #[tauri::command]
 fn riven_screen_status() -> String {
-    let riven_log = std::env::temp_dir().join("frameforge_riven_session.txt");
+    let riven_log = paths::state_dir().join("frameforge_riven_session.txt");
     let ts = chrono::Local::now().format("%H:%M:%S%.3f").to_string();
 
     let Ok((pixels, w, h)) = ocr::capture_warframe_pixels() else {
@@ -3075,7 +3224,7 @@ fn riven_screen_status() -> String {
 /// AND "FITS IN" is gone — so alt-tabbing away doesn't trigger a false close.
 #[tauri::command]
 fn riven_screen_visible() -> bool {
-    let riven_log = std::env::temp_dir().join("frameforge_riven_session.txt");
+    let riven_log = paths::state_dir().join("frameforge_riven_session.txt");
     let ts = chrono::Local::now().format("%H:%M:%S%.3f").to_string();
 
     let Ok((pixels, w, h)) = ocr::capture_warframe_pixels() else {
@@ -3225,7 +3374,7 @@ fn start_riven_memory_watcher(app: tauri::AppHandle) {
 /// Write an error into the riven session log (called from TypeScript when OCR command fails).
 #[tauri::command]
 fn ocr_riven_log_error(error: String) {
-    let path = std::env::temp_dir().join("frameforge_riven_session.txt");
+    let path = paths::state_dir().join("frameforge_riven_session.txt");
     let ts = chrono::Local::now().format("%H:%M:%S%.3f").to_string();
     let _ = append_to_file(&path, &format!(
         "[STEP 2] OCR COMMAND FAILED — {}\n└─ Error: {}\n\n", ts, error
@@ -3274,8 +3423,7 @@ fn rename_saved_riven_roll(state: tauri::State<'_, AppState>, id: String, label:
 /// Return all weapon names that have riven data.
 #[tauri::command]
 fn get_riven_weapons() -> Vec<String> {
-    let db = get_riven_db().lock().unwrap_or_else(|e| e.into_inner());
-    let mut weapons: Vec<String> = db.keys().cloned().collect();
+    let mut weapons: Vec<String> = with_riven_db(|db| db.keys().cloned().collect());
     weapons.sort();
     weapons
 }
@@ -3283,9 +3431,16 @@ fn get_riven_weapons() -> Vec<String> {
 /// Reload the riven database from the Google Sheet.
 #[tauri::command]
 fn reload_riven_database() -> Result<usize, String> {
-    let fresh = load_riven_csv_from_url()?;
+    let (fresh, source, warning) = fetch_riven_db(true);
     let count = fresh.len();
-    *get_riven_db().lock().unwrap_or_else(|e| e.into_inner()) = fresh;
+    if count > 0 {
+        *RIVEN_DB.write().unwrap_or_else(|e| e.into_inner()) = Some(fresh);
+    }
+    // The user asked for the current sheet, so a stale copy is not an answer
+    // even though it is still worth showing.
+    if source != cache::Source::Refreshed {
+        return Err(warning.unwrap_or_else(|| "Failed to load riven database.".to_string()));
+    }
     Ok(count)
 }
 
@@ -3293,9 +3448,8 @@ fn reload_riven_database() -> Result<usize, String> {
 /// positives / negatives are full stat names (e.g. "Critical Damage", "Zoom").
 #[tauri::command]
 fn analyze_riven(weapon: String, positives: Vec<String>, negatives: Vec<String>) -> Option<RivenAnalysis> {
-    let db = get_riven_db().lock().unwrap_or_else(|e| e.into_inner());
     let key = weapon.to_lowercase();
-    let entry = db.get(&key)?;
+    let entry = with_riven_db(|db| db.get(&key).cloned())?;
 
     let normalize = |s: &str| s.to_lowercase();
 
@@ -3549,9 +3703,7 @@ fn fetch_wfm_items(state: State<AppState>) -> Result<Vec<WfmItem>, String> {
 /// removed — WFM is inconsistent about whether component blueprints include it.
 #[tauri::command]
 fn fetch_wfm_price(state: State<AppState>, url_name: String) -> Result<WfmPrice, String> {
-    // A lookup that errors and one that finds no listing both surface the same way
-    // to the UI — no price — so `price_with_fallback` collapsing both to None is fine.
-    let sell_median = state.wfm.price_with_fallback(&url_name).map(|p| p as f64);
+    let sell_median = state.wfm.price_with_fallback(&url_name)?.map(|p| p as f64);
     Ok(WfmPrice { url_name, sell_median, buy_median: None })
 }
 
@@ -3579,10 +3731,13 @@ fn get_item_price(item_name: String, state: State<AppState>) -> Result<Option<u3
     // display names, where a prime component's name carries "Blueprint" but WFM lists
     // it without the suffix. A non-blueprint name must NOT fall back to a _blueprint
     // slug, or a frame would be priced as its blueprint.
-    let price = state.wfm.price_for_slug(&slug)?.or_else(|| {
-        slug.strip_suffix("_blueprint")
-            .and_then(|base| state.wfm.price_for_slug(base).unwrap_or(None))
-    });
+    let price = match state.wfm.price_for_slug(&slug)? {
+        Some(p) => Some(p),
+        None => match slug.strip_suffix("_blueprint") {
+            Some(base) => state.wfm.price_for_slug(base)?,
+            None => None,
+        },
+    };
     state.wfm.cache_price(slug, price);
 
     // Persist WFM price into the inventory cache file so it survives restarts.
@@ -3707,7 +3862,15 @@ fn start_wfm_queue(app: tauri::AppHandle, state: State<'_, AppState>) -> Result<
             if wfm.is_price_cached(&slug) { continue; }
 
             // Fetch — the rate limiter inside enforces the 3 req/sec limit.
-            let price = wfm.price_with_fallback(&slug);
+            // A failed lookup is dropped rather than cached: the slug carries no
+            // verdict yet, and the next request for it re-queues.
+            let price = match wfm.price_with_fallback(&slug) {
+                Ok(price) => price,
+                Err(e) => {
+                    tracing::debug!("wfm price queue: {e}");
+                    continue;
+                }
+            };
             let tradeable = price.is_some();
 
             // Update in-memory cache.
@@ -4038,6 +4201,8 @@ async fn toggle_raw_scan(state: State<'_, AppState>) -> Result<String, String> {
     Ok("started".to_string())
 }
 
+/// Resets the scanned inventory only. The downloaded caches are untouched.
+/// The refresh button is what re-fetches those.
 #[tauri::command]
 fn clear_cache(state: State<AppState>) -> Result<(), String> {
     // Clear change log from DB
@@ -5073,8 +5238,8 @@ async fn start_monitor(app: tauri::AppHandle, state: State<'_, AppState>) -> Res
         .map(|(u, n)| (u.clone(), n.clone()))
         .collect();
 
-    let debug_path      = std::env::temp_dir().join("frameforge_reward_debug.txt");
-    let last_found_path = std::env::temp_dir().join("frameforge_last_reward.txt");
+    let debug_path      = paths::state_dir().join("frameforge_reward_debug.txt");
+    let last_found_path = paths::state_dir().join("frameforge_last_reward.txt");
 
     // ── EE.log watcher ────────────────────────────────────────────────────────
     // Warframe writes "Script [Info]: Got rewards" to EE.log the moment the
@@ -5112,7 +5277,7 @@ async fn start_monitor(app: tauri::AppHandle, state: State<'_, AppState>) -> Res
     let ee_ocr_app   = reward_app.clone();
     let ee_catalog   = std::sync::Arc::clone(&catalog_pairs);
     let ee_last_path = last_found_path.clone();
-    let session_log_path = std::env::temp_dir().join("frameforge_overlay_session.txt");
+    let session_log_path = paths::state_dir().join("frameforge_overlay_session.txt");
     let ee_auto_capture_dir = auto_capture_dir.clone();
 
     if let Some(log_path) = ee_log_path {
@@ -6177,10 +6342,10 @@ fn append_to_file(path: &std::path::Path, text: &str) -> std::io::Result<()> {
 
 /// Append text to both the global overlay session log and the per-session diagnostic file.
 /// The diagnostic target is found by picking the most recently modified folder under
-/// %TEMP%\warframe-companion\diagnostics\ that contains an ocr_session_log.txt.
+/// the state directory's `diagnostics/` that contains an ocr_session_log.txt.
 fn append_to_diag(global_log: &std::path::Path, text: &str) {
     let _ = append_to_file(global_log, text);
-    let diag_base = std::env::temp_dir().join("warframe-companion").join("diagnostics");
+    let diag_base = paths::state_dir().join("diagnostics");
     if let Ok(entries) = std::fs::read_dir(&diag_base) {
         let mut folders: Vec<std::path::PathBuf> = entries
             .filter_map(|e| e.ok().map(|d| d.path()))
@@ -7289,44 +7454,8 @@ async fn fetch_worldstate(state: State<'_, AppState>) -> Result<serde_json::Valu
             }
             return Ok((result, None));
         }
-        let raw = ureq::get("https://api.warframe.com/cdn/worldState.php")
-            .set("User-Agent", "FrameForge/3.2.0")
-            .timeout(std::time::Duration::from_secs(20))
-            .call()
-            .map_err(|e| format!("worldstate fetch failed: {}", e))?
-            .into_json::<serde_json::Value>()
-            .map_err(|e| format!("worldstate parse failed: {}", e))?;
+        let (raw, news_value) = fetch_worldstate_upstream()?;
         let mut result = parse_worldstate_value(&raw, now_ms, &catalog);
-
-        // Fetch news/promotions from Steam — official Warframe community announcements only.
-        // warframestat.us/pc/news was removed from that API entirely.
-        let news: Vec<serde_json::Value> = ureq::get(
-            "https://api.steampowered.com/ISteamNews/GetNewsForApp/v2/?appid=230410&count=10&maxlength=500&format=json"
-        )
-            .set("User-Agent", "FrameForge/3.2.0")
-            .timeout(std::time::Duration::from_secs(10))
-            .call()
-            .ok()
-            .and_then(|r| r.into_json::<serde_json::Value>().ok())
-            .and_then(|v| v["appnews"]["newsitems"].as_array().cloned())
-            .unwrap_or_default()
-            .into_iter()
-            .filter(|item| item["feed_type"].as_i64().unwrap_or(0) == 1)
-            .map(|item| {
-                let title = item["title"].as_str().unwrap_or("").to_string();
-                let lower = title.to_lowercase();
-                let ts_ms = item["date"].as_i64().unwrap_or(0) * 1000;
-                serde_json::json!({
-                    "message":     title,
-                    "link":        item["url"].as_str().unwrap_or(""),
-                    "date":        ts_ms,
-                    "stream":      false,
-                    "primeAccess": lower.contains("prime access") || lower.contains("prime "),
-                    "update":      lower.contains("update") || lower.contains("patch notes"),
-                })
-            })
-            .collect();
-        let news_value = serde_json::json!(news);
         if let Some(obj) = result.as_object_mut() {
             obj.insert("news".to_string(), news_value.clone());
         }
@@ -7336,21 +7465,108 @@ async fn fetch_worldstate(state: State<'_, AppState>) -> Result<serde_json::Valu
     .map_err(|e| format!("task error: {}", e))??;
 
     if let Some((raw, news)) = fetched {
-        let mut cache = state.worldstate_cache.lock().unwrap_or_else(|e| e.into_inner());
-        // Two callers that both missed can finish out of order, so a response
-        // that started before what is already stored must not replace it.
-        let stored_is_newer = cache.as_ref().is_some_and(|(fetched_at, _, _)| *fetched_at > started_at);
-        if !stored_is_newer {
-            *cache = Some((std::time::Instant::now(), raw, news));
-        }
+        store_worldstate(&state, started_at, raw, news);
     }
     Ok(result)
+}
+
+/// Pull the raw worldstate and the Steam news that goes with it.
+fn fetch_worldstate_upstream() -> Result<(serde_json::Value, serde_json::Value), String> {
+    let raw = ureq::get("https://api.warframe.com/cdn/worldState.php")
+        .set("User-Agent", "FrameForge/3.2.0")
+        .timeout(std::time::Duration::from_secs(20))
+        .call()
+        .map_err(|e| format!("worldstate fetch failed: {}", e))?
+        .into_json::<serde_json::Value>()
+        .map_err(|e| format!("worldstate parse failed: {}", e))?;
+
+    // Official Warframe community announcements only: warframestat.us/pc/news
+    // was removed from that API entirely.
+    let news: Vec<serde_json::Value> = ureq::get(
+        "https://api.steampowered.com/ISteamNews/GetNewsForApp/v2/?appid=230410&count=10&maxlength=500&format=json"
+    )
+        .set("User-Agent", "FrameForge/3.2.0")
+        .timeout(std::time::Duration::from_secs(10))
+        .call()
+        .ok()
+        .and_then(|r| r.into_json::<serde_json::Value>().ok())
+        .and_then(|v| v["appnews"]["newsitems"].as_array().cloned())
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|item| item["feed_type"].as_i64().unwrap_or(0) == 1)
+        .map(|item| {
+            let title = item["title"].as_str().unwrap_or("").to_string();
+            let lower = title.to_lowercase();
+            let ts_ms = item["date"].as_i64().unwrap_or(0) * 1000;
+            serde_json::json!({
+                "message":     title,
+                "link":        item["url"].as_str().unwrap_or(""),
+                "date":        ts_ms,
+                "stream":      false,
+                "primeAccess": lower.contains("prime access") || lower.contains("prime "),
+                "update":      lower.contains("update") || lower.contains("patch notes"),
+            })
+        })
+        .collect();
+    Ok((raw, serde_json::json!(news)))
+}
+
+fn store_worldstate(
+    state: &AppState,
+    started_at: std::time::Instant,
+    raw: Arc<serde_json::Value>,
+    news: Arc<serde_json::Value>,
+) {
+    let mut cache = state.worldstate_cache.lock().unwrap_or_else(|e| e.into_inner());
+    // Two callers that both missed can finish out of order, so a response that
+    // started before what is already stored must not replace it.
+    let stored_is_newer = cache.as_ref().is_some_and(|(fetched_at, _, _)| *fetched_at > started_at);
+    if !stored_is_newer {
+        *cache = Some((std::time::Instant::now(), raw, news));
+    }
+}
+
+/// Background-refresh entry point: keeps the shared worldstate warm so a window
+/// polling on its own timer is served from memory. `force` has nothing to skip:
+/// the endpoint carries no validator.
+pub(crate) fn refresh_worldstate(app: &tauri::AppHandle, _force: bool) -> Result<(), String> {
+    // A frontend poll that missed the cache may have refetched moments ago;
+    // pulling again on the scheduler's own beat would double the upstream rate
+    // for nothing. Just under the frontend's 55 s TTL so a copy this task let
+    // age out is refetched on the next 5 s tick.
+    {
+        let state = app.state::<AppState>();
+        let cache = state.worldstate_cache.lock().unwrap_or_else(|e| e.into_inner());
+        let still_warm = cache
+            .as_ref()
+            .is_some_and(|(at, _, _)| at.elapsed() < std::time::Duration::from_secs(50));
+        if still_warm {
+            return Ok(());
+        }
+    }
+    let started_at = std::time::Instant::now();
+    let (raw, news) = fetch_worldstate_upstream().inspect_err(|e| {
+        // Nothing of the worldstate is on disk, so a failed fetch has no cached
+        // copy behind it to report the age of.
+        cache::set_status("worldstate", cache::CacheStatus {
+            source:       cache::Source::Stale,
+            last_updated: None,
+            warning:      Some(format!("worldstate refresh failed: {e}")),
+        });
+    })?;
+    store_worldstate(&app.state::<AppState>(), started_at, Arc::new(raw), Arc::new(news));
+    cache::set_status("worldstate", cache::CacheStatus {
+        source:       cache::Source::Refreshed,
+        last_updated: Some(cache::now_unix()),
+        warning:      None,
+    });
+    Ok(())
 }
 
 /// Read the riven overlay session log.
 #[tauri::command]
 fn get_riven_session_log() -> String {
-    let path = std::env::temp_dir().join("frameforge_riven_session.txt");
+    let path = paths::state_dir().join("frameforge_riven_session.txt");
     std::fs::read_to_string(&path)
         .unwrap_or_else(|_| "(no riven session log yet — open the riven reroll screen first)".into())
 }
@@ -7358,7 +7574,7 @@ fn get_riven_session_log() -> String {
 /// Read the current overlay session log.
 #[tauri::command]
 fn get_overlay_session_log() -> String {
-    let path = std::env::temp_dir().join("frameforge_overlay_session.txt");
+    let path = paths::state_dir().join("frameforge_overlay_session.txt");
     std::fs::read_to_string(&path).unwrap_or_else(|_| "(no session log yet — trigger a Void Fissure first)".into())
 }
 
@@ -7366,7 +7582,7 @@ fn get_overlay_session_log() -> String {
 /// lines into the same session log that gets copied to the diagnostics folder.
 #[tauri::command]
 fn log_relic_fe(msg: String) {
-    let path = std::env::temp_dir().join("frameforge_overlay_session.txt");
+    let path = paths::state_dir().join("frameforge_overlay_session.txt");
     let _ = append_to_file(&path, &format!("[FE] {}\n", msg));
 }
 
@@ -7634,7 +7850,6 @@ fn dir_size_bytes(dir: &std::path::Path) -> u64 {
 }
 
 
-/// Return the total size of %TEMP%\warframe-companion\diagnostics\ in bytes.
 #[tauri::command]
 fn get_diag_folder_size(state: State<AppState>) -> u64 {
     dir_size_bytes(&state.auto_capture_dir)
@@ -7653,6 +7868,50 @@ fn clear_diag_folder(state: State<AppState>) -> u64 {
         }
     }
     0
+}
+
+/// A download cut short by a dropped connection leaves a file the filesystem
+/// is happy with, and the webview renders it as a broken image forever.
+/// The header is what decides whether a cached image counts as one.
+fn looks_like_image(data: &[u8]) -> bool {
+    data.starts_with(b"\x89PNG\r\n\x1a\n")
+        || data.starts_with(&[0xFF, 0xD8, 0xFF])
+        || data.starts_with(b"GIF8")
+        || (data.len() >= 12 && data.starts_with(b"RIFF") && &data[8..12] == b"WEBP")
+}
+
+/// Whether a fully read cached file is a complete image. The header identifies
+/// the format. The trailer is what a download cut short by a dropped connection
+/// loses, and a truncated file keeps its header.
+fn image_complete(data: &[u8]) -> bool {
+    if !looks_like_image(data) {
+        return false;
+    }
+    if data.starts_with(b"\x89PNG") {
+        // A PNG ends with the IEND chunk: its name followed by a 4-byte CRC.
+        return data.len() >= 12 && data[data.len() - 8..data.len() - 4] == *b"IEND";
+    }
+    if data.starts_with(&[0xFF, 0xD8]) {
+        return data.ends_with(&[0xFF, 0xD9]);
+    }
+    if data.starts_with(b"GIF8") {
+        return data.ends_with(&[0x3B]);
+    }
+    // WEBP: the RIFF size field counts everything after the first 8 bytes.
+    let size = u32::from_le_bytes([data[4], data[5], data[6], data[7]]) as usize;
+    data.len() >= size.saturating_add(8)
+}
+
+/// Whether the cached file at `path` is worth serving. Reads only the header
+/// (this runs once per catalogued image on every startup), so truncation past
+/// the header slips through here and is caught at serve time instead.
+fn cached_image_ok(path: &std::path::Path) -> bool {
+    use std::io::Read;
+    let mut buf = [0u8; 12];
+    std::fs::File::open(path)
+        .and_then(|mut f| f.read_exact(&mut buf))
+        .is_ok()
+        && looks_like_image(&buf)
 }
 
 /// Minimal HTTP file server for the local image cache.
@@ -7680,7 +7939,14 @@ async fn serve_image_files(listener: tokio::net::TcpListener, cache_dir: PathBuf
                     return;
                 }
             };
-            match tokio::fs::read(dir.join(filename)).await {
+            let path = dir.join(filename);
+            match tokio::fs::read(&path).await {
+                // A corrupt file is thrown away rather than served: the 404
+                // sends the caller to the CDN, and the next prewarm refetches it.
+                Ok(data) if !image_complete(&data) => {
+                    let _ = tokio::fs::remove_file(&path).await;
+                    let _ = stream.write_all(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n").await;
+                }
                 Ok(data) => {
                     let mime = if filename.ends_with(".png") { "image/png" }
                         else if filename.ends_with(".jpg") || filename.ends_with(".jpeg") { "image/jpeg" }
@@ -7728,7 +7994,16 @@ async fn prewarm_image_cache(state: tauri::State<'_, AppState>) -> Result<(), St
             .filter_map(|i| i.image_name.clone())
             .collect::<HashSet<_>>()
             .into_iter()
-            .filter(|n| !cache_dir.join(n).exists())
+            .filter(|n| {
+                let path = cache_dir.join(n);
+                if cached_image_ok(&path) {
+                    return false;
+                }
+                // Whatever is there is not an image; a refetch needs the name
+                // free of it either way.
+                let _ = std::fs::remove_file(&path);
+                true
+            })
             .collect();
 
         if names.is_empty() { return; }
@@ -7742,7 +8017,7 @@ async fn prewarm_image_cache(state: tauri::State<'_, AppState>) -> Result<(), St
                     let url = format!("https://cdn.warframestat.us/img/{}", name);
                     if let Ok(resp) = ureq::get(&url).call() {
                         let mut buf = Vec::new();
-                        if resp.into_reader().read_to_end(&mut buf).is_ok() {
+                        if resp.into_reader().read_to_end(&mut buf).is_ok() && looks_like_image(&buf) {
                             let _ = std::fs::write(dir.join(&name), buf);
                         }
                     }
@@ -7862,8 +8137,6 @@ fn write_bmp(path: &std::path::Path, bgra: &[u8], w: u32, h: u32) -> std::io::Re
 
 /// Capture a diagnostic bundle: scan log + screenshot of the full Warframe window
 /// (including any overlay on top via GDI desktop BitBlt / DXGI fallback).
-/// Saves everything to %TEMP%\warframe-companion\diagnostics\<timestamp>\ and
-/// returns the folder path so the frontend can show it.
 #[tauri::command]
 async fn save_auto_diag_capture(state: State<'_, AppState>) -> Result<String, String> {
     // Reuse the frame already captured by the OCR pipeline — no second GPU readback,
@@ -7878,7 +8151,7 @@ async fn save_auto_diag_capture(state: State<'_, AppState>) -> Result<String, St
         let folder = auto_capture_dir.join(&ts);
         std::fs::create_dir_all(&folder).map_err(|e| e.to_string())?;
 
-        let session_log = std::env::temp_dir().join("frameforge_overlay_session.txt");
+        let session_log = paths::state_dir().join("frameforge_overlay_session.txt");
         if session_log.exists() {
             let _ = std::fs::copy(&session_log, folder.join("ocr_session_log.txt"));
         }
@@ -8021,58 +8294,99 @@ fn patch_item_category(name: &str, category: &str, unique_name: &str) -> String 
     if name.contains("Blueprint") { "Blueprints".to_string() } else { category.to_string() }
 }
 
-/// Delete the bulk price cache and re-fetch from FrameForgePricing.
+/// Re-fetch bulk prices from FrameForgePricing, ignoring the cache's age.
 /// Updates both relics_run_prices and the WFM price cache in-place.
 #[tauri::command]
 async fn refresh_bulk_prices(state: State<'_, AppState>) -> Result<(), String> {
-    let _ = std::fs::remove_file(&state.relics_run_prices_cache_path);
+    let (prices, source, warning) = tauri::async_runtime::spawn_blocking(|| {
+        cache::get_or_refresh(BULK_PRICES_CACHE, std::time::Duration::ZERO, fetch_relics_run_data)
+    })
+    .await
+    .map_err(|e| e.to_string())?;
 
-    let (by_name, by_slug) = tauri::async_runtime::spawn_blocking(fetch_relics_run_data)
-        .await
-        .map_err(|e| e.to_string())?;
-
-    if by_name.is_empty() {
-        return Err("Failed to fetch bulk prices — check your internet connection.".to_string());
+    // The user asked for new prices, so a stale copy is not an answer even
+    // though it is good enough for the background refresh.
+    if source != cache::Source::Refreshed {
+        return Err(warning.unwrap_or_else(|| "Failed to fetch bulk prices.".to_string()));
     }
+    let prices = prices.ok_or("Failed to fetch bulk prices.")?;
 
-    let today = chrono::Local::now().format("%Y-%m-%d").to_string();
-    let j = serde_json::json!({ "date": today, "by_name": &by_name, "by_slug": &by_slug });
-    if let Ok(s) = serde_json::to_string(&j) {
-        let _ = std::fs::write(&state.relics_run_prices_cache_path, s);
-    }
-
-    *state.relics_run_prices.lock().map_err(|e| e.to_string())? = by_name;
-    for (slug, price) in by_slug {
-        state.wfm.cache_price(slug, Some(price));
-    }
+    apply_bulk_prices(&state, prices, true);
     Ok(())
 }
 
-/// Load today's relics.run price cache from disk.
-/// Returns (by_name, by_slug) or None if missing/stale.
-fn load_relics_run_cache(path: &PathBuf) -> Option<(HashMap<String, u32>, HashMap<String, u32>)> {
-    let s = std::fs::read_to_string(path).ok()?;
-    let v: serde_json::Value = serde_json::from_str(&s).ok()?;
-    let today = chrono::Local::now().format("%Y-%m-%d").to_string();
-    if v.get("date").and_then(|d| d.as_str()) != Some(today.as_str()) { return None; }
-    let by_name: HashMap<String, u32> = serde_json::from_value(v["by_name"].clone()).ok()?;
-    let by_slug: HashMap<String, u32> = serde_json::from_value(v["by_slug"].clone()).ok()?;
-    Some((by_name, by_slug))
+/// Background-refresh entry point. Unlike the manual command it defers to any
+/// per-item WFM lookup that has already priced a slug more precisely.
+pub(crate) fn refresh_bulk_prices_task(app: &tauri::AppHandle, force: bool) -> Result<(), String> {
+    let ttl = if force { std::time::Duration::ZERO } else { BULK_PRICES_TTL };
+    let (prices, _, warning) = cache::get_or_refresh(BULK_PRICES_CACHE, ttl, fetch_relics_run_data);
+    match prices {
+        Some(prices) if warning.is_none() => {
+            apply_bulk_prices(&app.state::<AppState>(), prices, false);
+            Ok(())
+        }
+        _ => Err(warning.unwrap_or_else(|| "bulk prices unavailable".into())),
+    }
+}
+
+/// Per-cache freshness for the status chip: which rung each cache last answered
+/// from, when it was last updated, and what went wrong if anything did.
+#[tauri::command]
+fn get_cache_statuses() -> HashMap<String, cache::CacheStatus> {
+    cache::statuses()
+}
+
+/// Bring every cache due at once, ignoring both TTLs and ETags. The scheduler
+/// picks this up on its next tick, so the work happens off the UI thread.
+#[tauri::command]
+fn refresh_all_caches() {
+    refresh::force_all();
+}
+
+/// Publish bulk prices into the shared state. `overwrite_slugs` decides whether
+/// a slug already priced by a per-item WFM lookup gets replaced: a manual
+/// refresh replaces, the background one defers to the fresher single lookup.
+fn apply_bulk_prices(state: &AppState, prices: BulkPrices, overwrite_slugs: bool) {
+    if prices.by_name.is_empty() {
+        return;
+    }
+    *state.relics_run_prices.lock().unwrap_or_else(|e| e.into_inner()) = prices.by_name;
+    for (slug, price) in prices.by_slug {
+        if overwrite_slugs || !state.wfm.is_price_cached(&slug) {
+            state.wfm.cache_price(slug, Some(price));
+        }
+    }
 }
 
 const PRICING_BASE: &str = "https://raw.githubusercontent.com/WyrmStudios/FrameForgePricing/main";
 
-/// Fetch items.json + today's price_history from the FrameForgePricing mirror.
-/// Returns (by_name, by_slug):
-///   by_name: item display name (lowercase) → median sell price  (for get_item_price)
-///   by_slug: authoritative WFM slug         → median sell price  (for wfm_price_cache)
+const BULK_PRICES_CACHE: &str = "bulk-prices-v1.json";
+
+/// The mirror republishes a few times a day; an hour keeps a long session from
+/// tallying a relic run against yesterday's plat.
+const BULK_PRICES_TTL: std::time::Duration = std::time::Duration::from_secs(3600);
+
+/// Median sell prices keyed two ways: display name for the relic-run tally,
+/// WFM slug for seeding the per-item price cache.
+#[derive(Default, serde::Serialize, serde::Deserialize)]
+struct BulkPrices {
+    by_name: HashMap<String, u32>,
+    by_slug: HashMap<String, u32>,
+}
+
+/// Fetch items.json + the latest price_history from the FrameForgePricing mirror.
+///
+/// Both files are served without a usable ETag, and the pair only makes sense
+/// together, so the conditional-GET slot goes unused here.
 #[tracing::instrument(level = "debug", skip_all)]
-fn fetch_relics_run_data() -> (HashMap<String, u32>, HashMap<String, u32>) {
+fn fetch_relics_run_data(_etag: Option<&str>) -> Result<cache::Fetched<BulkPrices>, String> {
     // items.json gives the authoritative name → WFM slug mapping for every tradeable item.
-    let name_to_slug: HashMap<String, String> = ureq::get(&format!("{}/items.json", PRICING_BASE))
-        .call().ok()
-        .and_then(|r| r.into_json::<Vec<serde_json::Value>>().ok())
-        .unwrap_or_default()
+    let items: Vec<serde_json::Value> = ureq::get(&format!("{}/items.json", PRICING_BASE))
+        .call()
+        .map_err(|e| format!("items.json: {e}"))?
+        .into_json()
+        .map_err(|e| format!("items.json: {e}"))?;
+    let name_to_slug: HashMap<String, String> = items
         .into_iter()
         .filter_map(|v| {
             let name = v["i18n"]["en"]["name"].as_str()?.to_lowercase();
@@ -8081,12 +8395,14 @@ fn fetch_relics_run_data() -> (HashMap<String, u32>, HashMap<String, u32>) {
         })
         .collect();
 
-    let price_json: serde_json::Value = ureq::get(
-        &format!("{}/price_history_latest.json", PRICING_BASE)
-    ).call().ok().and_then(|r| r.into_json().ok()).unwrap_or_default();
+    let price_json: serde_json::Value =
+        ureq::get(&format!("{}/price_history_latest.json", PRICING_BASE))
+            .call()
+            .map_err(|e| format!("price_history_latest.json: {e}"))?
+            .into_json()
+            .map_err(|e| format!("price_history_latest.json: {e}"))?;
 
-    let mut by_name: HashMap<String, u32> = HashMap::new();
-    let mut by_slug: HashMap<String, u32> = HashMap::new();
+    let mut prices = BulkPrices::default();
 
     if let Some(obj) = price_json.as_object() {
         for (name, records) in obj {
@@ -8101,43 +8417,16 @@ fn fetch_relics_run_data() -> (HashMap<String, u32>, HashMap<String, u32>) {
                 let slug = name_to_slug.get(&name_lower)
                     .cloned()
                     .unwrap_or_else(|| to_wfm_slug(&name_lower));
-                by_name.insert(name_lower, price_u32);
-                by_slug.insert(slug, price_u32);
+                prices.by_name.insert(name_lower, price_u32);
+                prices.by_slug.insert(slug, price_u32);
             }
         }
     }
 
-    (by_name, by_slug)
-}
-
-fn load_items_cache(path: &PathBuf) -> Option<Vec<WfcdItem>> {
-    let s = std::fs::read_to_string(path).ok()?;
-    let arr: Vec<serde_json::Value> = serde_json::from_str(&s).ok()?;
-    // If the cache predates the item_type/product_category fields, discard it so
-    // a fresh fetch populates the new fields needed by fix_category.
-    if arr.first().map_or(false, |v| v.get("item_type").is_none()) {
-        let _ = std::fs::remove_file(path);
-        return None;
+    if prices.by_name.is_empty() {
+        return Err("price history carried no closed-order medians".to_string());
     }
-    let items: Vec<WfcdItem> = arr.into_iter().filter_map(|v| {
-        let unique_name = v["unique_name"].as_str()?.to_string();
-        let raw_name = v["name"].as_str()?.to_string();
-        let name = patch_item_name(&unique_name, &raw_name);
-        let image_name = v["image_name"].as_str().map(|s| s.to_string());
-        let vaulted = v["vaulted"].as_bool();
-        let ducats = v["ducats"].as_u64().map(|n| n as u32);
-        let raw_cat          = v["category"].as_str()?.to_string();
-        let category         = patch_item_category(&name, &raw_cat, &unique_name);
-        let item_type        = v["item_type"].as_str().unwrap_or("").to_string();
-        let product_category = v["product_category"].as_str().unwrap_or("").to_string();
-        let mastery_req       = v["mastery_req"].as_u64().map(|n| n as u32);
-        let omega_attenuation = v["omega_attenuation"].as_f64().map(|n| n as f32);
-        let fusion_limit      = v["fusion_limit"].as_u64().map(|n| n as u32);
-        let max_level_cap     = v["max_level_cap"].as_u64().map(|n| n as u32)
-            .or_else(|| if unique_name.contains("/EntratiMech/") { Some(40) } else { None });
-        Some(WfcdItem { unique_name, name, category, item_type, product_category, image_name, vaulted, ducats, mastery_req, omega_attenuation, fusion_limit, max_level_cap })
-    }).collect();
-    if items.is_empty() { None } else { Some(dedup_known_aliases(items)) }
+    Ok(cache::Fetched::New(prices, None))
 }
 
 /// Remove known duplicate entries caused by the game listing the same warframe under
@@ -8468,12 +8757,6 @@ fn load_inventory_state_cache(path: &PathBuf) -> InventoryStateCache {
         .unwrap_or_default()
 }
 
-fn load_recipes_cache(path: &PathBuf) -> HashMap<String, Vec<RecipeComponent>> {
-    std::fs::read_to_string(path).ok()
-        .and_then(|s| serde_json::from_str(&s).ok())
-        .unwrap_or_default()
-}
-
 fn save_window_state(window: &tauri::WebviewWindow, settings_path: &std::path::Path, prefix: &str) {
     let maximized = window.is_maximized().unwrap_or(false);
     let minimized = window.is_minimized().unwrap_or(false);
@@ -8573,26 +8856,24 @@ fn restore_window_state(app: &tauri::AppHandle, window: &tauri::WebviewWindow, s
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    let data_dir = dirs::data_local_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join("warframe-companion");
+    // Everything below used to sit in a single directory; carry the files that
+    // cannot be refetched over to the split layout before anything opens them.
+    paths::migrate_legacy();
+    let cache_dir = paths::cache_dir();
+    let data_dir = paths::data_dir();
+    let state_dir = paths::state_dir();
 
-    std::fs::create_dir_all(&data_dir).expect("Failed to create data directory");
     // ── BEGIN ocrs fallback ─────────────────────────────────────────────────
-    ocr_fallback::set_data_dir(data_dir.clone());
+    ocr_fallback::set_data_dir(cache_dir.clone());
     // ── END ocrs fallback ───────────────────────────────────────────────────
 
     let db_path = data_dir.join("data.db");
-    let items_cache_path = data_dir.join("items_cache.json");
-    let recipes_cache_path = data_dir.join("recipes_cache.json");
-    let relic_drops_cache_path = data_dir.join("relic_drops_cache.json");
-    let relic_rewards_cache_path = data_dir.join("relic_rewards_cache.json");
-    let quantities_cache_path = data_dir.join("quantities_cache.json");
-    let inventory_state_cache_path = data_dir.join("inventory_state_cache.json");
-    let settings_path = data_dir.join("settings.json");
-    let log_path = data_dir.join("scan_log.txt");
-    let changes_log_path = data_dir.join("inventory_changes.txt");
-    let debug_root = data_dir.join("Debugging");
+    let quantities_cache_path = cache_dir.join("quantities_cache.json");
+    let inventory_state_cache_path = cache_dir.join("inventory_state_cache.json");
+    let settings_path = paths::config_dir().join("settings.json");
+    let log_path = state_dir.join("scan_log.txt");
+    let changes_log_path = state_dir.join("inventory_changes.txt");
+    let debug_root = state_dir.join("Debugging");
     let blob_log_dir = debug_root.join("Inventory Snapshots");
     let api_log_dir = debug_root.join("Api Responses");
     let auto_capture_dir = debug_root.join("Auto-Capture");
@@ -8606,83 +8887,60 @@ pub fn run() {
                  &memory_probe_dir, &raw_scan_dir, &unmatched_paths_dir] {
         let _ = std::fs::create_dir_all(dir);
     }
-    let wfm_top_cache_path = data_dir.join("wfm_top_cache.json");
-    let syndicate_catalog_path = data_dir.join("syndicate_catalog.json");
-    let img_cache_dir = data_dir.join("img_cache");
+    let img_cache_dir = cache_dir.join("img_cache");
     let _ = std::fs::create_dir_all(&img_cache_dir);
     let auction_ids_path = data_dir.join("auction_ids.json");
     let initial_auction_ids: Vec<String> = std::fs::read_to_string(&auction_ids_path)
         .ok().and_then(|s| serde_json::from_str(&s).ok()).unwrap_or_default();
-    let relics_run_prices_cache_path = data_dir.join("relics_run_prices.json");
-    let initial_relics_run = load_relics_run_cache(&relics_run_prices_cache_path);
-    let initial_relics_run_prices = initial_relics_run.as_ref()
-        .map(|(by_name, _)| by_name.clone())
+    // Serve whatever prices were last written, however old; the background
+    // refresh below replaces them once the window is up.
+    let initial_relics_run = cache::load::<BulkPrices>(BULK_PRICES_CACHE)
+        .map(|c| c.data)
         .unwrap_or_default();
+    let initial_relics_run_prices = initial_relics_run.by_name;
     let initial_wfm_prices: HashMap<String, Option<u32>> = initial_relics_run
-        .map(|(_, by_slug)| by_slug.into_iter().map(|(k, v)| (k, Some(v))).collect())
-        .unwrap_or_default();
+        .by_slug
+        .into_iter()
+        .map(|(k, v)| (k, Some(v)))
+        .collect();
 
     let conn = db::init_db(&db_path).expect("Failed to initialize database");
 
-    // ── Version-based cache invalidation ──────────────────────────────────────
-    // On first launch after an upgrade, wipe item/recipe caches so bundled
-    // corrections and updated data sources take effect without manual clearing.
-    {
-        const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
-        let last_version = read_settings_map(&settings_path)
-            .ok()
-            .and_then(|m| m.get("lastVersion").and_then(|v| v.as_str().map(String::from)));
-        if last_version.as_deref() != Some(CURRENT_VERSION) {
-            // inventory_state_cache intentionally excluded — it holds mastery/shards/forma
-            // that can only be restored by a live scan; wiping it on upgrade loses that data.
-            for path in &[
-                &items_cache_path, &recipes_cache_path,
-                &relic_drops_cache_path, &relic_rewards_cache_path,
-            ] {
-                let _ = std::fs::remove_file(path);
-            }
-            let _ = merge_settings(&settings_path, |map| {
-                map.insert("lastVersion".to_string(), serde_json::Value::String(CURRENT_VERSION.to_string()));
-            });
-        }
-    }
-
-    let initial_items = load_items_cache(&items_cache_path)
-        .unwrap_or_else(wfcd::fallback_items);
+    // Serve the last catalogue written, however old; the frontend revalidates
+    // it in the background once the window is up. `fallback_items` is the floor
+    // for a first launch with no network.
+    let cached_catalogue = cache::load::<wfcd::FetchResult>(CATALOGUE_CACHE).map(|c| c.data);
+    let (
+        initial_items,
+        initial_recipes,
+        initial_relic_drops,
+        initial_relic_rewards,
+        initial_blueprint_names,
+        initial_wiki_reward_names,
+        initial_syndicate_catalog,
+    ) = match cached_catalogue {
+        Some(c) => (
+            patch_catalogue_items(c.items),
+            c.recipes,
+            c.relic_drops,
+            c.relic_rewards,
+            c.blueprint_names,
+            c.wiki_reward_names,
+            c.syndicate_catalog,
+        ),
+        None => (
+            wfcd::fallback_items(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            std::collections::HashSet::new(),
+            HashMap::new(),
+        ),
+    };
     let initial_weapon_dispositions: HashMap<String, f32> = initial_items.iter()
         .filter_map(|i| i.omega_attenuation.map(|d| (i.unique_name.clone(), d)))
         .collect();
-    let initial_recipes = load_recipes_cache(&recipes_cache_path);
-    let initial_relic_drops: HashMap<String, Vec<String>> = std::fs::read_to_string(&relic_drops_cache_path)
-        .ok().and_then(|s| serde_json::from_str(&s).ok()).unwrap_or_default();
-    // Load relic rewards cache. Two invalidation conditions:
-    // 1. Format: must contain at least one EE.log path key ("/Lotus/...") — old caches only
-    //    had display-name keys and would cause the OCR prefilter to always miss.
-    // 2. Age: discard after 24 hours so new relics added with game updates are picked up.
-    let initial_relic_rewards: HashMap<String, Vec<wfcd::RelicReward>> = {
-        let cache_age_ok = std::fs::metadata(&relic_rewards_cache_path)
-            .and_then(|m| m.modified())
-            .map(|t| t.elapsed().unwrap_or(std::time::Duration::MAX) < std::time::Duration::from_secs(86_400))
-            .unwrap_or(false);
-        let loaded: Option<HashMap<String, Vec<wfcd::RelicReward>>> = if cache_age_ok {
-            std::fs::read_to_string(&relic_rewards_cache_path)
-                .ok().and_then(|s| serde_json::from_str(&s).ok())
-        } else {
-            None
-        };
-        match loaded {
-            Some(map) if map.keys().any(|k| k.starts_with("/Lotus/")) => map,
-            Some(_) => {
-                info!("relic_rewards cache is old format (no path keys) — discarding, will regenerate");
-                let _ = std::fs::remove_file(&relic_rewards_cache_path);
-                HashMap::new()
-            }
-            None => {
-                let _ = std::fs::remove_file(&relic_rewards_cache_path);
-                HashMap::new()
-            }
-        }
-    };
     // Load unified inventory state cache. All data lives in items: unique_name → CachedItem.
     let initial_state = load_inventory_state_cache(&inventory_state_cache_path);
     // Stackable resources: non-mod, non-unique paths.
@@ -8724,10 +8982,7 @@ pub fn run() {
             (k.clone(), mc)
         })
         .collect();
-    let initial_syndicate_catalog: HashMap<String, Vec<SyndicateOffer>> = std::fs::read_to_string(&syndicate_catalog_path)
-        .ok().and_then(|s| serde_json::from_str(&s).ok()).unwrap_or_default();
-
-    let corrections = load_corrections(&data_dir.join("corrections.json"));
+    let corrections = load_corrections(&paths::config_dir().join("corrections.json"));
 
     tauri::Builder::default()
         .register_uri_scheme_protocol("ffauth", |ctx, req| console_login::handle_ffauth(ctx.app_handle(), &req)) // [console-login feature]
@@ -8735,10 +8990,6 @@ pub fn run() {
         .plugin(tauri_plugin_notification::init())
         .manage(AppState {
             db_path,
-            items_cache_path,
-            recipes_cache_path,
-            relic_drops_cache_path,
-            relic_rewards_cache_path,
             quantities_cache_path,
             inventory_state_cache_path,
             settings_path,
@@ -8749,8 +9000,8 @@ pub fn run() {
             recipes: Mutex::new(initial_recipes),
             relic_drops: Mutex::new(initial_relic_drops),
             relic_rewards: Mutex::new(initial_relic_rewards),
-            blueprint_to_result: Mutex::new(HashMap::new()),
-            wiki_reward_names: Mutex::new(std::collections::HashSet::new()),
+            blueprint_to_result: Mutex::new(initial_blueprint_names),
+            wiki_reward_names: Mutex::new(initial_wiki_reward_names),
             weapon_dispositions: Mutex::new(initial_weapon_dispositions),
             current_quantities: Arc::new(Mutex::new(initial_quantities)),
             unique_quantities: Arc::new(Mutex::new(initial_unique)),
@@ -8776,9 +9027,7 @@ pub fn run() {
             wfm_price_queue: Arc::new(Mutex::new(std::collections::VecDeque::new())),
             wfm_priority_queue: Arc::new(Mutex::new(std::collections::VecDeque::new())),
             wfm_queue_started: Arc::new(AtomicBool::new(false)),
-            wfm_top_cache_path,
             syndicate_catalog: Mutex::new(initial_syndicate_catalog),
-            syndicate_catalog_path,
             auction_ids: Mutex::new(initial_auction_ids),
             auction_ids_path,
             img_cache_dir,
@@ -8786,7 +9035,6 @@ pub fn run() {
             local_player_name: Arc::new(Mutex::new(None)),
             pending_relic_rewards: Mutex::new(None),
             relics_run_prices: Mutex::new(initial_relics_run_prices),
-            relics_run_prices_cache_path,
             worldstate_cache: Mutex::new(None),
             debug_cat_enabled: Arc::new(AtomicBool::new(false)),
             auto_capture_dir,
@@ -8856,36 +9104,10 @@ pub fn run() {
                 ));
             }
 
-            // Load relics.run prices in the background. On a cache hit (today's file exists)
-            // this is just a disk read; on a miss it fetches items.json + price_history.
-            {
-                let app_handle = app.handle().clone();
-                tauri::async_runtime::spawn(async move {
-                    let state = app_handle.state::<AppState>();
-                    let (by_name, by_slug) = match load_relics_run_cache(&state.relics_run_prices_cache_path) {
-                        Some(cached) => cached,
-                        None => {
-                            let data = tauri::async_runtime::spawn_blocking(fetch_relics_run_data)
-                                .await.unwrap_or_default();
-                            if !data.0.is_empty() {
-                                let today = chrono::Local::now().format("%Y-%m-%d").to_string();
-                                let j = serde_json::json!({ "date": today, "by_name": &data.0, "by_slug": &data.1 });
-                                if let Ok(s) = serde_json::to_string(&j) {
-                                    let _ = std::fs::write(&state.relics_run_prices_cache_path, s);
-                                }
-                            }
-                            data
-                        }
-                    };
-                    if by_name.is_empty() { return; }
-                    *state.relics_run_prices.lock().unwrap_or_else(|e| e.into_inner()) = by_name;
-                    for (slug, price) in by_slug {
-                        if !state.wfm.is_price_cached(&slug) {
-                            state.wfm.cache_price(slug, Some(price));
-                        }
-                    }
-                });
-            }
+            // Every cache is revalidated from here on: the first tick, five
+            // seconds in, walks the whole table, and a cache still inside its
+            // TTL costs a disk read.
+            refresh::spawn(app.handle().clone());
 
             Ok(())
         })
@@ -8922,6 +9144,7 @@ pub fn run() {
             get_recipes_bulk,
             get_relic_drops,
             get_relic_rewards,
+            wfcd::get_drop_data,
             fetch_wfm_items,
             fetch_wfm_price,
             start_wfm_queue,
@@ -8931,6 +9154,8 @@ pub fn run() {
             get_wfm_top_items,
             get_item_price,
             refresh_bulk_prices,
+            refresh_all_caches,
+            get_cache_statuses,
             wfm_set_status,
             start_log_watcher,
             ocr_riven_log_error,
@@ -9339,3 +9564,17 @@ MR 11
     }
 }
 
+#[cfg(test)]
+mod image_validation_tests {
+    use super::looks_like_image;
+
+    #[test]
+    fn a_truncated_download_is_not_an_image() {
+        assert!(looks_like_image(b"\x89PNG\r\n\x1a\n\0\0\0\rIHDR"));
+        assert!(looks_like_image(b"RIFF\0\0\0\0WEBPVP8 "));
+        assert!(!looks_like_image(b""));
+        assert!(!looks_like_image(b"<!DOCTYPE html>"));
+        // A WEBP header that stops before the format tag.
+        assert!(!looks_like_image(b"RIFF\0\0\0\0"));
+    }
+}

--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -123,11 +123,20 @@ fn migrate_into(old: &Path, config: &Path, data: &Path, cache: &Path) {
     info!("migrating from {}", old.display());
 
     move_file(&old.join("settings.json"), &config.join("settings.json"));
-    move_file(&old.join("corrections.json"), &config.join("corrections.json"));
-    move_file(&old.join("auction_ids.json"), &data.join("auction_ids.json"));
+    move_file(
+        &old.join("corrections.json"),
+        &config.join("corrections.json"),
+    );
+    move_file(
+        &old.join("auction_ids.json"),
+        &data.join("auction_ids.json"),
+    );
     // Named like caches and stored with them, but only a live game scan can
     // produce them again, so they travel rather than get dropped.
-    move_file(&old.join("quantities_cache.json"), &cache.join("quantities_cache.json"));
+    move_file(
+        &old.join("quantities_cache.json"),
+        &cache.join("quantities_cache.json"),
+    );
     move_file(
         &old.join("inventory_state_cache.json"),
         &cache.join("inventory_state_cache.json"),
@@ -214,7 +223,9 @@ mod tests {
     use super::*;
 
     fn scratch(name: &str) -> PathBuf {
-        let dir = std::env::temp_dir().join("frameforge-paths-tests").join(name);
+        let dir = std::env::temp_dir()
+            .join("frameforge-paths-tests")
+            .join(name);
         let _ = fs::remove_dir_all(&dir);
         fs::create_dir_all(dir.join("old")).unwrap();
         fs::create_dir_all(dir.join("config")).unwrap();
@@ -230,8 +241,12 @@ mod tests {
     #[test]
     fn moves_user_state_and_drops_caches() {
         let dir = scratch("moves");
-        let (old, config, data, cache) =
-            (dir.join("old"), dir.join("config"), dir.join("data"), dir.join("cache"));
+        let (old, config, data, cache) = (
+            dir.join("old"),
+            dir.join("config"),
+            dir.join("data"),
+            dir.join("cache"),
+        );
         write(old.join("settings.json"), "{}");
         write(old.join("auction_ids.json"), "[]");
         write(old.join("corrections.json"), "[]");
@@ -244,13 +259,28 @@ mod tests {
 
         migrate_into(&old, &config, &data, &cache);
 
-        assert_eq!(fs::read_to_string(config.join("settings.json")).unwrap(), "{}");
-        assert_eq!(fs::read_to_string(data.join("auction_ids.json")).unwrap(), "[]");
+        assert_eq!(
+            fs::read_to_string(config.join("settings.json")).unwrap(),
+            "{}"
+        );
+        assert_eq!(
+            fs::read_to_string(data.join("auction_ids.json")).unwrap(),
+            "[]"
+        );
         assert_eq!(fs::read_to_string(data.join("data.db")).unwrap(), "db");
         assert_eq!(fs::read_to_string(data.join("data.db-wal")).unwrap(), "wal");
-        assert_eq!(fs::read_to_string(config.join("corrections.json")).unwrap(), "[]");
-        assert_eq!(fs::read_to_string(cache.join("inventory_state_cache.json")).unwrap(), "inv");
-        assert_eq!(fs::read_to_string(cache.join("quantities_cache.json")).unwrap(), "qty");
+        assert_eq!(
+            fs::read_to_string(config.join("corrections.json")).unwrap(),
+            "[]"
+        );
+        assert_eq!(
+            fs::read_to_string(cache.join("inventory_state_cache.json")).unwrap(),
+            "inv"
+        );
+        assert_eq!(
+            fs::read_to_string(cache.join("quantities_cache.json")).unwrap(),
+            "qty"
+        );
         assert!(!old.join("items_cache.json").exists());
         assert!(!old.join("img_cache").exists());
         assert!(!old.exists(), "emptied old directory should be gone");
@@ -259,8 +289,12 @@ mod tests {
     #[test]
     fn never_overwrites_the_destination() {
         let dir = scratch("no-overwrite");
-        let (old, config, data, cache) =
-            (dir.join("old"), dir.join("config"), dir.join("data"), dir.join("cache"));
+        let (old, config, data, cache) = (
+            dir.join("old"),
+            dir.join("config"),
+            dir.join("data"),
+            dir.join("cache"),
+        );
         write(old.join("settings.json"), "old");
         write(config.join("settings.json"), "new");
         write(old.join("data.db"), "old-db");
@@ -268,16 +302,26 @@ mod tests {
 
         migrate_into(&old, &config, &data, &cache);
 
-        assert_eq!(fs::read_to_string(config.join("settings.json")).unwrap(), "new");
+        assert_eq!(
+            fs::read_to_string(config.join("settings.json")).unwrap(),
+            "new"
+        );
         assert_eq!(fs::read_to_string(data.join("data.db")).unwrap(), "new-db");
-        assert_eq!(fs::read_to_string(old.join("settings.json")).unwrap(), "old");
+        assert_eq!(
+            fs::read_to_string(old.join("settings.json")).unwrap(),
+            "old"
+        );
     }
 
     #[test]
     fn keeps_the_old_directory_when_something_is_left_in_it() {
         let dir = scratch("leftovers");
-        let (old, config, data, cache) =
-            (dir.join("old"), dir.join("config"), dir.join("data"), dir.join("cache"));
+        let (old, config, data, cache) = (
+            dir.join("old"),
+            dir.join("config"),
+            dir.join("data"),
+            dir.join("cache"),
+        );
         write(old.join("settings.json"), "{}");
         write(old.join("scan_log.txt"), "log");
 
@@ -291,20 +335,32 @@ mod tests {
     fn does_nothing_without_an_old_directory() {
         let dir = scratch("absent");
         fs::remove_dir_all(dir.join("old")).unwrap();
-        migrate_into(&dir.join("old"), &dir.join("config"), &dir.join("data"), &dir.join("cache"));
+        migrate_into(
+            &dir.join("old"),
+            &dir.join("config"),
+            &dir.join("data"),
+            &dir.join("cache"),
+        );
         assert!(!dir.join("config").join("settings.json").exists());
     }
 
     #[test]
     fn a_second_run_changes_nothing() {
         let dir = scratch("idempotent");
-        let (old, config, data, cache) =
-            (dir.join("old"), dir.join("config"), dir.join("data"), dir.join("cache"));
+        let (old, config, data, cache) = (
+            dir.join("old"),
+            dir.join("config"),
+            dir.join("data"),
+            dir.join("cache"),
+        );
         write(old.join("settings.json"), "{}");
 
         migrate_into(&old, &config, &data, &cache);
         migrate_into(&old, &config, &data, &cache);
 
-        assert_eq!(fs::read_to_string(config.join("settings.json")).unwrap(), "{}");
+        assert_eq!(
+            fs::read_to_string(config.join("settings.json")).unwrap(),
+            "{}"
+        );
     }
 }

--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -1,0 +1,293 @@
+//! Where FrameForge keeps its files.
+//!
+//! Everything used to live in one directory next to the database. The four
+//! functions below split it along the XDG roles instead: throwaway downloads in
+//! the cache root, the user's settings in the config root, the database and the
+//! auction IDs in the data root, and logs and debug dumps in the state root.
+//! `migrate_legacy` carries the irreplaceable files over from the old layout.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use tracing::{info, warn};
+
+const APP_DIR: &str = "frameforge";
+
+/// Layout used before the XDG split, still on disk for anyone upgrading.
+const LEGACY_DIR: &str = "warframe-companion";
+
+/// When set, all four roots become subdirectories of this path. Tests use it to
+/// keep off the real user directories.
+static ROOT_OVERRIDE: OnceLock<PathBuf> = OnceLock::new();
+
+/// Fails if a root has already been chosen, which is why tests share one.
+#[cfg(test)]
+pub fn set_root_override(root: PathBuf) -> Result<(), PathBuf> {
+    ROOT_OVERRIDE.set(root)
+}
+
+/// Downloaded catalogues, price snapshots, item images, OCR models: anything
+/// that can be fetched again.
+pub fn cache_dir() -> PathBuf {
+    ensure(match ROOT_OVERRIDE.get() {
+        Some(root) => root.join("cache"),
+        None => base(dirs::cache_dir()),
+    })
+}
+
+/// settings.json.
+pub fn config_dir() -> PathBuf {
+    ensure(match ROOT_OVERRIDE.get() {
+        Some(root) => root.join("config"),
+        None => base(dirs::config_dir()),
+    })
+}
+
+/// data.db and the WFM auction IDs: user state that no refetch can rebuild.
+pub fn data_dir() -> PathBuf {
+    ensure(match ROOT_OVERRIDE.get() {
+        Some(root) => root.join("data"),
+        None => base(dirs::data_dir()),
+    })
+}
+
+/// Logs, session transcripts, screenshot dumps.
+pub fn state_dir() -> PathBuf {
+    ensure(match ROOT_OVERRIDE.get() {
+        Some(root) => root.join("state"),
+        // Only Linux defines a state directory; elsewhere this material sits
+        // with the rest of the app data.
+        None => base(dirs::state_dir().or_else(dirs::data_dir)),
+    })
+}
+
+fn base(dir: Option<PathBuf>) -> PathBuf {
+    dir.unwrap_or_else(|| PathBuf::from(".")).join(APP_DIR)
+}
+
+fn ensure(dir: PathBuf) -> PathBuf {
+    if let Err(e) = fs::create_dir_all(&dir) {
+        warn!("cannot create {}: {e}", dir.display());
+    }
+    dir
+}
+
+fn legacy_root() -> PathBuf {
+    match ROOT_OVERRIDE.get() {
+        Some(root) => root.join("legacy"),
+        None => dirs::data_local_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(LEGACY_DIR),
+    }
+}
+
+/// Caches the old layout kept beside the user's real files. These caches are
+/// deleted rather than moved. Each one refills itself on the next fetch.
+const LEGACY_CACHE_FILES: &[&str] = &[
+    "items_cache.json",
+    "recipes_cache.json",
+    "relic_drops_cache.json",
+    "relic_rewards_cache.json",
+    "wfm_top_cache.json",
+    "syndicate_catalog.json",
+    "relics_run_prices.json",
+];
+
+const LEGACY_CACHE_DIRS: &[&str] = &["img_cache", "ocr_models"];
+
+/// Move the irreplaceable files out of the pre-XDG directory, then clear what is
+/// left of its caches. Doing nothing when the old directory is gone makes this
+/// safe to call on every launch, so no marker file records that it ran.
+pub fn migrate_legacy() {
+    migrate_into(&legacy_root(), &config_dir(), &data_dir(), &cache_dir());
+}
+
+fn migrate_into(old: &Path, config: &Path, data: &Path, cache: &Path) {
+    if !old.is_dir() {
+        return;
+    }
+    info!("migrating from {}", old.display());
+
+    move_file(&old.join("settings.json"), &config.join("settings.json"));
+    move_file(&old.join("corrections.json"), &config.join("corrections.json"));
+    move_file(&old.join("auction_ids.json"), &data.join("auction_ids.json"));
+    // Named like caches and stored with them, but only a live game scan can
+    // produce them again, so they travel rather than get dropped.
+    move_file(&old.join("quantities_cache.json"), &cache.join("quantities_cache.json"));
+    move_file(
+        &old.join("inventory_state_cache.json"),
+        &cache.join("inventory_state_cache.json"),
+    );
+    move_db(old, data);
+
+    for name in LEGACY_CACHE_FILES {
+        let _ = fs::remove_file(old.join(name));
+    }
+    for name in LEGACY_CACHE_DIRS {
+        let _ = fs::remove_dir_all(old.join(name));
+    }
+    // Anything unrecognised still in there keeps the old directory alive; the
+    // user can look at what is left and delete it themselves.
+    let _ = fs::remove_dir(old);
+}
+
+/// SQLite's write-ahead log and shared-memory files only make sense next to the
+/// database they belong to, so either all three arrive or none do.
+fn move_db(old: &Path, data: &Path) {
+    let db = old.join("data.db");
+    if !db.exists() || data.join("data.db").exists() {
+        return;
+    }
+    if !move_file(&db, &data.join("data.db")) {
+        return;
+    }
+    for suffix in ["data.db-wal", "data.db-shm"] {
+        let src = old.join(suffix);
+        if !src.exists() {
+            continue;
+        }
+        if !move_file(&src, &data.join(suffix)) {
+            warn!("rolling the database back to {}", old.display());
+            let _ = move_file(&data.join("data.db"), &db);
+            for done in ["data.db-wal", "data.db-shm"] {
+                let _ = move_file(&data.join(done), &old.join(done));
+            }
+            return;
+        }
+    }
+}
+
+/// Returns whether `dst` now holds the file. An existing destination is left
+/// untouched and reported as success: the new location wins, and the stale
+/// copy stays where it is for the user to inspect.
+fn move_file(src: &Path, dst: &Path) -> bool {
+    if !src.exists() {
+        return false;
+    }
+    if dst.exists() {
+        warn!("{} already exists, keeping it", dst.display());
+        return true;
+    }
+    match fs::rename(src, dst) {
+        Ok(()) => true,
+        // A rename across filesystems fails, which is the normal case when the
+        // XDG roots are on different mounts.
+        Err(_) => match copy_then_delete(src, dst) {
+            Ok(()) => true,
+            Err(e) => {
+                warn!("cannot move {} to {}: {e}", src.display(), dst.display());
+                false
+            }
+        },
+    }
+}
+
+fn copy_then_delete(src: &Path, dst: &Path) -> io::Result<()> {
+    fs::copy(src, dst)?;
+    // The delete below makes the copy the only remaining version, so it has to
+    // be on the platter before then.
+    fs::File::open(dst)?.sync_all()?;
+    fs::remove_file(src)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join("frameforge-paths-tests").join(name);
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(dir.join("old")).unwrap();
+        fs::create_dir_all(dir.join("config")).unwrap();
+        fs::create_dir_all(dir.join("data")).unwrap();
+        fs::create_dir_all(dir.join("cache")).unwrap();
+        dir
+    }
+
+    fn write(path: PathBuf, body: &str) {
+        fs::write(path, body).unwrap();
+    }
+
+    #[test]
+    fn moves_user_state_and_drops_caches() {
+        let dir = scratch("moves");
+        let (old, config, data, cache) =
+            (dir.join("old"), dir.join("config"), dir.join("data"), dir.join("cache"));
+        write(old.join("settings.json"), "{}");
+        write(old.join("auction_ids.json"), "[]");
+        write(old.join("corrections.json"), "[]");
+        write(old.join("inventory_state_cache.json"), "inv");
+        write(old.join("quantities_cache.json"), "qty");
+        write(old.join("data.db"), "db");
+        write(old.join("data.db-wal"), "wal");
+        write(old.join("items_cache.json"), "[]");
+        fs::create_dir_all(old.join("img_cache")).unwrap();
+
+        migrate_into(&old, &config, &data, &cache);
+
+        assert_eq!(fs::read_to_string(config.join("settings.json")).unwrap(), "{}");
+        assert_eq!(fs::read_to_string(data.join("auction_ids.json")).unwrap(), "[]");
+        assert_eq!(fs::read_to_string(data.join("data.db")).unwrap(), "db");
+        assert_eq!(fs::read_to_string(data.join("data.db-wal")).unwrap(), "wal");
+        assert_eq!(fs::read_to_string(config.join("corrections.json")).unwrap(), "[]");
+        assert_eq!(fs::read_to_string(cache.join("inventory_state_cache.json")).unwrap(), "inv");
+        assert_eq!(fs::read_to_string(cache.join("quantities_cache.json")).unwrap(), "qty");
+        assert!(!old.join("items_cache.json").exists());
+        assert!(!old.join("img_cache").exists());
+        assert!(!old.exists(), "emptied old directory should be gone");
+    }
+
+    #[test]
+    fn never_overwrites_the_destination() {
+        let dir = scratch("no-overwrite");
+        let (old, config, data, cache) =
+            (dir.join("old"), dir.join("config"), dir.join("data"), dir.join("cache"));
+        write(old.join("settings.json"), "old");
+        write(config.join("settings.json"), "new");
+        write(old.join("data.db"), "old-db");
+        write(data.join("data.db"), "new-db");
+
+        migrate_into(&old, &config, &data, &cache);
+
+        assert_eq!(fs::read_to_string(config.join("settings.json")).unwrap(), "new");
+        assert_eq!(fs::read_to_string(data.join("data.db")).unwrap(), "new-db");
+        assert_eq!(fs::read_to_string(old.join("settings.json")).unwrap(), "old");
+    }
+
+    #[test]
+    fn keeps_the_old_directory_when_something_is_left_in_it() {
+        let dir = scratch("leftovers");
+        let (old, config, data, cache) =
+            (dir.join("old"), dir.join("config"), dir.join("data"), dir.join("cache"));
+        write(old.join("settings.json"), "{}");
+        write(old.join("scan_log.txt"), "log");
+
+        migrate_into(&old, &config, &data, &cache);
+
+        assert!(old.join("scan_log.txt").exists());
+        assert!(old.exists());
+    }
+
+    #[test]
+    fn does_nothing_without_an_old_directory() {
+        let dir = scratch("absent");
+        fs::remove_dir_all(dir.join("old")).unwrap();
+        migrate_into(&dir.join("old"), &dir.join("config"), &dir.join("data"), &dir.join("cache"));
+        assert!(!dir.join("config").join("settings.json").exists());
+    }
+
+    #[test]
+    fn a_second_run_changes_nothing() {
+        let dir = scratch("idempotent");
+        let (old, config, data, cache) =
+            (dir.join("old"), dir.join("config"), dir.join("data"), dir.join("cache"));
+        write(old.join("settings.json"), "{}");
+
+        migrate_into(&old, &config, &data, &cache);
+        migrate_into(&old, &config, &data, &cache);
+
+        assert_eq!(fs::read_to_string(config.join("settings.json")).unwrap(), "{}");
+    }
+}

--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -31,10 +31,22 @@ pub fn set_root_override(root: PathBuf) -> Result<(), PathBuf> {
 /// Downloaded catalogues, price snapshots, item images, OCR models: anything
 /// that can be fetched again.
 pub fn cache_dir() -> PathBuf {
-    ensure(match ROOT_OVERRIDE.get() {
+    let dir = ensure(match ROOT_OVERRIDE.get() {
         Some(root) => root.join("cache"),
         None => base(dirs::cache_dir()),
-    })
+    });
+    // Tells backup and sync tools to skip the directory
+    // (https://bford.info/cachedir/).
+    let tag = dir.join("CACHEDIR.TAG");
+    if !tag.exists() {
+        let _ = fs::write(
+            &tag,
+            "Signature: 8a477f597d28d172789f06886806bc55\n\
+             # This file is a cache directory tag created by FrameForge.\n\
+             # For information about cache directory tags see https://bford.info/cachedir/\n",
+        );
+    }
+    dir
 }
 
 /// settings.json.

--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -199,8 +199,13 @@ fn move_file(src: &Path, dst: &Path) -> bool {
 fn copy_then_delete(src: &Path, dst: &Path) -> io::Result<()> {
     fs::copy(src, dst)?;
     // The delete below makes the copy the only remaining version, so it has to
-    // be on the platter before then.
+    // be on the platter before then, directory entry included: a power loss
+    // right after the unlink would lose the file despite its synced contents.
     fs::File::open(dst)?.sync_all()?;
+    #[cfg(unix)]
+    if let Some(dir) = dst.parent() {
+        fs::File::open(dir)?.sync_all()?;
+    }
     fs::remove_file(src)
 }
 

--- a/src-tauri/src/refresh.rs
+++ b/src-tauri/src/refresh.rs
@@ -1,0 +1,103 @@
+//! Background refresh loop.
+//!
+//! One thread ticks every five seconds over a fixed table of tasks, each with
+//! its own interval. A task that fails climbs a backoff ladder instead of
+//! retrying on its normal schedule. An outage then costs a handful of requests
+//! rather than one per interval. A success drops the task back to the ladder's foot.
+//!
+//! Every task is a cache-ladder call, so a run whose data is still fresh is a
+//! disk read and nothing more.
+
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use tauri::{AppHandle, Emitter};
+use tracing::warn;
+
+use crate::cache;
+
+/// Seconds to wait after the 1st, 2nd, 3rd and any later consecutive failure.
+const BACKOFF: [u64; 4] = [5, 30, 120, 300];
+
+const TICK: Duration = Duration::from_secs(5);
+
+/// How long to wait after `failures` consecutive failures, the last rung
+/// repeating for as long as the outage lasts.
+fn backoff_delay(failures: usize) -> Duration {
+    Duration::from_secs(BACKOFF[failures.min(BACKOFF.len() - 1)])
+}
+
+struct Task {
+    name: &'static str,
+    interval: Duration,
+    run: fn(&AppHandle, bool) -> Result<(), String>,
+}
+
+const TASKS: &[Task] = &[
+    // Just under the 60s frontend poll, so a window's own tick is served from
+    // the cache this fills rather than from the network.
+    Task { name: "worldstate", interval: Duration::from_secs(55), run: crate::refresh_worldstate },
+    Task { name: "bulk-prices", interval: Duration::from_secs(3600), run: crate::refresh_bulk_prices_task },
+    Task { name: "catalogue", interval: Duration::from_secs(24 * 3600), run: crate::refresh_catalogue },
+    Task { name: "drop-data", interval: Duration::from_secs(24 * 3600), run: crate::wfcd::refresh_drop_data },
+    Task { name: "riven-db", interval: Duration::from_secs(24 * 3600), run: crate::refresh_riven_db_task },
+    Task { name: "wfm-top", interval: Duration::from_secs(3 * 3600), run: crate::refresh_wfm_top },
+];
+
+/// Set by the manual refresh; consumed by the next tick, which then runs every
+/// task at once and tells each one to ignore its ETag.
+static FORCE_ALL: AtomicBool = AtomicBool::new(false);
+
+pub fn force_all() {
+    FORCE_ALL.store(true, Ordering::SeqCst);
+}
+
+pub fn spawn(app: AppHandle) {
+    std::thread::spawn(move || {
+        let mut due: Vec<Instant> = TASKS.iter().map(|_| Instant::now()).collect();
+        let mut failures: Vec<usize> = TASKS.iter().map(|_| 0).collect();
+
+        loop {
+            std::thread::sleep(TICK);
+            let force = FORCE_ALL.swap(false, Ordering::SeqCst);
+
+            for (i, task) in TASKS.iter().enumerate() {
+                if !force && Instant::now() < due[i] {
+                    continue;
+                }
+
+                // A panic in one fetcher must not take the whole loop, and
+                // with it every other refresh, down with it.
+                let result = catch_unwind(AssertUnwindSafe(|| (task.run)(&app, force)))
+                    .unwrap_or_else(|_| Err(format!("{} refresh panicked", task.name)));
+
+                match result {
+                    Ok(()) => {
+                        failures[i] = 0;
+                        due[i] = Instant::now() + task.interval;
+                    }
+                    Err(e) => {
+                        warn!(task = task.name, error = %e, "refresh failed");
+                        due[i] = Instant::now() + backoff_delay(failures[i]);
+                        failures[i] = failures[i].saturating_add(1);
+                    }
+                }
+
+                let _ = app.emit("cache-status", cache::statuses());
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_ladder_climbs_once_and_then_holds() {
+        assert_eq!(backoff_delay(0), Duration::from_secs(5));
+        assert_eq!(backoff_delay(3), Duration::from_secs(300));
+        assert_eq!(backoff_delay(99), Duration::from_secs(300));
+    }
+}

--- a/src-tauri/src/refresh.rs
+++ b/src-tauri/src/refresh.rs
@@ -37,12 +37,36 @@ struct Task {
 const TASKS: &[Task] = &[
     // Just under the 60s frontend poll, so a window's own tick is served from
     // the cache this fills rather than from the network.
-    Task { name: "worldstate", interval: Duration::from_secs(55), run: crate::refresh_worldstate },
-    Task { name: "bulk-prices", interval: Duration::from_secs(3600), run: crate::refresh_bulk_prices_task },
-    Task { name: "catalogue", interval: Duration::from_secs(24 * 3600), run: crate::refresh_catalogue },
-    Task { name: "drop-data", interval: Duration::from_secs(24 * 3600), run: crate::wfcd::refresh_drop_data },
-    Task { name: "riven-db", interval: Duration::from_secs(24 * 3600), run: crate::refresh_riven_db_task },
-    Task { name: "wfm-top", interval: Duration::from_secs(3 * 3600), run: crate::refresh_wfm_top },
+    Task {
+        name: "worldstate",
+        interval: Duration::from_secs(55),
+        run: crate::refresh_worldstate,
+    },
+    Task {
+        name: "bulk-prices",
+        interval: Duration::from_secs(3600),
+        run: crate::refresh_bulk_prices_task,
+    },
+    Task {
+        name: "catalogue",
+        interval: Duration::from_secs(24 * 3600),
+        run: crate::refresh_catalogue,
+    },
+    Task {
+        name: "drop-data",
+        interval: Duration::from_secs(24 * 3600),
+        run: crate::wfcd::refresh_drop_data,
+    },
+    Task {
+        name: "riven-db",
+        interval: Duration::from_secs(24 * 3600),
+        run: crate::refresh_riven_db_task,
+    },
+    Task {
+        name: "wfm-top",
+        interval: Duration::from_secs(3 * 3600),
+        run: crate::refresh_wfm_top,
+    },
 ];
 
 /// Set by the manual refresh; consumed by the next tick, which then runs every

--- a/src-tauri/src/wfcd.rs
+++ b/src-tauri/src/wfcd.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::sync::Mutex;
-use tracing::warn;
 use std::io::{Cursor, Read};
+use std::sync::Mutex;
+use tracing::{info, warn};
 
 use crate::cache::{self, Fetched};
 
@@ -298,17 +298,26 @@ enum Probe {
 }
 
 /// Ask about one source, taking the first mirror that answers with usable JSON.
+#[tracing::instrument(level = "debug", skip_all, fields(source = %spec.name, answer, bytes))]
 fn probe_source(spec: &SourceSpec, etag: Option<&str>, force: bool, fetch: &FetchFn<'_>) -> Probe {
+    let span = tracing::Span::current();
     let sent = if force { None } else { etag };
     let mut last = format!("{} unavailable", spec.name);
     for url in &spec.urls {
         match fetch(url, sent) {
-            Ok(Fetched::NotModified) => return Probe::Unchanged,
+            Ok(Fetched::NotModified) => {
+                span.record("answer", "unchanged");
+                return Probe::Unchanged;
+            }
             // Validated but not kept: a mirror that answers with something
             // unparseable should fall through to the next one, and the tree is
             // only wanted once, in `resolve_source`.
             Ok(Fetched::New(body, new_etag)) => match serde_json::from_str::<serde::de::IgnoredAny>(&body) {
-                Ok(_) => return Probe::Body(body, new_etag),
+                Ok(_) => {
+                    span.record("answer", "body");
+                    span.record("bytes", body.len());
+                    return Probe::Body(body, new_etag);
+                }
                 Err(e) => {
                     warn!("{url}: {e}");
                     last = e.to_string();
@@ -320,6 +329,7 @@ fn probe_source(spec: &SourceSpec, etag: Option<&str>, force: bool, fetch: &Fetc
             }
         }
     }
+    span.record("answer", "failed");
     Probe::Failed(last)
 }
 
@@ -331,6 +341,7 @@ struct Resolved {
 
 /// Turn a probe into a body, reaching for the stored copy where the server did
 /// not supply one.
+#[tracing::instrument(level = "debug", skip_all, fields(source = %spec.name, origin))]
 fn resolve_source(
     spec: &SourceSpec,
     etag: Option<&str>,
@@ -338,31 +349,45 @@ fn resolve_source(
     fetch: &FetchFn<'_>,
     store: &dyn BodyStore,
 ) -> Resolved {
+    let span = tracing::Span::current();
     let kept = || etag.map(str::to_string);
     match probe {
         Probe::Body(body, new_etag) => {
+            span.record("origin", "network");
             store.write(&spec.name, &body);
             Resolved { json: serde_json::from_str(&body).ok(), etag: new_etag }
         }
         Probe::Unchanged => match store.read(&spec.name).and_then(|b| serde_json::from_str(&b).ok())
         {
-            Some(json) => Resolved { json: Some(json), etag: kept() },
+            Some(json) => {
+                span.record("origin", "store");
+                Resolved { json: Some(json), etag: kept() }
+            }
             // The ETag outlived the body it described. Ask again without it.
             None => match probe_source(spec, None, true, fetch) {
                 Probe::Body(body, new_etag) => {
+                    span.record("origin", "refetched");
+                    warn!("{}: the stored body was gone; fetched it again", spec.name);
                     store.write(&spec.name, &body);
                     Resolved { json: serde_json::from_str(&body).ok(), etag: new_etag }
                 }
-                _ => Resolved { json: None, etag: None },
+                _ => {
+                    span.record("origin", "missing");
+                    Resolved { json: None, etag: None }
+                }
             },
         },
         Probe::Failed(e) => {
             match store.read(&spec.name).and_then(|b| serde_json::from_str(&b).ok()) {
                 Some(json) => {
+                    span.record("origin", "stale");
                     warn!("{}: {e}, building from the stored copy", spec.name);
                     Resolved { json: Some(json), etag: kept() }
                 }
-                None => Resolved { json: None, etag: None },
+                None => {
+                    span.record("origin", "missing");
+                    Resolved { json: None, etag: None }
+                }
             }
         }
     }
@@ -372,6 +397,7 @@ fn resolve_source(
 ///
 /// The bodies are megabytes each over one connection apiece, so this is waiting
 /// on the network rather than on a CPU.
+#[tracing::instrument(level = "debug", skip_all, fields(sources = specs.len(), force))]
 fn probe_all(specs: &[SourceSpec], etags: &BTreeMap<String, String>, force: bool, fetch: &FetchFn<'_>) -> Vec<Probe> {
     let next = std::sync::atomic::AtomicUsize::new(0);
     let out: Mutex<Vec<(usize, Probe)>> = Mutex::new(Vec::with_capacity(specs.len()));
@@ -401,6 +427,7 @@ pub fn fetch_items(prev_etags: Option<&str>, force: bool) -> Result<Fetched<Fetc
     fetch_items_with(prev_etags, force, &|url, etag| cache::get_conditional(url, etag), &DiskStore)
 }
 
+#[tracing::instrument(level = "info", skip_all, fields(force))]
 fn fetch_items_with(
     prev_etags: Option<&str>,
     force: bool,
@@ -412,7 +439,16 @@ fn fetch_items_with(
     let specs = source_specs();
 
     let probes = probe_all(&specs, &prev, force, fetch);
-    if probes.iter().all(|p| matches!(p, Probe::Unchanged)) {
+    let unchanged = probes.iter().filter(|p| matches!(p, Probe::Unchanged)).count();
+    let failed = probes.iter().filter(|p| matches!(p, Probe::Failed(_))).count();
+    info!(
+        sources = specs.len(),
+        unchanged,
+        downloaded = specs.len() - unchanged - failed,
+        failed,
+        "catalogue sources probed"
+    );
+    if unchanged == probes.len() {
         return Ok(Fetched::NotModified);
     }
 
@@ -452,7 +488,16 @@ fn fetch_items_with(
     let recipes_json = bodies.get("ExportRecipes");
     let syndicates_json = bodies.get("syndicates");
 
+    info!(raw_items = all_items.len(), "catalogue sources assembled");
     let result = fetch_from_wfcd(&all_items, recipes_json, syndicates_json, relics_json)?;
+    info!(
+        items = result.items.len(),
+        recipes = result.recipes.len(),
+        relic_rewards = result.relic_rewards.len(),
+        syndicates = result.syndicate_catalog.len(),
+        dispositions = result.weapon_dispositions.len(),
+        "catalogue rebuilt"
+    );
 
     Ok(Fetched::New(result, serde_json::to_string(&etags).ok()))
 }

--- a/src-tauri/src/wfcd.rs
+++ b/src-tauri/src/wfcd.rs
@@ -2,7 +2,9 @@ use std::collections::{HashMap, HashSet};
 use tracing::warn;
 use std::io::{Cursor, Read};
 
-#[derive(Clone, Debug)]
+use crate::cache::{self, Fetched};
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct WfcdItem {
     pub name: String,
     pub unique_name: String,
@@ -60,6 +62,7 @@ pub struct SyndicateOffer {
     pub result_unique: Option<String>,
 }
 
+#[derive(serde::Serialize, serde::Deserialize)]
 pub struct FetchResult {
     pub items: Vec<WfcdItem>,
     /// parent unique_name → list of components needed to craft it
@@ -172,8 +175,114 @@ fn fetch_wiki_reward_names() -> HashSet<String> {
     names
 }
 
-pub fn fetch_items() -> Result<FetchResult, String> {
-    fetch_from_wfcd()
+/// The upstream files the catalogue is built from. Each is a static file behind
+/// a CDN that answers conditional requests, so an unchanged catalogue costs four
+/// empty responses instead of tens of megabytes.
+const ALL_URL: &str =
+    "https://raw.githubusercontent.com/WFCD/warframe-items/master/data/json/All.json";
+const RECIPES_URLS: [&str; 2] = [
+    "https://raw.githubusercontent.com/calamity-inc/warframe-public-export-plus/master/ExportRecipes.json",
+    "https://raw.githubusercontent.com/calamity-inc/warframe-public-export-plus/HEAD/ExportRecipes.json",
+];
+const SYNDICATES_URL: &str =
+    "https://raw.githubusercontent.com/WFCD/warframe-drop-data/gh-pages/data/syndicates.json";
+const RELICS_URL: &str =
+    "https://raw.githubusercontent.com/WFCD/warframe-items/master/data/json/Relics.json";
+
+/// The four upstream ETags, packed into the single tag the cache stores per entry.
+#[derive(Default, serde::Serialize, serde::Deserialize)]
+struct SourceEtags {
+    all: Option<String>,
+    recipes: Option<String>,
+    syndicates: Option<String>,
+    relics: Option<String>,
+}
+
+struct Source {
+    /// Absent when the server confirmed the copy already held, and when the
+    /// fetch failed outright. `unchanged` tells the two apart.
+    json: Option<serde_json::Value>,
+    etag: Option<String>,
+    unchanged: bool,
+}
+
+/// Conditional GET across `urls`, taking the first that answers.
+fn fetch_source(urls: &[&str], etag: Option<&str>) -> Source {
+    for url in urls {
+        match cache::get_conditional(url, etag) {
+            Ok(Fetched::NotModified) => {
+                return Source { json: None, etag: etag.map(str::to_string), unchanged: true }
+            }
+            Ok(Fetched::New(body, new_etag)) => match serde_json::from_str(&body) {
+                Ok(json) => return Source { json: Some(json), etag: new_etag, unchanged: false },
+                Err(e) => warn!("{url}: {e}"),
+            },
+            Err(e) => warn!("{url}: {e}"),
+        }
+    }
+    Source { json: None, etag: None, unchanged: false }
+}
+
+/// Rebuild the catalogue unless every source says nothing has moved.
+///
+/// `prev_etags` is what the last successful build stored; `force` asks for the
+/// bodies regardless of it, and still uses it to tell an outage apart from a
+/// source that was never there. Only All.json is mandatory on a first build.
+/// The other three degrade to their empty defaults, so a syndicate or relic
+/// outage does not cost a new user the item list.
+pub fn fetch_items(prev_etags: Option<&str>, force: bool) -> Result<Fetched<FetchResult>, String> {
+    let prev: SourceEtags =
+        prev_etags.and_then(|s| serde_json::from_str(s).ok()).unwrap_or_default();
+    fn sent(etag: &Option<String>, force: bool) -> Option<&str> {
+        if force { None } else { etag.as_deref() }
+    }
+
+    let mut sources = [
+        (&[ALL_URL][..], fetch_source(&[ALL_URL], sent(&prev.all, force))),
+        (&RECIPES_URLS[..], fetch_source(&RECIPES_URLS, sent(&prev.recipes, force))),
+        (&[SYNDICATES_URL][..], fetch_source(&[SYNDICATES_URL], sent(&prev.syndicates, force))),
+        (&[RELICS_URL][..], fetch_source(&[RELICS_URL], sent(&prev.relics, force))),
+    ];
+
+    if sources.iter().all(|(_, s)| s.unchanged) {
+        return Ok(Fetched::NotModified);
+    }
+
+    // One file moving means the whole catalogue is rebuilt, and a body skipped
+    // as unchanged is still needed to do that.
+    for (urls, source) in sources.iter_mut() {
+        if source.unchanged {
+            *source = fetch_source(urls, None);
+        }
+    }
+
+    // A source that answered on the last build and cannot be reached now would
+    // rebuild the catalogue without its recipes or relic rewards, and that
+    // hollowed-out payload would then be cached over the good one for a day.
+    // Failing instead leaves the ladder to serve the previous copy.
+    let had = [prev.all, prev.recipes, prev.syndicates, prev.relics];
+    for ((urls, source), before) in sources.iter().zip(&had) {
+        if source.json.is_none() && before.is_some() {
+            return Err(format!("{} unavailable", urls[0]));
+        }
+    }
+
+    let [(_, all), (_, recipes), (_, syndicates), (_, relics)] = sources;
+    let all_json = all.json.ok_or_else(|| "All.json unavailable".to_string())?;
+    let result = fetch_from_wfcd(
+        &all_json,
+        recipes.json.as_ref(),
+        syndicates.json.as_ref(),
+        relics.json.as_ref(),
+    )?;
+
+    let etags = SourceEtags {
+        all: all.etag,
+        recipes: recipes.etag,
+        syndicates: syndicates.etag,
+        relics: relics.etag,
+    };
+    Ok(Fetched::New(result, serde_json::to_string(&etags).ok()))
 }
 
 fn strip_tags(s: &str) -> &str {
@@ -218,25 +327,14 @@ struct ExportRecipe {
     result_count: u32,
 }
 
-/// Fetch ExportRecipes from warframe-public-export-plus (stable URL, pre-processed, always current).
-/// Returns a map from resultType (= what gets crafted) → ExportRecipe.
+/// Read DE's recipe export, keyed by resultType (= what gets crafted).
 #[tracing::instrument(level = "debug", skip_all)]
-fn fetch_export_recipes() -> Result<HashMap<String, ExportRecipe>, String> {
-    // Try two URLs: the warframe-public-export-plus repo (pre-processed) and a fallback
-    let urls = [
-        "https://raw.githubusercontent.com/calamity-inc/warframe-public-export-plus/master/ExportRecipes.json",
-        "https://raw.githubusercontent.com/calamity-inc/warframe-public-export-plus/HEAD/ExportRecipes.json",
-    ];
-    let url = urls[0]; // primary
-
-    let json: serde_json::Value = ureq::get(url)
-        .set("User-Agent", "FrameForge/3.1.0")
-        .call()
-        .map_err(|e| format!("ExportRecipes fetch: {}", e))?
-        .into_json()
-        .map_err(|e| format!("ExportRecipes parse: {}", e))?;
-
+fn parse_export_recipes(json: Option<&serde_json::Value>) -> HashMap<String, ExportRecipe> {
     let mut map: HashMap<String, ExportRecipe> = HashMap::new();
+    let json = match json {
+        Some(j) => j,
+        None => return map,
+    };
 
     // warframe-public-export-plus format:
     //   { "/Lotus/Types/Recipes/...Blueprint": { "resultType": "...", "num": 1, "ingredients": [...] } }
@@ -266,26 +364,21 @@ fn fetch_export_recipes() -> Result<HashMap<String, ExportRecipe>, String> {
             }
         }
     }
-    Ok(map)
+    map
 }
 
-/// Fetch complete syndicate store catalog from warframe-drop-data/syndicates.json.
+/// Read the syndicate store catalog from warframe-drop-data/syndicates.json.
 /// This covers all vendor-purchased items: sigils, specters, health restores,
 /// weapon blueprints, augment mods — items that WFCD's `drops` field mostly omits.
 #[tracing::instrument(level = "debug", skip_all)]
-fn fetch_syndicate_store_catalog(items: &[WfcdItem]) -> HashMap<String, Vec<SyndicateOffer>> {
-    const URL: &str =
-        "https://raw.githubusercontent.com/WFCD/warframe-drop-data/gh-pages/data/syndicates.json";
-
-    let json: serde_json::Value = match ureq::get(URL)
-        .set("User-Agent", "FrameForge/3.1.0")
-        .call()
-        .ok()
-        .and_then(|r| r.into_json().ok())
-    {
+fn parse_syndicate_store_catalog(
+    json: Option<&serde_json::Value>,
+    items: &[WfcdItem],
+) -> HashMap<String, Vec<SyndicateOffer>> {
+    let json = match json {
         Some(v) => v,
         None => {
-            warn!("failed to fetch syndicates.json");
+            warn!("no syndicates.json available");
             return HashMap::new();
         }
     };
@@ -552,21 +645,18 @@ fn wfcd_category_to_display(wfcd_cat: &str) -> &'static str {
     }
 }
 
-/// Fetch relic → reward mappings from WFCD Relics.json.
+/// Read relic → reward mappings from WFCD Relics.json.
 /// Each entry is one specific refinement (Bronze/Silver/Gold/Platinum) with a
 /// uniqueName that matches the EE.log path exactly — no normalization needed.
 #[tracing::instrument(level = "debug", skip_all)]
-fn fetch_relics_rewards(image_by_name: &HashMap<String, String>) -> HashMap<String, Vec<RelicReward>> {
-    const URL: &str =
-        "https://raw.githubusercontent.com/WFCD/warframe-items/master/data/json/Relics.json";
-
-    let json: serde_json::Value = match ureq::get(URL)
-        .set("User-Agent", "FrameForge/3.1.0")
-        .call().ok().and_then(|r| r.into_json().ok())
-    {
+fn parse_relics_rewards(
+    json: Option<&serde_json::Value>,
+    image_by_name: &HashMap<String, String>,
+) -> HashMap<String, Vec<RelicReward>> {
+    let json = match json {
         Some(v) => v,
         None => {
-            warn!("failed to fetch Relics.json");
+            warn!("no Relics.json available");
             return HashMap::new();
         }
     };
@@ -628,7 +718,12 @@ fn fetch_relics_rewards(image_by_name: &HashMap<String, String>) -> HashMap<Stri
 }
 
 #[tracing::instrument(level = "debug", skip_all)]
-fn fetch_from_wfcd() -> Result<FetchResult, String> {
+fn fetch_from_wfcd(
+    all_json: &serde_json::Value,
+    recipes_json: Option<&serde_json::Value>,
+    syndicates_json: Option<&serde_json::Value>,
+    relics_json: Option<&serde_json::Value>,
+) -> Result<FetchResult, String> {
     let mut items: Vec<WfcdItem> = Vec::new();
     let mut seen: HashSet<String> = HashSet::new();
     let mut raw_craftable: Vec<(String, serde_json::Value)> = Vec::new();
@@ -636,16 +731,6 @@ fn fetch_from_wfcd() -> Result<FetchResult, String> {
     // Built by inverting each item's drops[] array (All.json stores item→relics).
     // WFCD canonicalizes all refinements under the Bronze path — dedup at build time.
     let mut raw_drop_entries: HashMap<String, Vec<(String, String, String)>> = HashMap::new();
-
-    // Single All.json request replaces 20 sequential per-category fetches.
-    let all_json: serde_json::Value = ureq::get(
-        "https://raw.githubusercontent.com/WFCD/warframe-items/master/data/json/All.json"
-    )
-    .set("User-Agent", "FrameForge/3.1.0")
-    .call()
-    .map_err(|e| format!("All.json fetch: {}", e))?
-    .into_json()
-    .map_err(|e| format!("All.json parse: {}", e))?;
 
     let all_items_raw = all_json.as_array()
         .ok_or_else(|| "All.json: expected top-level array".to_string())?;
@@ -880,16 +965,15 @@ fn fetch_from_wfcd() -> Result<FetchResult, String> {
         .map(|i| (i.unique_name.clone(), i.name.clone()))
         .collect();
 
-    // Fetch DE's authoritative recipe data (best-effort; fall back to WFCD-only if it fails)
-    let export_recipes = fetch_export_recipes().unwrap_or_default();
+    // DE's authoritative recipe data (best-effort; fall back to WFCD-only if absent)
+    let export_recipes = parse_export_recipes(recipes_json);
 
     // Reverse map: blueprint unique_name → result item unique_name
     let bp_to_result: HashMap<String, String> = export_recipes.iter()
         .map(|(result, recipe)| (recipe.blueprint_unique.clone(), result.clone()))
         .collect();
 
-    // Fetch complete syndicate store catalog from warframe-drop-data (sigils, specters, etc.)
-    let mut syndicate_catalog = fetch_syndicate_store_catalog(&items);
+    let mut syndicate_catalog = parse_syndicate_store_catalog(syndicates_json, &items);
 
     // Fill result_unique on blueprint offers so the frontend can show crafted-item status
     for offers in syndicate_catalog.values_mut() {
@@ -1137,7 +1221,7 @@ fn fetch_from_wfcd() -> Result<FetchResult, String> {
 
     // Build relic_rewards from Relics.json — each entry is one specific refinement
     // (Bronze/Silver/Gold/Platinum) with its own uniqueName matching EE.log paths exactly.
-    let relic_rewards = fetch_relics_rewards(&image_by_name);
+    let relic_rewards = parse_relics_rewards(relics_json, &image_by_name);
 
     // Build blueprint_names: blueprint_path → (display_name, ducats)
     // Lets the frontend create virtual catalog entries for component blueprints that
@@ -1234,4 +1318,44 @@ pub fn fallback_items() -> Vec<WfcdItem> {
         image_name: None, vaulted: None, ducats: None, mastery_req: None, omega_attenuation: None, fusion_limit: None, max_level_cap: None,
     })
     .collect()
+}
+
+const DROP_DATA_URL: &str =
+    "https://raw.githubusercontent.com/WFCD/warframe-drop-data/gh-pages/data/all.json";
+const DROP_DATA_CACHE: &str = "drop-data-v1.json";
+const DROP_DATA_TTL: std::time::Duration = std::time::Duration::from_secs(24 * 60 * 60);
+
+/// Serve the drop tables off the cache ladder. `force` both ignores the cached
+/// copy's age and drops its ETag, so the server has to send the body back.
+fn load_drop_data(force: bool) -> (Option<serde_json::Value>, Option<String>) {
+    let ttl = if force { std::time::Duration::ZERO } else { DROP_DATA_TTL };
+    let (data, _, warning) = cache::get_or_refresh(DROP_DATA_CACHE, ttl, |etag| {
+        let etag = if force { None } else { etag };
+        match cache::get_conditional(DROP_DATA_URL, etag)? {
+            Fetched::New(body, etag) => serde_json::from_str(&body)
+                .map(|v| Fetched::New(v, etag))
+                .map_err(|e| e.to_string()),
+            Fetched::NotModified => Ok(Fetched::NotModified),
+        }
+    });
+    (data, warning)
+}
+
+/// The WFCD drop tables, verbatim. The relic view picks what it needs out of the
+/// payload, so parsing it here would only mean maintaining the same shape twice.
+#[tauri::command]
+pub async fn get_drop_data(force: Option<bool>) -> Result<serde_json::Value, String> {
+    let force = force.unwrap_or(false);
+    let (data, warning) = tauri::async_runtime::spawn_blocking(move || load_drop_data(force))
+        .await
+        .map_err(|e| e.to_string())?;
+
+    data.ok_or_else(|| warning.unwrap_or_else(|| "drop data unavailable".into()))
+}
+
+pub fn refresh_drop_data(_app: &tauri::AppHandle, force: bool) -> Result<(), String> {
+    match load_drop_data(force) {
+        (Some(_), None) => Ok(()),
+        (_, warning) => Err(warning.unwrap_or_else(|| "drop data unavailable".into())),
+    }
 }

--- a/src-tauri/src/wfcd.rs
+++ b/src-tauri/src/wfcd.rs
@@ -1,4 +1,5 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::Mutex;
 use tracing::warn;
 use std::io::{Cursor, Read};
 
@@ -175,113 +176,284 @@ fn fetch_wiki_reward_names() -> HashSet<String> {
     names
 }
 
-/// The upstream files the catalogue is built from. Each is a static file behind
-/// a CDN that answers conditional requests, so an unchanged catalogue costs four
-/// empty responses instead of tens of megabytes.
-const ALL_URL: &str =
-    "https://raw.githubusercontent.com/WFCD/warframe-items/master/data/json/All.json";
+// ==============================================================================
+// Upstream sources
+// ==============================================================================
+
+/// warframe-items stopped publishing the combined `All.json` once it outgrew
+/// what the repository would carry, so the catalogue is rebuilt from the
+/// per-category files that file used to be a concatenation of.
+///
+/// `Enemy`, `Node` and `Quests` are deliberately left out: nothing in them can
+/// be owned, and node entries are discarded downstream in any case.
+const CATEGORY_BASE: &str = "https://raw.githubusercontent.com/WFCD/warframe-items/master/data/json/";
+const CATEGORIES: [&str; 21] = [
+    "Arcanes",
+    "Arch-Gun",
+    "Arch-Melee",
+    "Archwing",
+    "Fish",
+    "Gear",
+    "Glyphs",
+    "Melee",
+    "Misc",
+    "Mods",
+    "Pets",
+    "Primary",
+    "Railjack",
+    "Relics",
+    "Resources",
+    "Secondary",
+    "Sentinels",
+    "SentinelWeapons",
+    "Sigils",
+    "Skins",
+    "Warframes",
+];
 const RECIPES_URLS: [&str; 2] = [
     "https://raw.githubusercontent.com/calamity-inc/warframe-public-export-plus/master/ExportRecipes.json",
     "https://raw.githubusercontent.com/calamity-inc/warframe-public-export-plus/HEAD/ExportRecipes.json",
 ];
 const SYNDICATES_URL: &str =
     "https://raw.githubusercontent.com/WFCD/warframe-drop-data/gh-pages/data/syndicates.json";
-const RELICS_URL: &str =
-    "https://raw.githubusercontent.com/WFCD/warframe-items/master/data/json/Relics.json";
 
-/// The four upstream ETags, packed into the single tag the cache stores per entry.
-#[derive(Default, serde::Serialize, serde::Deserialize)]
-struct SourceEtags {
-    all: Option<String>,
-    recipes: Option<String>,
-    syndicates: Option<String>,
-    relics: Option<String>,
+/// One upstream file, and what its absence costs.
+struct SourceSpec {
+    /// Names both the stored body and the stored ETag.
+    name: String,
+    /// Mirrors, tried in order.
+    urls: Vec<String>,
+    /// A category the catalogue cannot be built without. The extras degrade to
+    /// their empty defaults so a syndicate outage does not cost a new user the
+    /// item list.
+    required: bool,
 }
 
-struct Source {
-    /// Absent when the server confirmed the copy already held, and when the
-    /// fetch failed outright. `unchanged` tells the two apart.
-    json: Option<serde_json::Value>,
-    etag: Option<String>,
-    unchanged: bool,
+fn source_specs() -> Vec<SourceSpec> {
+    let mut specs: Vec<SourceSpec> = CATEGORIES
+        .iter()
+        .map(|name| SourceSpec {
+            name: (*name).to_string(),
+            urls: vec![format!("{CATEGORY_BASE}{name}.json")],
+            required: true,
+        })
+        .collect();
+    specs.push(SourceSpec {
+        name: "ExportRecipes".to_string(),
+        urls: RECIPES_URLS.iter().map(|u| u.to_string()).collect(),
+        required: false,
+    });
+    specs.push(SourceSpec {
+        name: "syndicates".to_string(),
+        urls: vec![SYNDICATES_URL.to_string()],
+        required: false,
+    });
+    specs
 }
 
-/// Conditional GET across `urls`, taking the first that answers.
-fn fetch_source(urls: &[&str], etag: Option<&str>) -> Source {
-    for url in urls {
-        match cache::get_conditional(url, etag) {
-            Ok(Fetched::NotModified) => {
-                return Source { json: None, etag: etag.map(str::to_string), unchanged: true }
-            }
-            Ok(Fetched::New(body, new_etag)) => match serde_json::from_str(&body) {
-                Ok(json) => return Source { json: Some(json), etag: new_etag, unchanged: false },
-                Err(e) => warn!("{url}: {e}"),
-            },
-            Err(e) => warn!("{url}: {e}"),
+/// Where the raw upstream bodies live between builds.
+///
+/// Keeping them means an upstream commit to one file re-downloads that file
+/// rather than all twenty-three.
+trait BodyStore: Sync {
+    fn read(&self, name: &str) -> Option<String>;
+    fn write(&self, name: &str, body: &str);
+}
+
+struct DiskStore;
+
+impl DiskStore {
+    fn dir() -> std::path::PathBuf {
+        let dir = crate::paths::cache_dir().join("catalogue");
+        let _ = std::fs::create_dir_all(&dir);
+        dir
+    }
+}
+
+impl BodyStore for DiskStore {
+    fn read(&self, name: &str) -> Option<String> {
+        std::fs::read_to_string(Self::dir().join(format!("{name}.json"))).ok()
+    }
+
+    fn write(&self, name: &str, body: &str) {
+        let path = Self::dir().join(format!("{name}.json"));
+        if let Err(e) = cache::atomic_write(&path, body.as_bytes()) {
+            warn!("cannot store {name}: {e}");
         }
     }
-    Source { json: None, etag: None, unchanged: false }
+}
+
+/// A conditional GET, injected so the resolution table below can be tested
+/// without a network.
+type FetchFn<'a> = dyn Fn(&str, Option<&str>) -> Result<Fetched<String>, String> + Sync + 'a;
+
+/// What the server said when asked about one source.
+enum Probe {
+    Unchanged,
+    /// The body as it arrived, kept unparsed so it reaches the store byte for
+    /// byte and is only turned into a tree once.
+    Body(String, Option<String>),
+    /// Every mirror failed, or answered with something that would not parse.
+    Failed(String),
+}
+
+/// Ask about one source, taking the first mirror that answers with usable JSON.
+fn probe_source(spec: &SourceSpec, etag: Option<&str>, force: bool, fetch: &FetchFn<'_>) -> Probe {
+    let sent = if force { None } else { etag };
+    let mut last = format!("{} unavailable", spec.name);
+    for url in &spec.urls {
+        match fetch(url, sent) {
+            Ok(Fetched::NotModified) => return Probe::Unchanged,
+            // Validated but not kept: a mirror that answers with something
+            // unparseable should fall through to the next one, and the tree is
+            // only wanted once, in `resolve_source`.
+            Ok(Fetched::New(body, new_etag)) => match serde_json::from_str::<serde::de::IgnoredAny>(&body) {
+                Ok(_) => return Probe::Body(body, new_etag),
+                Err(e) => {
+                    warn!("{url}: {e}");
+                    last = e.to_string();
+                }
+            },
+            Err(e) => {
+                warn!("{url}: {e}");
+                last = e;
+            }
+        }
+    }
+    Probe::Failed(last)
+}
+
+/// One source's contribution to this build.
+struct Resolved {
+    json: Option<serde_json::Value>,
+    etag: Option<String>,
+}
+
+/// Turn a probe into a body, reaching for the stored copy where the server did
+/// not supply one.
+fn resolve_source(
+    spec: &SourceSpec,
+    etag: Option<&str>,
+    probe: Probe,
+    fetch: &FetchFn<'_>,
+    store: &dyn BodyStore,
+) -> Resolved {
+    let kept = || etag.map(str::to_string);
+    match probe {
+        Probe::Body(body, new_etag) => {
+            store.write(&spec.name, &body);
+            Resolved { json: serde_json::from_str(&body).ok(), etag: new_etag }
+        }
+        Probe::Unchanged => match store.read(&spec.name).and_then(|b| serde_json::from_str(&b).ok())
+        {
+            Some(json) => Resolved { json: Some(json), etag: kept() },
+            // The ETag outlived the body it described. Ask again without it.
+            None => match probe_source(spec, None, true, fetch) {
+                Probe::Body(body, new_etag) => {
+                    store.write(&spec.name, &body);
+                    Resolved { json: serde_json::from_str(&body).ok(), etag: new_etag }
+                }
+                _ => Resolved { json: None, etag: None },
+            },
+        },
+        Probe::Failed(e) => {
+            match store.read(&spec.name).and_then(|b| serde_json::from_str(&b).ok()) {
+                Some(json) => {
+                    warn!("{}: {e}, building from the stored copy", spec.name);
+                    Resolved { json: Some(json), etag: kept() }
+                }
+                None => Resolved { json: None, etag: None },
+            }
+        }
+    }
+}
+
+/// Probe every source, four at a time.
+///
+/// The bodies are megabytes each over one connection apiece, so this is waiting
+/// on the network rather than on a CPU.
+fn probe_all(specs: &[SourceSpec], etags: &BTreeMap<String, String>, force: bool, fetch: &FetchFn<'_>) -> Vec<Probe> {
+    let next = std::sync::atomic::AtomicUsize::new(0);
+    let out: Mutex<Vec<(usize, Probe)>> = Mutex::new(Vec::with_capacity(specs.len()));
+
+    std::thread::scope(|scope| {
+        for _ in 0..4.min(specs.len()) {
+            scope.spawn(|| loop {
+                let i = next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                let Some(spec) = specs.get(i) else { return };
+                let probe = probe_source(spec, etags.get(&spec.name).map(String::as_str), force, fetch);
+                out.lock().unwrap_or_else(|e| e.into_inner()).push((i, probe));
+            });
+        }
+    });
+
+    let mut probes = out.into_inner().unwrap_or_else(|e| e.into_inner());
+    probes.sort_by_key(|(i, _)| *i);
+    probes.into_iter().map(|(_, p)| p).collect()
 }
 
 /// Rebuild the catalogue unless every source says nothing has moved.
 ///
 /// `prev_etags` is what the last successful build stored; `force` asks for the
 /// bodies regardless of it, and still uses it to tell an outage apart from a
-/// source that was never there. Only All.json is mandatory on a first build.
-/// The other three degrade to their empty defaults, so a syndicate or relic
-/// outage does not cost a new user the item list.
+/// source that was never there.
 pub fn fetch_items(prev_etags: Option<&str>, force: bool) -> Result<Fetched<FetchResult>, String> {
-    let prev: SourceEtags =
+    fetch_items_with(prev_etags, force, &|url, etag| cache::get_conditional(url, etag), &DiskStore)
+}
+
+fn fetch_items_with(
+    prev_etags: Option<&str>,
+    force: bool,
+    fetch: &FetchFn<'_>,
+    store: &dyn BodyStore,
+) -> Result<Fetched<FetchResult>, String> {
+    let prev: BTreeMap<String, String> =
         prev_etags.and_then(|s| serde_json::from_str(s).ok()).unwrap_or_default();
-    fn sent(etag: &Option<String>, force: bool) -> Option<&str> {
-        if force { None } else { etag.as_deref() }
-    }
+    let specs = source_specs();
 
-    let mut sources = [
-        (&[ALL_URL][..], fetch_source(&[ALL_URL], sent(&prev.all, force))),
-        (&RECIPES_URLS[..], fetch_source(&RECIPES_URLS, sent(&prev.recipes, force))),
-        (&[SYNDICATES_URL][..], fetch_source(&[SYNDICATES_URL], sent(&prev.syndicates, force))),
-        (&[RELICS_URL][..], fetch_source(&[RELICS_URL], sent(&prev.relics, force))),
-    ];
-
-    if sources.iter().all(|(_, s)| s.unchanged) {
+    let probes = probe_all(&specs, &prev, force, fetch);
+    if probes.iter().all(|p| matches!(p, Probe::Unchanged)) {
         return Ok(Fetched::NotModified);
     }
 
-    // One file moving means the whole catalogue is rebuilt, and a body skipped
-    // as unchanged is still needed to do that.
-    for (urls, source) in sources.iter_mut() {
-        if source.unchanged {
-            *source = fetch_source(urls, None);
+    let mut etags: BTreeMap<String, String> = BTreeMap::new();
+    let mut bodies: HashMap<&str, serde_json::Value> = HashMap::with_capacity(specs.len());
+    for (spec, probe) in specs.iter().zip(probes) {
+        let etag = prev.get(&spec.name).map(String::as_str);
+        let resolved = resolve_source(spec, etag, probe, fetch, store);
+        // A source that answered on the last build and cannot be reached now
+        // would rebuild the catalogue without its recipes or relic rewards, and
+        // that hollowed-out payload would then be cached over the good one for a
+        // day. Failing instead leaves the ladder to serve the previous copy.
+        let Some(json) = resolved.json else {
+            if spec.required || etag.is_some() {
+                return Err(format!("{} unavailable", spec.name));
+            }
+            continue;
+        };
+        if let Some(tag) = resolved.etag {
+            etags.insert(spec.name.clone(), tag);
         }
+        bodies.insert(spec.name.as_str(), json);
     }
 
-    // A source that answered on the last build and cannot be reached now would
-    // rebuild the catalogue without its recipes or relic rewards, and that
-    // hollowed-out payload would then be cached over the good one for a day.
-    // Failing instead leaves the ladder to serve the previous copy.
-    let had = [prev.all, prev.recipes, prev.syndicates, prev.relics];
-    for ((urls, source), before) in sources.iter().zip(&had) {
-        if source.json.is_none() && before.is_some() {
-            return Err(format!("{} unavailable", urls[0]));
-        }
+    // The upstream All.json was these same files concatenated, so the catalogue
+    // builder still sees one flat item list. Order within it does not matter:
+    // no uniqueName appears in two files, and the builder regroups by category.
+    let arrays: Vec<&Vec<serde_json::Value>> =
+        CATEGORIES.iter().filter_map(|c| bodies.get(c)?.as_array()).collect();
+    let mut all_items: Vec<&serde_json::Value> =
+        Vec::with_capacity(arrays.iter().map(|a| a.len()).sum());
+    for arr in arrays {
+        all_items.extend(arr.iter());
     }
 
-    let [(_, all), (_, recipes), (_, syndicates), (_, relics)] = sources;
-    let all_json = all.json.ok_or_else(|| "All.json unavailable".to_string())?;
-    let result = fetch_from_wfcd(
-        &all_json,
-        recipes.json.as_ref(),
-        syndicates.json.as_ref(),
-        relics.json.as_ref(),
-    )?;
+    let relics_json = bodies.get("Relics");
+    let recipes_json = bodies.get("ExportRecipes");
+    let syndicates_json = bodies.get("syndicates");
 
-    let etags = SourceEtags {
-        all: all.etag,
-        recipes: recipes.etag,
-        syndicates: syndicates.etag,
-        relics: relics.etag,
-    };
+    let result = fetch_from_wfcd(&all_items, recipes_json, syndicates_json, relics_json)?;
+
     Ok(Fetched::New(result, serde_json::to_string(&etags).ok()))
 }
 
@@ -719,30 +891,27 @@ fn parse_relics_rewards(
 
 #[tracing::instrument(level = "debug", skip_all)]
 fn fetch_from_wfcd(
-    all_json: &serde_json::Value,
+    all_items_raw: &[&serde_json::Value],
     recipes_json: Option<&serde_json::Value>,
     syndicates_json: Option<&serde_json::Value>,
     relics_json: Option<&serde_json::Value>,
 ) -> Result<FetchResult, String> {
     let mut items: Vec<WfcdItem> = Vec::new();
     let mut seen: HashSet<String> = HashSet::new();
-    let mut raw_craftable: Vec<(String, serde_json::Value)> = Vec::new();
+    let mut raw_craftable: Vec<(String, &serde_json::Value)> = Vec::new();
     // relic_path → Vec<(item_unique, item_name, rarity)>
     // Built by inverting each item's drops[] array (All.json stores item→relics).
     // WFCD canonicalizes all refinements under the Bronze path — dedup at build time.
     let mut raw_drop_entries: HashMap<String, Vec<(String, String, String)>> = HashMap::new();
 
-    let all_items_raw = all_json.as_array()
-        .ok_or_else(|| "All.json: expected top-level array".to_string())?;
-
     // Group items by display category to preserve the two-pass structure below.
-    let mut category_map: HashMap<String, Vec<serde_json::Value>> = HashMap::new();
+    let mut category_map: HashMap<String, Vec<&serde_json::Value>> = HashMap::new();
     for item in all_items_raw.iter() {
         let wfcd_cat = item.get("category").and_then(|v| v.as_str()).unwrap_or("");
         let display_cat = wfcd_category_to_display(wfcd_cat).to_string();
-        category_map.entry(display_cat).or_default().push(item.clone());
+        category_map.entry(display_cat).or_default().push(item);
     }
-    let mut all_files: Vec<(String, Vec<serde_json::Value>)> = category_map.into_iter().collect();
+    let mut all_files: Vec<(String, Vec<&serde_json::Value>)> = category_map.into_iter().collect();
     all_files.sort_by(|a, b| a.0.cmp(&b.0));
 
     // Pass 1: record all top-level unique_names before processing components.
@@ -788,16 +957,16 @@ fn fetch_from_wfcd(
             // `category` (display category from wfcd_category_to_display) groups similar WFCD
             // categories together (e.g. "Sentinels"+"SentinelWeapons"+"Pets" → "Companions").
             // `wfcd_item_cat` is the raw WFCD category on the item itself; used to preserve
-            // fine-grained categories like "Emotes", "Ephemera" that would otherwise fall into "Misc".
+            // fine-grained categories that would otherwise fall into "Misc".
             let wfcd_item_cat = item.get("category").and_then(|v| v.as_str()).unwrap_or("");
 
             // Correct category before inserting:
             // • Blueprint items always go to "Blueprints"
-            // • Fine-grained categories (Sigils, Emotes, Ephemera, Skins) → keep as-is
+            // • Fine-grained categories (Sigils, Skins) → keep as-is
             // • Non-relic items that WFCD groups under Relics (segments, etc.) → "Misc"
             let corrected_cat = if name.contains("Blueprint") {
                 "Blueprints".to_string()
-            } else if matches!(wfcd_item_cat, "Sigils" | "Emotes" | "Skins" | "Ephemera") {
+            } else if matches!(wfcd_item_cat, "Sigils" | "Skins") {
                 wfcd_item_cat.to_string()
             } else if category == "Relics" {
                 let n = name.to_lowercase();
@@ -826,7 +995,7 @@ fn fetch_from_wfcd(
 
             if let Some(comps) = item.get("components").and_then(|v| v.as_array()) {
                 if !comps.is_empty() {
-                    raw_craftable.push((unique_name.clone(), item.clone()));
+                    raw_craftable.push((unique_name.clone(), *item));
                 }
             }
 
@@ -957,7 +1126,7 @@ fn fetch_from_wfcd(
     }
 
     if items.is_empty() {
-        return Err("All.json returned no usable items".to_string());
+        return Err("upstream categories held no usable items".to_string());
     }
 
     let display_names: HashMap<String, String> = items
@@ -1357,5 +1526,98 @@ pub fn refresh_drop_data(_app: &tauri::AppHandle, force: bool) -> Result<(), Str
     match load_drop_data(force) {
         (Some(_), None) => Ok(()),
         (_, warning) => Err(warning.unwrap_or_else(|| "drop data unavailable".into())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Default)]
+    struct MemStore(Mutex<HashMap<String, String>>);
+
+    impl MemStore {
+        fn with(name: &str, body: &str) -> Self {
+            let store = Self::default();
+            store.write(name, body);
+            store
+        }
+    }
+
+    impl BodyStore for MemStore {
+        fn read(&self, name: &str) -> Option<String> {
+            self.0.lock().expect("no test panics while holding this").get(name).cloned()
+        }
+
+        fn write(&self, name: &str, body: &str) {
+            self.0
+                .lock()
+                .expect("no test panics while holding this")
+                .insert(name.to_string(), body.to_string());
+        }
+    }
+
+    fn spec() -> SourceSpec {
+        SourceSpec { name: "Mods".into(), urls: vec!["https://example/Mods.json".into()], required: true }
+    }
+
+    fn never(_: &str, _: Option<&str>) -> Result<Fetched<String>, String> {
+        panic!("no request expected")
+    }
+
+    #[test]
+    fn fresh_body_is_used_and_stored() {
+        let store = MemStore::default();
+        let probe = Probe::Body("[1]".to_string(), Some("new".into()));
+        let out = resolve_source(&spec(), Some("old"), probe, &never, &store);
+
+        assert_eq!(out.json, Some(serde_json::json!([1])));
+        assert_eq!(out.etag.as_deref(), Some("new"));
+        assert_eq!(store.read("Mods").as_deref(), Some("[1]"));
+    }
+
+    #[test]
+    fn confirmed_body_comes_back_from_the_store() {
+        let store = MemStore::with("Mods", "[2]");
+        let out = resolve_source(&spec(), Some("old"), Probe::Unchanged, &never, &store);
+
+        assert_eq!(out.json, Some(serde_json::json!([2])));
+        // The tag still describes the body, so the next build can revalidate.
+        assert_eq!(out.etag.as_deref(), Some("old"));
+    }
+
+    #[test]
+    fn confirmation_without_a_stored_body_refetches_unconditionally() {
+        let store = MemStore::default();
+        let sent: Mutex<Vec<Option<String>>> = Mutex::new(Vec::new());
+        let fetch = |_: &str, etag: Option<&str>| {
+            sent.lock().expect("no panic in this closure").push(etag.map(str::to_string));
+            Ok(Fetched::New("[3]".to_string(), Some("fetched".into())))
+        };
+
+        let out = resolve_source(&spec(), Some("old"), Probe::Unchanged, &fetch, &store);
+
+        assert_eq!(out.json, Some(serde_json::json!([3])));
+        assert_eq!(out.etag.as_deref(), Some("fetched"));
+        assert_eq!(sent.into_inner().expect("no panic in this closure"), vec![None]);
+    }
+
+    #[test]
+    fn a_failed_source_falls_back_to_the_stored_body() {
+        let store = MemStore::with("Mods", "[4]");
+        let out =
+            resolve_source(&spec(), Some("old"), Probe::Failed("timed out".into()), &never, &store);
+
+        assert_eq!(out.json, Some(serde_json::json!([4])));
+        assert_eq!(out.etag.as_deref(), Some("old"));
+    }
+
+    #[test]
+    fn a_failed_source_with_nothing_stored_yields_no_body() {
+        let store = MemStore::default();
+        let out = resolve_source(&spec(), None, Probe::Failed("timed out".into()), &never, &store);
+
+        assert!(out.json.is_none());
+        assert!(out.etag.is_none());
     }
 }

--- a/src-tauri/src/wfm.rs
+++ b/src-tauri/src/wfm.rs
@@ -141,8 +141,9 @@ pub struct Wfm {
     limiter: Mutex<RateLimiter>,
     /// Contract limit: ≤10 requests/minute for /v1/auctions/... (rivens, liches, sisters).
     auction_limiter: Mutex<RateLimiter>,
-    /// slug → median sell price (None = not listed). Shared with the prefetch thread.
-    price_cache: Mutex<std::collections::HashMap<String, Option<u32>>>,
+    /// slug → median sell price (None = not listed) and when it was fetched.
+    /// Shared with the prefetch thread.
+    price_cache: Mutex<std::collections::HashMap<String, (Option<u32>, Instant)>>,
     /// Top-items-by-volume result, cached in memory for the session.
     top_cache: Mutex<Option<(Instant, Vec<WfmTopItem>)>>,
     /// Prime-set (name, slug) pairs, fetched once per session.
@@ -1038,20 +1039,26 @@ impl Wfm {
                 };
                 Ok(p.or_else(|| d90.and_then(|arr| trimmed_median_from_stats(arr))))
             }
-            Err(_) => Ok(None),
+            // 404 is warframe.market's answer for a slug it does not know:
+            // a real "unlisted", safe to cache.
+            Err(ureq::Error::Status(404, _)) => Ok(None),
+            // Anything else never got an answer about the item. Collapsing it
+            // into `Ok(None)` would cache "unlisted" for everything looked up
+            // while offline.
+            Err(e) => Err(format!("wfm price {}: {}", slug, e)),
         }
     }
 
     /// Price for a slug, retrying the blueprint-suffix variant — WFM is
     /// inconsistent about whether component blueprints keep the "_blueprint" suffix.
-    pub fn price_with_fallback(&self, slug: &str) -> Option<u32> {
-        self.price_for_slug(slug).unwrap_or(None).or_else(|| {
-            if let Some(stripped) = slug.strip_suffix("_blueprint") {
-                self.price_for_slug(stripped).unwrap_or(None)
-            } else {
-                self.price_for_slug(&format!("{}_blueprint", slug)).unwrap_or(None)
-            }
-        })
+    pub fn price_with_fallback(&self, slug: &str) -> Result<Option<u32>, String> {
+        if let Some(price) = self.price_for_slug(slug)? {
+            return Ok(Some(price));
+        }
+        match slug.strip_suffix("_blueprint") {
+            Some(stripped) => self.price_for_slug(stripped),
+            None => self.price_for_slug(&format!("{}_blueprint", slug)),
+        }
     }
 
     /// 7-day price + average daily volume for a slug, or None if unlisted / stale.
@@ -1125,28 +1132,42 @@ impl Wfm {
 
     // ── Price cache ───────────────────────────────────────────────────────────
 
-    /// The cached price for a slug: `Some(price_opt)` when the slug was fetched
-    /// (`price_opt` distinguishes "listed at N" from "not listed"), `None` when
-    /// it has never been fetched.
+    /// The cached price for a slug: `Some(price_opt)` when the slug has a live
+    /// entry (`price_opt` distinguishes "listed at N" from "not listed"), `None`
+    /// when it has never been fetched or its entry has expired.
     pub fn cached_price(&self, slug: &str) -> Option<Option<u32>> {
-        self.price_cache.lock().unwrap_or_else(|e| e.into_inner()).get(slug).copied()
+        self.price_cache
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(slug)
+            .filter(|(price, at)| price_entry_live(*price, at.elapsed()))
+            .map(|(price, _)| *price)
     }
 
     pub fn is_price_cached(&self, slug: &str) -> bool {
-        self.price_cache.lock().unwrap_or_else(|e| e.into_inner()).contains_key(slug)
+        self.cached_price(slug).is_some()
     }
 
     pub fn cache_price(&self, slug: String, price: Option<u32>) {
-        self.price_cache.lock().unwrap_or_else(|e| e.into_inner()).insert(slug, price);
+        self.price_cache
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(slug, (price, Instant::now()));
     }
 
     pub fn uncache_price(&self, slug: &str) {
         self.price_cache.lock().unwrap_or_else(|e| e.into_inner()).remove(slug);
     }
 
-    /// A clone of the whole slug → price cache.
+    /// A clone of the live entries in the slug → price cache.
     pub fn cached_prices(&self) -> std::collections::HashMap<String, Option<u32>> {
-        self.price_cache.lock().unwrap_or_else(|e| e.into_inner()).clone()
+        self.price_cache
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .iter()
+            .filter(|(_, (price, at))| price_entry_live(*price, at.elapsed()))
+            .map(|(slug, (price, _))| (slug.clone(), *price))
+            .collect()
     }
 
     // ── Top items cache ───────────────────────────────────────────────────────
@@ -1170,6 +1191,23 @@ impl Wfm {
 // ==============================================================================
 // Pure helpers (no session, no network) — the tested core
 // ==============================================================================
+
+/// How long "this slug has no listings" is believed before it is looked up again.
+const NEGATIVE_PRICE_TTL: Duration = Duration::from_secs(3600);
+
+/// How long a known price is served before it is looked up again. Generous,
+/// since prices drift over days rather than minutes, but bounded, so a session
+/// left running overnight does not keep quoting yesterday's plat.
+const POSITIVE_PRICE_TTL: Duration = Duration::from_secs(6 * 3600);
+
+/// Whether a price-cache entry may still be served.
+///
+/// An absent price only describes the order book at the moment of the lookup.
+/// An item listed an hour later would otherwise stay unpriced, so it expires
+/// far sooner than a known price.
+fn price_entry_live(price: Option<u32>, age: Duration) -> bool {
+    age < if price.is_some() { POSITIVE_PRICE_TTL } else { NEGATIVE_PRICE_TTL }
+}
 
 /// Convert a display name to a warframe.market URL slug.
 /// E.g. "Ash Prime Neuroptics Blueprint" → "ash_prime_neuroptics_blueprint"
@@ -1333,5 +1371,30 @@ mod tests {
         assert!(rl.try_acquire().is_none());
         // Fourth within the window must be told to wait.
         assert!(rl.try_acquire().is_some());
+    }
+
+    #[test]
+    fn only_missing_prices_expire() {
+        let old = NEGATIVE_PRICE_TTL + Duration::from_secs(1);
+        assert!(price_entry_live(Some(42), old));
+        assert!(price_entry_live(None, Duration::ZERO));
+        assert!(!price_entry_live(None, old));
+    }
+
+    #[test]
+    fn an_unlisted_slug_is_looked_up_again_after_the_ttl() {
+        let wfm = Wfm::new();
+        wfm.cache_price("ash_prime_set".to_string(), None);
+        assert!(wfm.is_price_cached("ash_prime_set"));
+
+        // Backdate the entry past the TTL rather than waiting an hour for it.
+        wfm.price_cache
+            .lock()
+            .unwrap()
+            .insert("ash_prime_set".to_string(), (None, Instant::now() - NEGATIVE_PRICE_TTL));
+
+        assert!(!wfm.is_price_cached("ash_prime_set"));
+        assert!(wfm.cached_price("ash_prime_set").is_none());
+        assert!(wfm.cached_prices().is_empty());
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,6 +63,7 @@ import TimerHelper, { FissureWatch, fmtMs } from "./TimerHelper";
 import { useWorldState } from "./worldstate";
 import { notify, ensurePermission } from "./notify";
 import { collectNewMatches, type SeenFissures } from "./fissureAlerts";
+import CacheStatusChip from "./CacheStatusChip";
 import Statistics from "./Statistics";
 import Syndicates from "./Syndicates";
 import Weapons from "./Weapons";
@@ -695,18 +696,20 @@ function OverlayTestPage() {
   );
 }
 
-function BulkPriceRefreshButton() {
-  const [state, setState] = useState<'idle' | 'loading' | 'ok' | 'err'>('idle');
-  const label = state === 'loading' ? 'Fetching…' : state === 'ok' ? 'Done!' : state === 'err' ? 'Failed' : 'Refresh Now';
+// Marks every cache due at once; the background scheduler picks the work up on
+// its next tick, so the button reports that it was queued, not that it is done.
+function RefreshAllButton() {
+  const [state, setState] = useState<'idle' | 'loading' | 'err'>('idle');
+  const label = state === 'loading' ? 'Refreshing…' : state === 'err' ? 'Failed' : 'Refresh Now';
   return (
     <button
       className="btn-secondary"
       disabled={state === 'loading'}
-      style={{ minWidth: 100, borderColor: state === 'ok' ? 'var(--accent)' : state === 'err' ? '#e05252' : undefined }}
+      style={{ minWidth: 100, borderColor: state === 'err' ? '#e05252' : undefined }}
       onClick={() => {
         setState('loading');
-        invoke('refresh_bulk_prices')
-          .then(() => { setState('ok'); setTimeout(() => setState('idle'), 3000); })
+        invoke('refresh_all_caches')
+          .then(() => setTimeout(() => setState('idle'), 5000))
           .catch(() => { setState('err'); setTimeout(() => setState('idle'), 4000); });
       }}
     >{label}</button>
@@ -1298,7 +1301,7 @@ if (typeof s.autoDiagEnabled === "boolean") {
       setMonitoring(false);
     }
     try {
-      const count = await invoke<number>("fetch_item_list");
+      const count = await invoke<number>("fetch_item_list", { force: true });
       setItemCount(count);
       const items = await invoke<CatalogItem[]>("get_all_items");
       setCatalog(items);
@@ -1319,9 +1322,22 @@ if (typeof s.autoDiagEnabled === "boolean") {
     }
   };
 
-  // Auto-refresh item database on every app start so the OCR catalog stays current.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => { handleFetch(); }, []);
+  // The catalogue the backend loaded from disk is already on screen; revalidate
+  // it behind the UI so a launch never waits on the network, and leave the
+  // monitor running since the refresh is a no-op while the cache is fresh.
+  useEffect(() => {
+    invoke<number>("fetch_item_list").then(async count => {
+      setItemCount(count);
+      const items = await invoke<CatalogItem[]>("get_all_items");
+      setCatalog(items);
+      catalogRef.current = items;
+      const status = await invoke<{ count: number; recipe_count: number }>("get_item_list_status");
+      setRecipeCount(status.recipe_count);
+      setItemsRefreshKey(k => k + 1);
+      invoke("prewarm_image_cache").catch(() => {});
+    }).catch(e => setFetchMsg(`Error: ${e}`));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // ── Warframe API: process inventory response ──────────────────────────────
 
@@ -2078,6 +2094,7 @@ if (typeof s.autoDiagEnabled === "boolean") {
           </span>
         )}
         <div className="header-right">
+          <CacheStatusChip />
           {/* ── Connection status chips ── */}
           {(() => {
             // Memory chip
@@ -2468,13 +2485,13 @@ if (typeof s.autoDiagEnabled === "boolean") {
                 {/* ════════════ MARKET ════════════ */}
                 {settingsTab === "market" && <>
                   <div className="settings-section">
-                    <div className="settings-section-title">Bulk Prices</div>
+                    <div className="settings-section-title">Cached Data</div>
                     <div className="settings-row">
                       <div className="settings-row-info">
                         <span className="settings-row-label">Force Refresh</span>
-                        <span className="settings-row-desc">Re-download price data from FrameForgePricing right now. Use this if prices look stale or missing.</span>
+                        <span className="settings-row-desc">Re-download prices, the item catalogue, drop tables and riven data right now. Use this if anything looks stale or missing.</span>
                       </div>
-                      <BulkPriceRefreshButton />
+                      <RefreshAllButton />
                     </div>
                   </div>
                   <div className="settings-section">

--- a/src/CacheStatusChip.tsx
+++ b/src/CacheStatusChip.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+
+type Source = "fresh" | "refreshed" | "stale" | "fallback";
+
+type CacheStatus = {
+  source: Source;
+  last_updated: number | null;
+  warning: string | null;
+};
+
+type Statuses = Record<string, CacheStatus>;
+
+/** Worst rung any cache is currently on decides the chip's colour. */
+function overall(statuses: Statuses): "online" | "warn" | "offline" {
+  const values = Object.values(statuses);
+  if (values.some(s => s.source === "fallback")) return "offline";
+  if (values.some(s => s.source === "stale" || s.warning)) return "warn";
+  return "online";
+}
+
+function age(ts: number | null): string {
+  if (!ts) return "never";
+  const mins = Math.floor((Date.now() / 1000 - ts) / 60);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+export default function CacheStatusChip() {
+  const [statuses, setStatuses] = useState<Statuses>({});
+  const [open, setOpen] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+
+  useEffect(() => {
+    invoke<Statuses>("get_cache_statuses").then(setStatuses).catch(() => {});
+    const unlisten = listen<Statuses>("cache-status", e => setStatuses(e.payload));
+    return () => { unlisten.then(fn => fn()); };
+  }, []);
+
+  const state = overall(statuses);
+  const names = Object.keys(statuses).sort();
+  const detail = state === "online" ? "Fresh" : state === "warn" ? "Stale" : "Offline";
+
+  return (
+    <span style={{ position: "relative" }}>
+      <span
+        className={`conn-chip conn-${state}`}
+        title="Cached game data. Click for details."
+        style={{ cursor: "pointer" }}
+        onClick={() => setOpen(o => !o)}
+      >
+        <span className="conn-dot" />
+        <span className="conn-label">Data</span>
+        <span className="conn-detail">{detail}</span>
+      </span>
+      {open && (
+        <div
+          style={{
+            position: "absolute", top: "calc(100% + 6px)", right: 0, zIndex: 50,
+            minWidth: 280, padding: 10, borderRadius: 6,
+            background: "var(--panel, #1b1d22)", border: "1px solid rgba(255,255,255,.12)",
+            boxShadow: "0 6px 18px rgba(0,0,0,.5)", fontSize: 11, lineHeight: 1.5,
+          }}
+        >
+          {names.length === 0 && <div style={{ opacity: .7 }}>No refresh has run yet.</div>}
+          {names.map(name => {
+            const s = statuses[name];
+            return (
+              <div key={name} style={{ marginBottom: 6 }}>
+                <div style={{ display: "flex", justifyContent: "space-between", gap: 12 }}>
+                  <strong>{name.replace(/-v\d+\.json$/, "")}</strong>
+                  <span style={{ opacity: .8 }}>{s.source} · {age(s.last_updated)}</span>
+                </div>
+                {s.warning && <div style={{ color: "#e0a052" }}>{s.warning}</div>}
+              </div>
+            );
+          })}
+          <button
+            className="btn-secondary"
+            style={{ marginTop: 4, width: "100%" }}
+            disabled={refreshing}
+            onClick={() => {
+              setRefreshing(true);
+              invoke("refresh_all_caches")
+                .catch(() => {})
+                .finally(() => setTimeout(() => setRefreshing(false), 5000));
+            }}
+          >{refreshing ? "Refreshing…" : "Refresh all data"}</button>
+        </div>
+      )}
+    </span>
+  );
+}

--- a/src/ImgCacheDir.ts
+++ b/src/ImgCacheDir.ts
@@ -1,5 +1,37 @@
-import { createContext } from "react";
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
 
-/** Absolute path to the local image cache directory (%LOCALAPPDATA%\warframe-companion\img_cache).
+/** Base URL of the local image server (the img_cache folder in the user cache directory).
  *  Empty string = not yet known (images fall back to CDN). Set once on app startup. */
 export const ImgCacheDirContext = createContext<string>("");
+
+const CDN_PREFIX = "https://cdn.warframestat.us/img/";
+
+export function cdnUrl(imageName?: string): string | undefined {
+  return imageName ? CDN_PREFIX + imageName : undefined;
+}
+
+/** Put the locally cached copy of every CDN image in front of the CDN one.
+ *  The image server 404s a file whose bytes are not an image, so a corrupt
+ *  cache entry costs one failed request and then loads from the CDN. */
+export function cdnCandidates(baseUrl: string, urls: (string | undefined)[]): string[] {
+  const out: string[] = [];
+  for (const url of urls) {
+    if (!url) continue;
+    if (baseUrl && url.startsWith(CDN_PREFIX)) out.push(`${baseUrl}/${url.slice(CDN_PREFIX.length)}`);
+    out.push(url);
+  }
+  return [...new Set(out)];
+}
+
+/** Walk a list of image URLs, one step per load error, cache before CDN.
+ *  `src` is undefined once every candidate has failed; that is the caller's
+ *  cue to draw its placeholder. */
+export function useImgLadder(urls: (string | undefined)[]): { src?: string; onError: () => void } {
+  const baseUrl = useContext(ImgCacheDirContext);
+  const key = urls.join("|");
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const srcs = useMemo(() => cdnCandidates(baseUrl, urls), [baseUrl, key]);
+  const [idx, setIdx] = useState(0);
+  useEffect(() => setIdx(0), [baseUrl, key]);
+  return { src: srcs[idx], onError: () => setIdx(i => i + 1) };
+}

--- a/src/ItemMarketPopup.tsx
+++ b/src/ItemMarketPopup.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { useImgLadder, cdnUrl } from "./ImgCacheDir";
 import "./ItemMarketPopup.css";
 
 async function invokeWfm<T>(command: string, args?: Record<string, unknown>): Promise<T> {
@@ -217,7 +218,7 @@ export default function ItemMarketPopup({ urlName, displayName, imageName, onClo
   const [showForm, setShowForm] = useState(false);
   const [prefillPrice, setPrefillPrice] = useState(0);
   const [prefillType, setPrefillType]   = useState<"sell" | "buy">("sell");
-  const [imgFailed, setImgFailed]       = useState(false);
+  const thumb = useImgLadder([cdnUrl(imageName)]);
 
   // Mod rank state — lifted here so orders re-fetch when rank changes
   const [modRankInput, setModRankInput] = useState(prefillModRank ?? 0);
@@ -276,9 +277,8 @@ export default function ItemMarketPopup({ urlName, displayName, imageName, onClo
         {/* ── Header ── */}
         <div className="imp-header">
           <div className="imp-item-identity">
-            {imageName && !imgFailed
-              ? <img className="imp-thumb" src={`https://cdn.warframestat.us/img/${imageName}`}
-                  alt="" onError={() => setImgFailed(true)} />
+            {thumb.src
+              ? <img key={thumb.src} className="imp-thumb" src={thumb.src} alt="" onError={thumb.onError} />
               : <div className="imp-thumb-placeholder">P</div>
             }
             <div className="imp-title-group">

--- a/src/RelicHelper.tsx
+++ b/src/RelicHelper.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { HelpTip } from "./HelpTip";
+import { cdnUrl, useImgLadder } from "./ImgCacheDir";
 import type { InventoryItem, ViewMode } from "./App";
 import { ViewToggle } from "./App";
 
@@ -66,10 +67,6 @@ function chanceToRarity(chance: number): string {
   return "Rare";
 }
 
-const DROP_URL       = "https://raw.githubusercontent.com/WFCD/warframe-drop-data/gh-pages/data/all.json";
-const DROP_CACHE_KEY = "ff-drop-data-v7";
-const DROP_CACHE_TTL = 24 * 60 * 60 * 1000;
-
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function findCatalogItemGlobal(itemName: string, nameMap: Map<string, CatalogItem>): CatalogItem | undefined {
@@ -95,8 +92,8 @@ function extractPrimeName(name: string): string | null {
   return idx >= 0 ? name.slice(0, idx + " Prime".length) : null;
 }
 
-function parseDropData(raw: any): RelicDrop[] {
-  const relicsArray: any[] = Array.isArray(raw?.relics) ? raw.relics : [];
+function parseDropData(raw: unknown): RelicDrop[] {
+  const relicsArray: any[] = Array.isArray((raw as any)?.relics) ? (raw as any).relics : [];
 
   const map = new Map<string, RelicDrop>();
   for (const r of relicsArray) {
@@ -128,11 +125,11 @@ function parseDropData(raw: any): RelicDrop[] {
 // ─── Images ───────────────────────────────────────────────────────────────────
 
 function RelicImg({ src }: { src?: string }) {
-  const [failed, setFailed] = useState(false);
+  const img = useImgLadder([src]);
   const base = { width: 44, height: 44, borderRadius: 6, flexShrink: 0 } as const;
-  if (!src || failed)
+  if (!img.src)
     return <div style={{ ...base, background: "rgba(255,255,255,.06)", display: "flex", alignItems: "center", justifyContent: "center", fontSize: 11, color: "#8b949e" }}>R</div>;
-  return <img style={{ ...base, objectFit: "contain" }} src={src} alt="" loading="lazy" onError={() => setFailed(true)} />;
+  return <img key={img.src} style={{ ...base, objectFit: "contain" }} src={img.src} alt="" loading="lazy" onError={img.onError} />;
 }
 
 const RARITY_BG: Record<string, string> = {
@@ -142,11 +139,8 @@ const RARITY_BG: Record<string, string> = {
 };
 
 function PartImg({ srcs, rarity }: { srcs: (string | undefined)[]; rarity?: string }) {
-  // Deduplicate so the same failing URL isn't retried
-  const valid = [...new Set(srcs.filter(Boolean) as string[])];
-  const [idx, setIdx] = useState(0);
+  const { src, onError } = useImgLadder(srcs);
   const base = { width: 40, height: 40, borderRadius: 4 } as const;
-  const src = valid[idx];
   if (!src) {
     const bg = rarity ? (RARITY_BG[rarity] ?? "rgba(255,255,255,.06)") : "rgba(255,255,255,.06)";
     return <div style={{ ...base, background: bg, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 9, color: "rgba(255,255,255,.3)" }}>?</div>;
@@ -154,10 +148,8 @@ function PartImg({ srcs, rarity }: { srcs: (string | undefined)[]; rarity?: stri
   // key={src} forces React to unmount/remount the img when src changes,
   // preventing the broken-image icon from persisting between attempts
   return <img key={src} style={{ ...base, objectFit: "contain", display: "block" }} src={src} alt=""
-    onError={() => setIdx(i => i + 1)} />;
+    onError={onError} />;
 }
-
-const CDN = (name?: string) => name ? `https://cdn.warframestat.us/img/${name}` : undefined;
 
 // ─── Reward box ───────────────────────────────────────────────────────────────
 
@@ -283,7 +275,7 @@ function RelicCard({ drop, catalogRelicByName, inventory, ownedPrimeNames, searc
   if (view === "icons") {
     return (
       <div className={`${cardClass} relic-card-icon-only`} title={`${drop.fullName} ×${total}`}>
-        <RelicImg src={CDN(intactCat?.image_name)} />
+        <RelicImg src={cdnUrl(intactCat?.image_name)} />
         <span className="relic-icon-count">×{total}</span>
       </div>
     );
@@ -295,7 +287,7 @@ function RelicCard({ drop, catalogRelicByName, inventory, ownedPrimeNames, searc
       .join(" ");
     return (
       <div className={`${cardClass} relic-card-row`}>
-        {view === "list" && <div className="relic-row-img"><RelicImg src={CDN(intactCat?.image_name)} /></div>}
+        {view === "list" && <div className="relic-row-img"><RelicImg src={cdnUrl(intactCat?.image_name)} /></div>}
         <div className="relic-row-name">{drop.fullName}</div>
         {intactCat?.vaulted && <span className="vault-badge vault-yes" style={{ fontSize: 9 }}>🔒</span>}
         <span className="relic-row-total">×{total}</span>
@@ -335,7 +327,7 @@ function RelicCard({ drop, catalogRelicByName, inventory, ownedPrimeNames, searc
     <div className={cardClass}>
       <div className="relic-card-left">
         <div className="relic-card-icon-row">
-          <RelicImg src={CDN(intactCat?.image_name)} />
+          <RelicImg src={cdnUrl(intactCat?.image_name)} />
           <span className="relic-total">×{total}</span>
           {colorblindMode && allComplete && <span className="relic-cb-relic-check" title="All rewards obtained">✓✓</span>}
         </div>
@@ -370,21 +362,21 @@ function RelicCard({ drop, catalogRelicByName, inventory, ownedPrimeNames, searc
 
           const imageSrcs: (string | undefined)[] = [
             // 1. Catalog item image (direct or parent-prime fallback from findCatalogItem)
-            CDN(imageItem?.image_name),
+            cdnUrl(imageItem?.image_name),
             // 2. Parent prime warframe/weapon image
-            CDN(primeImageItem?.image_name),
+            cdnUrl(primeImageItem?.image_name),
             // 3. Construct from catalog unique_name: "YareliPrimeBlueprint" → "YareliPrime.png"
             (() => {
               const seg = (catalogItem?.unique_name ?? "").split("/").pop() ?? "";
               const file = seg.replace(/Blueprint$/, "");
-              return file ? `https://cdn.warframestat.us/img/${file}.png` : undefined;
+              return cdnUrl(file ? `${file}.png` : undefined);
             })(),
             // 4. Construct from parent prime name: "Yareli Prime" → "YareliPrime.png"
-            primeName ? `https://cdn.warframestat.us/img/${primeName.replace(/\s+/g, "")}.png` : undefined,
+            cdnUrl(primeName ? `${primeName.replace(/\s+/g, "")}.png` : undefined),
             // 5. Strip "Blueprint" from item name: "Forma Blueprint" → "Forma.png"
-            `https://cdn.warframestat.us/img/${r.itemName.replace(" Blueprint", "").replace(/\s+/g, "")}.png`,
+            cdnUrl(`${r.itemName.replace(" Blueprint", "").replace(/\s+/g, "")}.png`),
             // 6. Strip leading count prefix: "2X Forma" → "Forma.png"
-            `https://cdn.warframestat.us/img/${r.itemName.replace(/^\d+[xX]\s*/, "").replace(" Blueprint", "").replace(/\s+/g, "")}.png`,
+            cdnUrl(`${r.itemName.replace(/^\d+[xX]\s*/, "").replace(" Blueprint", "").replace(/\s+/g, "")}.png`),
           ];
           // Gold: the complete parent prime item is built and in inventory
           // "Burston Prime Barrel" → find "Burston Prime" → check inventory by name
@@ -715,16 +707,11 @@ export default function RelicHelper({ inventory, refreshKey, colorblindMode = fa
   const { search, tiers, ownership, vault, completion, sortMode, ignoreFormaKuva } = filters;
   const set = <K extends keyof RelicFilters>(k: K, v: RelicFilters[K]) => onFiltersChange({ ...filters, [k]: v });
 
-  const loadDrops = useCallback(() => {
+  const loadDrops = useCallback((force = false) => {
     setDropLoading(true);
     setDropError(false);
-    fetch(DROP_URL)
-      .then(r => r.json())
-      .then(d => {
-        const result = parseDropData(d);
-        setDrops(result);
-        try { localStorage.setItem(DROP_CACHE_KEY, JSON.stringify({ data: result, ts: Date.now() })); } catch {}
-      })
+    invoke<unknown>("get_drop_data", { force })
+      .then(d => setDrops(parseDropData(d)))
       .catch(() => setDropError(true))
       .finally(() => setDropLoading(false));
   }, []);
@@ -734,16 +721,6 @@ export default function RelicHelper({ inventory, refreshKey, colorblindMode = fa
   }, [refreshKey]);
 
   useEffect(() => {
-    try {
-      const cached = localStorage.getItem(DROP_CACHE_KEY);
-      if (cached) {
-        const { data, ts } = JSON.parse(cached);
-        if (typeof ts === "number" && Date.now() - ts < DROP_CACHE_TTL && Array.isArray(data)) {
-          setDrops(data);
-          return;
-        }
-      }
-    } catch {}
     loadDrops();
   }, [loadDrops]);
 
@@ -895,7 +872,7 @@ export default function RelicHelper({ inventory, refreshKey, colorblindMode = fa
           <button className={`fchip ${sortMode === "za"     ? "fchip-on" : ""}`} onClick={() => set("sortMode", "za")}>Z–A</button>
           <span className="fbar-sep"/>
           <button className="fchip fchip-reset" onClick={() => onFiltersChange(RELIC_FILTERS_DEFAULT)}>Show All</button>
-          {dropError && <button className="btn-secondary" style={{ marginLeft: 4 }} onClick={loadDrops}>↺ Retry</button>}
+          {dropError && <button className="btn-secondary" style={{ marginLeft: 4 }} onClick={() => loadDrops(true)}>↺ Retry</button>}
           <span style={{ marginLeft: "auto", fontSize: 11, color: "var(--muted)" }}>
             {dropLoading ? "Loading…" : `${visibleDrops.length} relics · ${ownedCount} owned`}
           </span>

--- a/src/Reports.tsx
+++ b/src/Reports.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { useImgLadder, cdnUrl } from "./ImgCacheDir";
 import "./Reports.css";
 
 interface WfmTopItem {
@@ -270,11 +271,11 @@ function Legend({ items }: { items: { label: string; color: string; value: numbe
 // ── Main component ───────────────────────────────────────────────────────────
 
 function ItemImg({ imageName, size = 28 }: { imageName?: string; size?: number }) {
-  const [failed, setFailed] = useState(false);
+  const { src, onError } = useImgLadder([cdnUrl(imageName)]);
   const s: React.CSSProperties = { width: size, height: size, objectFit: "contain", flexShrink: 0, borderRadius: 3 };
-  if (!imageName || failed)
+  if (!src)
     return <span style={{ ...s, background: "rgba(255,255,255,.06)", border: "1px solid #30363d", display: "inline-block" }} />;
-  return <img style={s} src={`https://cdn.warframestat.us/img/${imageName}`} alt="" loading="lazy" onError={() => setFailed(true)} />;
+  return <img key={src} style={s} src={src} alt="" loading="lazy" onError={onError} />;
 }
 
 interface Props {

--- a/src/Syndicates.tsx
+++ b/src/Syndicates.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { useImgLadder, cdnUrl } from "./ImgCacheDir";
 import "./Syndicates.css";
 import type { InventoryItem } from "./App";
 
@@ -102,23 +103,15 @@ const GROUP_LABELS: Record<SynGroup, string> = {
 // ── Image component ───────────────────────────────────────────────────────────
 
 function SynItemImg({ imageName, category }: { imageName?: string; category: string }) {
-  const [failed, setFailed] = useState(false);
-  if (!imageName || failed) {
+  const { src, onError } = useImgLadder([cdnUrl(imageName)]);
+  if (!src) {
     return (
       <div className="syn-item-img-fallback">
         {category[0]?.toUpperCase() ?? "?"}
       </div>
     );
   }
-  return (
-    <img
-      className="syn-item-img"
-      src={`https://cdn.warframestat.us/img/${imageName}`}
-      alt=""
-      loading="lazy"
-      onError={() => setFailed(true)}
-    />
-  );
+  return <img key={src} className="syn-item-img" src={src} alt="" loading="lazy" onError={onError} />;
 }
 
 // ── Status badge ─────────────────────────────────────────────────────────────

--- a/src/Weapons.tsx
+++ b/src/Weapons.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { useImgLadder, cdnUrl } from "./ImgCacheDir";
 import "./Weapons.css";
 import type { InventoryItem } from "./App";
 
@@ -51,19 +52,11 @@ function effectiveCap(item: WeaponItem): number {
 // ── Image ─────────────────────────────────────────────────────────────────────
 
 function WeaponImg({ imageName, name }: { imageName?: string; name: string }) {
-  const [failed, setFailed] = useState(false);
-  if (!imageName || failed) {
+  const { src, onError } = useImgLadder([cdnUrl(imageName)]);
+  if (!src) {
     return <div className="wpn-img-fallback">{name[0]?.toUpperCase() ?? "?"}</div>;
   }
-  return (
-    <img
-      className="wpn-img"
-      src={`https://cdn.warframestat.us/img/${imageName}`}
-      alt=""
-      loading="lazy"
-      onError={() => setFailed(true)}
-    />
-  );
+  return <img key={src} className="wpn-img" src={src} alt="" loading="lazy" onError={onError} />;
 }
 
 // ── Item row ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What this does

All remote data (catalogue, drop tables, prices, warframe.market lookups, riven database, thumbnails) goes through one cache layer.
The UI renders immediately from the last known data; refreshes run in the background on per-type intervals (worldstate 55s, prices 1h, catalogue/drops/rivens 24h, WFM top 3h) with a 5s→30s→120s→300s backoff on failure.
Static sources use conditional GETs, so an unchanged catalogue costs a 304 instead of a ~30 MB download per launch.
A header chip shows cache freshness and offers a "refresh all" that ignores ETags.

## Bug fixes on the way

- Network errors were cached as "item unlisted" for the session. Only a real 404 counts now, and negative results expire after one hour.
- The manual bulk-price refresh deleted its cache before the fetch, losing data on a failed refresh.
- The bulk-price cache expired at midnight regardless of age.
- A failed riven-database load stayed empty for the whole session.
- Corrupt thumbnails were kept forever. Files are validated and refetched, and all views use the local image cache.
- Drop data moved from localStorage into the same cache layer, so offline now shows stale data instead of an error.

## Storage layout and migration

Files split by role under a new `frameforge` name: caches in `%LOCALAPPDATA%\frameforge` (tagged with `CACHEDIR.TAG`), settings and database in `%APPDATA%\frameforge`.
A one-shot migration moves the non-regenerable files (settings, database, auction IDs, corrections, scanned inventory) out of `%LOCALAPPDATA%\warframe-companion`.
It never overwrites, moves the SQLite db/-wal/-shm as one unit, and leaves unknown files in place.
Old caches are dropped and refetched.
Cache files carry a schema version in the filename, replacing the delete-all-on-version-change logic.

## Notes for review

- New code is in `paths.rs`, `cache.rs`, and `refresh.rs`. Offline unit tests cover the cache core and migration.
- Developed on Linux; a Windows CI run is the real compile check. Please smoke-test the migration against a real `%LOCALAPPDATA%\warframe-companion` before release.