### PR TITLE
fix: pass missing isDirectSell param to wfm_create_riven_auction

### DIFF
--- a/src/MarketHelper.tsx
+++ b/src/MarketHelper.tsx
@@ -1311,6 +1311,7 @@ function RivenSellModal({ riven, weaponName, disposition, category, onClose, onS
         minimalReputation:   saleType === "direct" ? 0 : (parseInt(minRep, 10) || 0),
         note,
         visible,
+        isDirectSell:        saleType === "direct",
       });
       onSuccess();
       onClose();


### PR DESCRIPTION
The wfm_create_riven_auction Tauri command requires an isDirectSell boolean parameter, but the TypeScript invoke call in MarketHelper.tsx was not passing it, causing a runtime error. This adds the missing parameter derived from the existing saleType state.

**Error:**
`
Invalid args `isDirectSell` for command `wfm_create_riven_auction`: command wfm_create_riven_auction missing required key isDirectSell
`