### PR TITLE
fix: auto-sort by recent when 'Changed recently' filter is enabled

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -825,6 +825,8 @@ const [blobLogEnabled, setBlobLogEnabled] = useState(false);
   const [filterVaulted,  setFilterVaulted]  = useState(false);
   const [filterUnvaulted,setFilterUnvaulted]= useState(false);
   const [sortMode, setSortMode] = useState<"qty-desc" | "qty-asc" | "name-asc" | "name-desc" | "recent">("qty-desc");
+  const prevSortRef = useRef(sortMode);
+  useEffect(() => { if (sortMode !== "recent") prevSortRef.current = sortMode; }, [sortMode]);
   const [filterRank, setFilterRank] = useState<number | "unranked" | null>(null);
   const [inventoryView, setInventoryView] = useState<ViewMode>(() =>
     (localStorage.getItem("ff-view-inventory") as ViewMode | null) ?? "cards"
@@ -3181,7 +3183,7 @@ if (typeof s.autoDiagEnabled === "boolean") {
               </div>
               <div className="filter-bar">
                 <button className={`fchip ${filterOwned?"fchip-on":""}`} onClick={()=>setFilterOwned(v=>!v)}>Owned</button>
-                <button className={`fchip ${filterRecent?"fchip-on":""}`} onClick={()=>setFilterRecent(v=>{ const next = !v; if (next) setSortMode("recent"); else if (sortMode === "recent") setSortMode("qty-desc"); return next; })}>Changed recently</button>
+                <button className={`fchip ${filterRecent?"fchip-on":""}`} onClick={()=>setFilterRecent(v=>{ const next = !v; if (next) { setSortMode("recent"); } else { setSortMode(prevSortRef.current); } return next; })}>Changed recently</button>
                 <button className={`fchip ${filterPrime?"fchip-on":""}`} onClick={()=>setFilterPrime(v=>!v)}>Prime</button>
                 <button className={`fchip ${filterVaulted?"fchip-on":""}`} onClick={()=>setFilterVaulted(v=>!v)}>🔒 Vaulted</button>
                 <button className={`fchip ${filterUnvaulted?"fchip-on":""}`} onClick={()=>setFilterUnvaulted(v=>!v)}>🔓 Unvaulted</button>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3181,7 +3181,7 @@ if (typeof s.autoDiagEnabled === "boolean") {
               </div>
               <div className="filter-bar">
                 <button className={`fchip ${filterOwned?"fchip-on":""}`} onClick={()=>setFilterOwned(v=>!v)}>Owned</button>
-                <button className={`fchip ${filterRecent?"fchip-on":""}`} onClick={()=>setFilterRecent(v=>!v)}>Changed recently</button>
+                <button className={`fchip ${filterRecent?"fchip-on":""}`} onClick={()=>setFilterRecent(v=>{ const next = !v; if (next) setSortMode("recent"); else if (sortMode === "recent") setSortMode("qty-desc"); return next; })}>Changed recently</button>
                 <button className={`fchip ${filterPrime?"fchip-on":""}`} onClick={()=>setFilterPrime(v=>!v)}>Prime</button>
                 <button className={`fchip ${filterVaulted?"fchip-on":""}`} onClick={()=>setFilterVaulted(v=>!v)}>🔒 Vaulted</button>
                 <button className={`fchip ${filterUnvaulted?"fchip-on":""}`} onClick={()=>setFilterUnvaulted(v=>!v)}>🔓 Unvaulted</button>


### PR DESCRIPTION
## fix: auto-sort by recent when 'Changed recently' filter is enabled

When toggling the **Changed recently** filter, items were filtered correctly but sorted by quantity (default), not by recency. The `sortMode: "recent"` sort existed in code but had no UI button, so recently changed items never appeared at the top.

### What changed

- **`src/App.tsx`** — Toggling **Changed recently** ON now auto-selects `sortMode: "recent"`. Toggling OFF reverts to `previous selected`.
