### PR TITLE
Feat: inventory grid refactor and image caching

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Warframe Companion</title>
+    <style>
+      html, body { background: #0d1117; margin: 0; padding: 0; }
+    </style>
   </head>
 
   <body>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Warframe Companion</title>
     <style>
-      html, body { background: #0d1117; margin: 0; padding: 0; }
+      html, body { background: #161b22; margin: 0; padding: 0; }
     </style>
   </head>
 

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -11,6 +11,9 @@ pub struct QuantityChange {
     pub new_qty: i64,
     pub delta: i64,
     pub timestamp: i64,
+    /// Rank of the mod/arcane that changed (None for regular items).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rank: Option<u8>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -319,6 +322,7 @@ pub fn get_quantity_changes(conn: &Connection, limit: i64) -> Result<Vec<Quantit
                 new_qty: row.get(4)?,
                 delta: row.get(5)?,
                 timestamp: row.get(6)?,
+                rank: None,
             })
         })?
         .filter_map(|r| r.ok())

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -101,6 +101,11 @@ fn migrate(conn: &Connection) -> Result<()> {
         conn.pragma_update(None, "user_version", 3)?;
     }
 
+    if version < 4 {
+        conn.execute_batch("ALTER TABLE quantity_changes ADD COLUMN rank INTEGER;")?;
+        conn.pragma_update(None, "user_version", 4)?;
+    }
+
     // Prune entries older than 7 days so the log doesn't grow unbounded.
     conn.execute_batch(
         "DELETE FROM quantity_changes WHERE timestamp < unixepoch('now', '-7 days');"
@@ -295,19 +300,20 @@ pub fn add_quantity_change(
     item_name: &str,
     old_qty: i64,
     new_qty: i64,
+    rank: Option<u8>,
 ) -> Result<()> {
     let ts = chrono::Utc::now().timestamp();
     conn.execute(
-        "INSERT INTO quantity_changes (unique_name, item_name, old_qty, new_qty, delta, timestamp)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-        params![unique_name, item_name, old_qty, new_qty, new_qty - old_qty, ts],
+        "INSERT INTO quantity_changes (unique_name, item_name, old_qty, new_qty, delta, timestamp, rank)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![unique_name, item_name, old_qty, new_qty, new_qty - old_qty, ts, rank],
     )?;
     Ok(())
 }
 
 pub fn get_quantity_changes(conn: &Connection, limit: i64) -> Result<Vec<QuantityChange>> {
     let mut stmt = conn.prepare(
-        "SELECT id, unique_name, item_name, old_qty, new_qty, delta, timestamp
+        "SELECT id, unique_name, item_name, old_qty, new_qty, delta, timestamp, rank
          FROM quantity_changes
          ORDER BY id DESC
          LIMIT ?1",
@@ -322,7 +328,7 @@ pub fn get_quantity_changes(conn: &Connection, limit: i64) -> Result<Vec<Quantit
                 new_qty: row.get(4)?,
                 delta: row.get(5)?,
                 timestamp: row.get(6)?,
-                rank: None,
+                rank: row.get(7)?,
             })
         })?
         .filter_map(|r| r.ok())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8037,7 +8037,8 @@ async fn prewarm_image_cache(state: tauri::State<'_, AppState>) -> Result<(), St
                     let url = format!("https://cdn.warframestat.us/img/{}", name);
                     if let Ok(resp) = agent.get(&url).call() {
                         let mut buf = Vec::new();
-                        if resp.into_reader().read_to_end(&mut buf).is_ok() {
+                        // Limit to 5 MB to prevent memory exhaustion from malformed responses
+                        if resp.into_reader().take(5 * 1024 * 1024).read_to_end(&mut buf).is_ok() {
                             let _ = std::fs::write(dir.join(&name), buf);
                         }
                     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4583,6 +4583,9 @@ async fn start_monitor(app: tauri::AppHandle, state: State<'_, AppState>) -> Res
         let mut known: HashMap<String, i64> =
             shared_quantities.lock().unwrap_or_else(|e| e.into_inner()).clone();
 
+        // Previous mod state for rank-specific change detection.
+        let mut prev_mods: HashMap<String, memory_scanner::ModCount> = HashMap::new();
+
         // Load the full inventory state from the last session so the UI shows data
         // immediately on restart without waiting for the first full scan pass.
         let startup_cache = load_inventory_state_cache(&inventory_state_cache_path);
@@ -4960,9 +4963,44 @@ async fn start_monitor(app: tauri::AppHandle, state: State<'_, AppState>) -> Res
                             new_qty,
                             delta: new_qty - old_qty,
                             timestamp: ts,
+                            rank: None,
                         });
                     }
                 }
+
+                // Rank-specific change detection for mods/arcanes.
+                // Compare current by_rank with previous to find which specific rank changed.
+                if !prev_mods.is_empty() {
+                    let ts = chrono::Utc::now().timestamp();
+                    for (path, mc) in &known_mods {
+                        if ignored_paths.contains(path.as_str()) { continue; }
+                        let prev = prev_mods.get(path);
+                        let all_ranks: std::collections::HashSet<u8> = match prev {
+                            Some(p) => p.by_rank.keys().chain(mc.by_rank.keys()).cloned().collect(),
+                            None => mc.by_rank.keys().cloned().collect(),
+                        };
+                        for rank in all_ranks {
+                            let old_count = prev.map(|p| *p.by_rank.get(&rank).unwrap_or(&0)).unwrap_or(0);
+                            let new_count = *mc.by_rank.get(&rank).unwrap_or(&0);
+                            if old_count == new_count { continue; }
+                            let item_name = path_to_name.get(path.as_str())
+                                .cloned()
+                                .unwrap_or_else(|| path.split('/').last().unwrap_or("?").to_string());
+                            changes.push(QuantityChange {
+                                id: 0,
+                                unique_name: path.clone(),
+                                item_name,
+                                old_qty: old_count,
+                                new_qty: new_count,
+                                delta: new_count - old_count,
+                                timestamp: ts,
+                                rank: Some(rank),
+                            });
+                        }
+                    }
+                }
+                // Update prev_mods for next iteration
+                prev_mods = known_mods.clone();
 
                 let crafting: Vec<CraftingJob> = blob.pending_recipes.iter().map(|r| {
                     let name = display_names.iter().zip(unique_names.iter())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4583,12 +4583,25 @@ async fn start_monitor(app: tauri::AppHandle, state: State<'_, AppState>) -> Res
         let mut known: HashMap<String, i64> =
             shared_quantities.lock().unwrap_or_else(|e| e.into_inner()).clone();
 
-        // Previous mod state for rank-specific change detection.
-        let mut prev_mods: HashMap<String, memory_scanner::ModCount> = HashMap::new();
-
         // Load the full inventory state from the last session so the UI shows data
         // immediately on restart without waiting for the first full scan pass.
         let startup_cache = load_inventory_state_cache(&inventory_state_cache_path);
+
+        // Previous mod state for rank-specific change detection.
+        // Pre-seed from startup cache so the first scan detects rank changes
+        // since the last session instead of requiring two full scans.
+        let mut prev_mods: HashMap<String, memory_scanner::ModCount> = startup_cache.items.iter()
+            .filter(|(_, v)| v.mod_ranks.is_some())
+            .map(|(path, v)| {
+                let by_rank: HashMap<u8, i64> = v.mod_ranks.as_ref()
+                    .map(|ranks| ranks.iter()
+                        .filter_map(|(r, &c)| r.parse::<u8>().ok().map(|rank| (rank, c)))
+                        .collect())
+                    .unwrap_or_default();
+                let total = by_rank.values().sum();
+                (path.clone(), memory_scanner::ModCount { total, by_rank })
+            })
+            .collect();
 
         // Pre-populate known with cached resource quantities so that per-cycle hint
         // emits never replace the frontend display with a partial inventory.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8010,14 +8010,11 @@ async fn prewarm_image_cache(state: tauri::State<'_, AppState>) -> Result<(), St
     use std::collections::HashSet;
     use std::sync::Arc;
     let items: Vec<_> = state.wfcd_items.lock().unwrap_or_else(|e| e.into_inner()).clone();
-    let recipe_names: HashSet<String> = state.recipes.lock()
-        .unwrap_or_else(|e| e.into_inner()).keys().cloned().collect();
     let cache_dir = Arc::new(state.img_cache_dir.clone());
 
     tokio::task::spawn_blocking(move || {
         use std::io::Read;
         let names: Vec<String> = items.iter()
-            .filter(|i| recipe_names.contains(&i.unique_name))
             .filter_map(|i| i.image_name.clone())
             .collect::<HashSet<_>>()
             .into_iter()
@@ -8027,13 +8024,18 @@ async fn prewarm_image_cache(state: tauri::State<'_, AppState>) -> Result<(), St
         if names.is_empty() { return; }
         debug!(count = names.len(), "prewarming images in background");
 
+        let agent = ureq::AgentBuilder::new()
+            .timeout(std::time::Duration::from_secs(10))
+            .build();
+
         for chunk in names.chunks(8) {
             let handles: Vec<_> = chunk.iter().map(|name| {
                 let dir = Arc::clone(&cache_dir);
                 let name = name.clone();
+                let agent = agent.clone();
                 std::thread::spawn(move || {
                     let url = format!("https://cdn.warframestat.us/img/{}", name);
-                    if let Ok(resp) = ureq::get(&url).call() {
+                    if let Ok(resp) = agent.get(&url).call() {
                         let mut buf = Vec::new();
                         if resp.into_reader().read_to_end(&mut buf).is_ok() {
                             let _ = std::fs::write(dir.join(&name), buf);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -751,6 +751,11 @@ fn get_current_quantities(state: State<AppState>) -> HashMap<String, i64> {
 }
 
 #[tauri::command]
+fn get_player_name(state: State<AppState>) -> Option<String> {
+    state.local_player_name.lock().ok().and_then(|name| name.clone())
+}
+
+#[tauri::command]
 fn get_current_crafting(state: State<AppState>) -> Vec<CraftingJob> {
     state.current_crafting.lock().unwrap_or_else(|e| e.into_inner()).clone()
 }
@@ -4967,7 +4972,7 @@ async fn start_monitor(app: tauri::AppHandle, state: State<'_, AppState>) -> Res
                         let item_name = path_to_name.get(key.as_str())
                             .cloned()
                             .unwrap_or_else(|| key.split('/').last().unwrap_or("?").to_string());
-                        let _ = db::add_quantity_change(&conn, key, &item_name, old_qty, new_qty);
+                        let _ = db::add_quantity_change(&conn, key, &item_name, old_qty, new_qty, None);
                         changes.push(QuantityChange {
                             id: 0,
                             unique_name: key.clone(),
@@ -4999,6 +5004,7 @@ async fn start_monitor(app: tauri::AppHandle, state: State<'_, AppState>) -> Res
                             let item_name = path_to_name.get(path.as_str())
                                 .cloned()
                                 .unwrap_or_else(|| path.split('/').last().unwrap_or("?").to_string());
+                            let _ = db::add_quantity_change(&conn, path, &item_name, old_count, new_count, Some(rank));
                             changes.push(QuantityChange {
                                 id: 0,
                                 unique_name: path.clone(),
@@ -5254,6 +5260,12 @@ async fn start_monitor(app: tauri::AppHandle, state: State<'_, AppState>) -> Res
                 // Searching only the first 64 KB misses the current session when the log
                 // has grown large from previous runs.
                 if let Ok(mut f) = std::fs::File::open(&log_path) {
+                    let mut first = Vec::with_capacity(64 * 1024);
+                    let _ = (&mut f).take(64 * 1024).read_to_end(&mut first);
+                    if let Ok(text) = std::str::from_utf8(&first) {
+                        parse_logged_in_name(text, &shared_squad_names2, &ee_ocr_app);
+                    }
+
                     let file_len = f.seek(SeekFrom::End(0)).unwrap_or(0);
                     let read_from = file_len.saturating_sub(1_048_576); // last 1 MB
                     let _ = f.seek(SeekFrom::Start(read_from));
@@ -9914,6 +9926,7 @@ pub fn run() {
             get_all_items,
             get_items_by_paths,
             get_current_quantities,
+            get_player_name,
             get_item_list_status,
             fetch_item_list,
             get_change_log,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4990,16 +4990,20 @@ async fn start_monitor(app: tauri::AppHandle, state: State<'_, AppState>) -> Res
                 // Compare current by_rank with previous to find which specific rank changed.
                 if !prev_mods.is_empty() {
                     let ts = chrono::Utc::now().timestamp();
-                    for (path, mc) in &known_mods {
+                    let all_paths: std::collections::HashSet<&String> =
+                        prev_mods.keys().chain(known_mods.keys()).collect();
+                    for path in all_paths {
                         if ignored_paths.contains(path.as_str()) { continue; }
                         let prev = prev_mods.get(path);
-                        let all_ranks: std::collections::HashSet<u8> = match prev {
-                            Some(p) => p.by_rank.keys().chain(mc.by_rank.keys()).cloned().collect(),
-                            None => mc.by_rank.keys().cloned().collect(),
-                        };
+                        let current = known_mods.get(path);
+                        let all_ranks: std::collections::HashSet<u8> = prev.into_iter()
+                            .flat_map(|mods| mods.by_rank.keys())
+                            .chain(current.into_iter().flat_map(|mods| mods.by_rank.keys()))
+                            .cloned()
+                            .collect();
                         for rank in all_ranks {
                             let old_count = prev.map(|p| *p.by_rank.get(&rank).unwrap_or(&0)).unwrap_or(0);
-                            let new_count = *mc.by_rank.get(&rank).unwrap_or(&0);
+                            let new_count = current.map(|mods| *mods.by_rank.get(&rank).unwrap_or(&0)).unwrap_or(0);
                             if old_count == new_count { continue; }
                             let item_name = path_to_name.get(path.as_str())
                                 .cloned()

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,8 @@
         "height": 600,
         "minWidth": 640,
         "minHeight": 480,
-        "visible": false
+        "visible": false,
+        "backgroundColor": "#161b22"
       },
       {
         "label": "relic-overlay",

--- a/src/App.css
+++ b/src/App.css
@@ -448,15 +448,7 @@ html, body, #root { height: 100%; font-family: -apple-system, BlinkMacSystemFont
 .item-gained     { border-left: 2px solid var(--green); background: rgba(63,185,80,.04); }
 .item-lost       { border-left: 2px solid var(--red);   background: rgba(248,81,73,.04); }
 
-.item-img { width: 32px; height: 32px; object-fit: contain; flex-shrink: 0; border-radius: 4px; opacity: 0; transform: translate(-4px, -4px) scale(0.9); transition: opacity 0.25s ease-out, transform 0.25s ease-out; }
-.item-img.img-loaded { opacity: 1; transform: translate(0, 0) scale(1); }
-.item-img-fallback {
-  width: 32px; height: 32px; flex-shrink: 0; border-radius: 4px;
-  background: rgba(255,255,255,.06); border: 1px solid var(--border);
-  display: flex; align-items: center; justify-content: center;
-  font-size: 11px; font-weight: 600; color: var(--muted); text-transform: uppercase;
-}
-svg.item-img-fallback { background: transparent; border: none; padding: 0; }
+/* .item-img, .item-img-fallback removed — now in images.css */
 .item-name { flex: 1; color: var(--text); font-size: 13px; overflow: hidden; text-overflow: ellipsis; display: flex; flex-direction: column; justify-content: center; gap: 1px; }
 .item-rank-info { font-size: 10px; color: var(--accent); opacity: 0.85; white-space: nowrap; }
 
@@ -801,11 +793,11 @@ svg.item-img-fallback { background: transparent; border: none; padding: 0; }
   background: rgba(0,0,0,.15);
   border-right: 1px solid var(--border);
 }
-.cc-image img, .cc-image .item-img {
+.cc-image img, .cc-image .img {
   width: 88px !important; height: 96px !important;
   object-fit: cover !important; border-radius: 0 !important; display: block !important;
 }
-.cc-image .item-img-fallback {
+.cc-image .img-fallback {
   width: 88px !important; height: 96px !important; border-radius: 0 !important;
 }
 .cc-subsumed-icon {
@@ -1788,7 +1780,7 @@ svg.item-img-fallback { background: transparent; border: none; padding: 0; }
 .craft-icon-card:hover { border-color: rgba(56,139,253,.5); }
 .craft-icon-card.craft-card-owned { border-color: rgba(240,192,64,.6); }
 .craft-icon-card.craft-card-ready { border-color: rgba(56,139,253,.55); }
-.craft-icon-card img, .craft-icon-card .item-img { width: 80px !important; height: 80px !important; object-fit: cover !important; }
+.craft-icon-card img, .craft-icon-card .img { width: 80px !important; height: 80px !important; object-fit: cover !important; }
 .craft-icon-badge {
   position: absolute; bottom: 2px; right: 3px;
   font-size: 9px; font-weight: 700; padding: 1px 3px; border-radius: 3px;
@@ -1812,7 +1804,7 @@ svg.item-img-fallback { background: transparent; border: none; padding: 0; }
 .craft-row.craft-row-owned { border-left: 2px solid rgba(240,192,64,.7); }
 .craft-row.craft-row-ready { border-left: 2px solid rgba(56,139,253,.7); }
 .craft-row-icon { width: 26px; height: 26px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; }
-.craft-row-icon img, .craft-row-icon .item-img { width: 24px !important; height: 24px !important; object-fit: cover !important; border-radius: 3px !important; }
+.craft-row-icon img, .craft-row-icon .img { width: 24px !important; height: 24px !important; object-fit: cover !important; border-radius: 3px !important; }
 .craft-row-name { flex: 1; min-width: 0; font-size: 12px; font-weight: 500; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .craft-row-mr { font-size: 10px; flex-shrink: 0; }
 .craft-row-status { display: flex; gap: 3px; flex-shrink: 0; }
@@ -1868,7 +1860,7 @@ svg.item-img-fallback { background: transparent; border: none; padding: 0; }
 .relic-card-row.relic-card-complete { border-left: 2px solid rgba(63,185,80,.6); }
 .relic-row-img { flex-shrink: 0; }
 .relic-list-list .relic-row-img img,
-.relic-list-list .relic-row-img .item-img { width: 24px !important; height: 24px !important; object-fit: contain !important; }
+.relic-list-list .relic-row-img .img { width: 24px !important; height: 24px !important; object-fit: contain !important; }
 .relic-row-name { flex: 1; min-width: 0; font-size: 12px; font-weight: 500; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .relic-row-total { font-size: 12px; font-weight: 700; color: var(--muted); flex-shrink: 0; }
 .relic-row-refs { font-size: 10px; color: var(--muted); flex-shrink: 0; letter-spacing: .02em; }

--- a/src/App.css
+++ b/src/App.css
@@ -415,111 +415,25 @@ html, body, #root { height: 100%; font-family: -apple-system, BlinkMacSystemFont
 .cat-sep   { color: var(--border); }
 .cat-total { color: var(--muted); }
 
-/* ── Inventory card grid ── */
-.item-grid {
-  flex: 1;
-  overflow-y: auto;
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
-  gap: 8px;
-  padding: 10px 12px;
-  align-content: start;
-}
-
-.inv-card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 6px 6px 8px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 3px;
-  cursor: default;
-  transition: border-color .12s;
-  min-width: 0;
-  position: relative;
-}
-
-.inv-fav-star {
-  position: absolute;
-  top: 2px;
-  left: 4px;
-  background: none;
-  border: none;
-  cursor: pointer;
-  font-size: 11px;
-  color: rgba(255,255,255,.25);
-  line-height: 1;
-  padding: 0;
-  z-index: 2;
-  transition: color .1s;
-}
-.inv-fav-star:hover { color: rgba(240,192,64,.8); }
-.inv-fav-star.active { color: #f0c040; }
-.inv-card:hover { border-color: rgba(56, 139, 253, .5); }
-.inv-card-zero  { opacity: .35; }
-.inv-card-gained { border-left: 2px solid var(--green); background: rgba(63,185,80,.04); }
-.inv-card-lost   { border-left: 2px solid var(--red);   background: rgba(248,81,73,.04); }
-
-/* Fixed-height mastery slot — always rendered so image doesn't jump position */
-.inv-mastery-row  { height: 18px; display: flex; align-items: center; justify-content: center; width: 100%; }
-.inv-mastery-star { font-size: 13px; color: #f0c040; line-height: 1; }
-.inv-mastery-rank { font-size: 10px; font-weight: 600; color: var(--muted); background: rgba(255,255,255,.06); border-radius: 3px; padding: 1px 5px; }
-
-.inv-card-img-wrap { position: relative; width: 48px; height: 48px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; }
-.inv-foundry-icon  { position: absolute; top: -5px; right: -7px; font-size: 13px; filter: drop-shadow(0 0 3px rgba(0,0,0,.9)); }
-
-.inv-card-name {
-  font-size: 11px; font-weight: 500; text-align: center;
-  line-height: 1.3; overflow: hidden;
-  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
-  width: 100%;
-}
-.inv-card-cat {
-  font-size: 9px; font-weight: 600; text-transform: uppercase; letter-spacing: .04em;
-  color: rgba(139,148,158,.6); text-align: center; width: 100%;
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-  margin-top: -1px;
-}
-.inv-card-meta { display: flex; gap: 3px; flex-wrap: wrap; justify-content: center; }
-.inv-card-qty      { font-size: 15px; font-weight: 700; color: var(--text); font-variant-numeric: tabular-nums; display: flex; align-items: center; gap: 4px; }
-.inv-card-qty-zero { color: var(--muted); }
-
-/* ── Mod rank breakdown card ── */
-.inv-card-mod { align-items: flex-start; padding: 8px 10px 8px; min-width: 140px; max-width: 200px; }
-.inv-card-mod .inv-card-img-wrap { width: 40px; height: 40px; }
-.inv-card-mod .inv-card-name { text-align: left; font-size: 12px; }
-.inv-card-mod .inv-card-cat  { text-align: left; }
-.mod-rank-table {
-  width: 100%; margin-top: 5px;
-  display: grid; grid-template-columns: 1fr 1fr;
-  gap: 1px 6px;
-}
-.mod-rank-row {
-  display: contents;
-}
-.mod-rank-label {
-  font-size: 10px; font-weight: 600; color: var(--muted);
-  font-variant-numeric: tabular-nums;
-}
-.mod-rank-count {
-  font-size: 10px; font-weight: 700; color: var(--text);
-  font-variant-numeric: tabular-nums; text-align: right;
-}
-.mod-rank-zero .mod-rank-label,
-.mod-rank-zero .mod-rank-count { color: rgba(139,148,158,.3); }
-.inv-card-mod .mod-total {
-  font-size: 12px; font-weight: 700; margin-top: 4px;
-  border-top: 1px solid var(--border); padding-top: 3px; width: 100%;
-  display: flex; justify-content: space-between; color: var(--text);
-}
-.inv-card-mod .mod-total::before { content: "Total"; font-size: 10px; font-weight: 600; color: var(--muted); }
+/* ── Inventory card grid (see InventoryGrid.css) ── */
 
 /* ── Item list (legacy, kept for safety) ── */
 .item-list { flex: 1; overflow-y: auto; padding: 4px 0; }
 
 .empty-msg { padding: 40px 24px; color: var(--muted); text-align: center; line-height: 1.6; }
+
+/* ── View toggle (shared across Inventory / Foundry / Relics) ── */
+
+.view-toggle { display: flex; align-items: center; gap: 2px; flex-shrink: 0; }
+.view-btn {
+  background: none; border: 1px solid transparent; border-radius: 4px;
+  cursor: pointer; color: var(--muted); padding: 3px 5px;
+  display: flex; align-items: center; justify-content: center;
+  transition: color .12s, border-color .12s, background .12s;
+  line-height: 0;
+}
+.view-btn:hover { color: var(--text); background: rgba(255,255,255,.06); }
+.view-btn-active { color: var(--accent); border-color: rgba(56,139,253,.4); background: rgba(56,139,253,.08); }
 
 .item-row {
   display: flex;
@@ -533,7 +447,6 @@ html, body, #root { height: 100%; font-family: -apple-system, BlinkMacSystemFont
 .item-zero       { opacity: .4; }
 .item-gained     { border-left: 2px solid var(--green); background: rgba(63,185,80,.04); }
 .item-lost       { border-left: 2px solid var(--red);   background: rgba(248,81,73,.04); }
-.item-updated    { font-size: 10px; color: var(--muted); white-space: nowrap; }
 
 .item-img { width: 32px; height: 32px; object-fit: contain; flex-shrink: 0; border-radius: 4px; }
 .item-img-fallback {
@@ -564,10 +477,6 @@ svg.item-img-fallback { background: transparent; border: none; padding: 0; }
   white-space: nowrap;
 }
 .crafting-done { color: var(--green); background: rgba(63,185,80,.12); border-color: rgba(63,185,80,.3); }
-
-.item-delta { font-size: 12px; font-weight: 600; flex-shrink: 0; padding: 1px 6px; border-radius: 4px; }
-.delta-pos  { color: var(--green); background: rgba(63,185,80,.12); }
-.delta-neg  { color: var(--red);   background: rgba(248,81,73,.12); }
 
 .item-qty    { font-variant-numeric: tabular-nums; font-size: 13px; color: var(--text); min-width: 70px; text-align: right; flex-shrink: 0; }
 .qty-zero    { color: var(--muted); }
@@ -1861,49 +1770,6 @@ svg.item-img-fallback { background: transparent; border: none; padding: 0; }
 }
 .view-btn:hover { color: var(--text); background: rgba(255,255,255,.06); }
 .view-btn-active { color: var(--accent); border-color: rgba(56,139,253,.4); background: rgba(56,139,253,.08); }
-
-/* ── Inventory view modes ── */
-
-/* icons */
-.item-grid.item-grid-icons {
-  grid-template-columns: repeat(auto-fill, 76px);
-  gap: 6px;
-}
-.item-grid-icons .inv-card-icon-only {
-  width: 76px; height: 76px; padding: 6px;
-  display: flex; align-items: center; justify-content: center;
-  cursor: pointer; border-radius: 8px;
-}
-.item-grid-icons .inv-card-icon-only img,
-.item-grid-icons .inv-card-icon-only .item-img { width: 56px !important; height: 56px !important; }
-
-/* text-cards: keep grid, just no image area — handled inline */
-
-/* list + list-compact */
-.item-grid.item-grid-list,
-.item-grid.item-grid-list-compact {
-  display: flex; flex-direction: column; gap: 1px; padding: 4px 0;
-  grid-template-columns: none;
-}
-.inv-card-row {
-  display: flex; flex-direction: row; align-items: center;
-  gap: 8px; padding: 4px 12px; border-radius: 0;
-  border-bottom: 1px solid rgba(48,54,61,.35);
-  min-height: 30px;
-}
-.inv-fav-star-row {
-  background: none; border: none; cursor: pointer;
-  font-size: 11px; color: rgba(255,255,255,.25); padding: 0; flex-shrink: 0;
-  line-height: 1; transition: color .1s;
-}
-.inv-fav-star-row:hover { color: rgba(240,192,64,.8); }
-.inv-fav-star-row.active { color: #f0c040; }
-.inv-row-icon { width: 22px; height: 22px; flex-shrink: 0; position: relative; display: flex; align-items: center; }
-.inv-row-icon img, .inv-row-icon .item-img { width: 20px !important; height: 20px !important; }
-.inv-foundry-icon-row { position: absolute; top: -4px; right: -6px; font-size: 9px; }
-.inv-row-name { flex: 1; min-width: 0; font-size: 12px; font-weight: 500; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.inv-row-cat  { width: 90px; flex-shrink: 0; font-size: 10px; color: var(--muted); text-align: right; text-transform: uppercase; letter-spacing: .03em; }
-.inv-row-qty  { width: 60px; flex-shrink: 0; text-align: right; font-size: 13px; font-weight: 700; color: var(--text); display: flex; align-items: center; justify-content: flex-end; gap: 4px; }
 
 /* ── Foundry view modes ── */
 

--- a/src/App.css
+++ b/src/App.css
@@ -1749,21 +1749,6 @@ html, body, #root { height: 100%; font-family: -apple-system, BlinkMacSystemFont
 .wfm-auction-topbid { color: var(--accent); }
 .wfm-auction-bidder { color: var(--text); }
 
-/* ══════════════════════════════════════════════════════
-   VIEW TOGGLE — shared across Inventory / Foundry / Relics
-   ══════════════════════════════════════════════════════ */
-
-.view-toggle { display: flex; align-items: center; gap: 2px; flex-shrink: 0; }
-.view-btn {
-  background: none; border: 1px solid transparent; border-radius: 4px;
-  cursor: pointer; color: var(--muted); padding: 3px 5px;
-  display: flex; align-items: center; justify-content: center;
-  transition: color .12s, border-color .12s, background .12s;
-  line-height: 0;
-}
-.view-btn:hover { color: var(--text); background: rgba(255,255,255,.06); }
-.view-btn-active { color: var(--accent); border-color: rgba(56,139,253,.4); background: rgba(56,139,253,.08); }
-
 /* ── Foundry view modes ── */
 
 /* icons */

--- a/src/App.css
+++ b/src/App.css
@@ -448,7 +448,8 @@ html, body, #root { height: 100%; font-family: -apple-system, BlinkMacSystemFont
 .item-gained     { border-left: 2px solid var(--green); background: rgba(63,185,80,.04); }
 .item-lost       { border-left: 2px solid var(--red);   background: rgba(248,81,73,.04); }
 
-.item-img { width: 32px; height: 32px; object-fit: contain; flex-shrink: 0; border-radius: 4px; }
+.item-img { width: 32px; height: 32px; object-fit: contain; flex-shrink: 0; border-radius: 4px; opacity: 0; transform: translate(-4px, -4px) scale(0.9); transition: opacity 0.25s ease-out, transform 0.25s ease-out; }
+.item-img.img-loaded { opacity: 1; transform: translate(0, 0) scale(1); }
 .item-img-fallback {
   width: 32px; height: 32px; flex-shrink: 0; border-radius: 4px;
   background: rgba(255,255,255,.06); border: 1px solid var(--border);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,6 +87,7 @@ import { type ViewMode, ViewToggle } from "./ViewToggle";
 import SearchBar from "./SearchBar";
 import { HelpTip } from "./HelpTip";
 import "./App.css";
+import "./images.css";
 import "./InventoryGrid.css";
 
 const _winLabel = getCurrentWindow().label;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,9 +84,9 @@ import ModularWindow from "./ModularWindow";
 import ChangeLog, { type ChangeLogEntry } from "./ChangeLog";
 import InventoryGrid from "./InventoryGrid";
 import InventoryBatchPreview from "./InventoryBatchPreview";
-import { type ViewMode, ViewToggle } from "./ViewToggle";
-import SearchBar from "./SearchBar";
-import { HelpTip } from "./HelpTip";
+import InventoryToolbar from "./InventoryToolbar";
+import { INVENTORY_FILTERS_DEFAULT, type InventoryFilters } from "./InventoryFilters";
+import type { ViewMode } from "./ViewToggle";
 import "./App.css";
 import "./images.css";
 import "./InventoryGrid.css";
@@ -537,20 +537,21 @@ const [blobLogEnabled, setBlobLogEnabled] = useState(false);
   const inventoryReadyRef = useRef(false);
   const [changeLogExpanded, setChangeLogExpanded] = useState(false);
   const [changeLogHeight, setChangeLogHeight] = useState(270);
-  const [category, setCategory] = useState("all");
-  const [search, setSearch] = useState("");
-  const [filterOwned,    setFilterOwned]    = useState(false);
-  const [filterRecent,   setFilterRecent]   = useState(false);
-  const [filterPrime,    setFilterPrime]    = useState(false);
-  const [filterVaulted,  setFilterVaulted]  = useState(false);
-  const [filterUnvaulted,setFilterUnvaulted]= useState(false);
-  const [sortMode, setSortMode] = useState<"qty-desc" | "qty-asc" | "name-asc" | "name-desc" | "recent">("qty-desc");
+  const [inventoryFilters, setInventoryFilters] = useState<InventoryFilters>(INVENTORY_FILTERS_DEFAULT);
+  const { category, search, filterOwned, filterRecent, filterPrime, filterVaulted, filterUnvaulted, filterRank, sortMode } = inventoryFilters;
   const prevSortRef = useRef(sortMode);
   useEffect(() => { if (sortMode !== "recent") prevSortRef.current = sortMode; }, [sortMode]);
-  const [filterRank, setFilterRank] = useState<number | "unranked" | null>(null);
+  const toggleInventoryRecent = useCallback(() => setInventoryFilters(previous => {
+    const filterRecent = !previous.filterRecent;
+    return { ...previous, filterRecent, sortMode: filterRecent ? "recent" : prevSortRef.current };
+  }), []);
   const [inventoryView, setInventoryView] = useState<ViewMode>(() =>
     (localStorage.getItem("ff-view-inventory") as ViewMode | null) ?? "cards"
   );
+  const setInventoryViewPreference = useCallback((view: ViewMode) => {
+    setInventoryView(view);
+    localStorage.setItem("ff-view-inventory", view);
+  }, []);
 
   // ── Per-tab persisted filter state ────────────────────────────────────────
   const [foundryFilters, setFoundryFilters] = useState<FoundryFilters>(FOUNDRY_FILTERS_DEFAULT);
@@ -1841,7 +1842,7 @@ if (typeof s.autoDiagEnabled === "boolean") {
       return b.qty - a.qty || a.name.localeCompare(b.name);
     });
     return out.slice(0, 1000);
-  }, [catalog, inventory, category, search, filterOwned, filterRecent, filterPrime, filterVaulted, filterUnvaulted, filterRank, sortMode, lastChanged, modCopiesMap, changeLog]); // eslint-disable-line
+  }, [catalog, inventory, inventoryFilters, lastChanged, modCopiesMap, changeLog]);
 
   const resetInventoryFilters = ({
     recent,
@@ -1853,14 +1854,13 @@ if (typeof s.autoDiagEnabled === "boolean") {
     categoryId?: string;
   }) => {
     setActiveModule("inventory");
-    setCategory(categoryId);
-    setSearch(searchTerm);
-    setFilterOwned(false);
-    setFilterRecent(recent);
-    setFilterPrime(false);
-    setFilterVaulted(false);
-    setFilterUnvaulted(false);
-    setFilterRank(null);
+    setInventoryFilters(previous => ({
+      ...INVENTORY_FILTERS_DEFAULT,
+      category: categoryId,
+      search: searchTerm,
+      filterRecent: recent,
+      sortMode: recent ? "recent" : previous.sortMode,
+    }));
   };
 
   // Navigate to an item from the changelog — only switches module and sets search,
@@ -1868,11 +1868,22 @@ if (typeof s.autoDiagEnabled === "boolean") {
   const openChangeLogItem = (uniqueName: string) => {
     const item = catalog.find(candidate => candidate.unique_name === uniqueName);
     setActiveModule("inventory");
-    setSearch(item?.name ?? "");
+    setInventoryFilters(previous => ({ ...previous, search: item?.name ?? "" }));
   };
 
   const openRecentChanges = () => resetInventoryFilters({ recent: true });
   const openRecentCategory = (categoryId: string) => resetInventoryFilters({ recent: true, categoryId });
+  const closeInventoryBatchPreview = useCallback(() => setShowInventoryBatchPreview(false), []);
+  const handleInventoryContextMenu = useCallback((e: React.MouseEvent) => {
+    const name = extractItemName(e);
+    if (name) {
+      e.preventDefault();
+      openCtx(e.clientX, e.clientY, [
+        { label: "Open Wiki", action: () => openWiki(name) },
+        { label: "Copy Wiki Link", action: () => copyWikiLink(name) },
+      ]);
+    }
+  }, [openCtx]);
 
   // ─── Render ─────────────────────────────────────────────────────────────────
 
@@ -2580,7 +2591,7 @@ if (typeof s.autoDiagEnabled === "boolean") {
                         <span className="settings-row-label">Incoming Batch</span>
                         <span className="settings-row-desc">Preview gained, lost, crafting, and mod rank changes without modifying your inventory.</span>
                       </div>
-                      <button className="btn-secondary" onClick={() => { setShowInventoryBatchPreview(true); setShowSettings(false); }}>Preview</button>
+                      <button className="btn-secondary" onClick={() => setShowInventoryBatchPreview(true)}>Preview</button>
                     </div>
                   </div>
 
@@ -2852,7 +2863,7 @@ if (typeof s.autoDiagEnabled === "boolean") {
         </div>
       )}
 
-      {showInventoryBatchPreview && <InventoryBatchPreview onClose={() => setShowInventoryBatchPreview(false)} />}
+      {showInventoryBatchPreview && <InventoryBatchPreview onClose={closeInventoryBatchPreview} />}
 
       <div className="body">
 
@@ -2938,7 +2949,7 @@ if (typeof s.autoDiagEnabled === "boolean") {
                   <button
                     key={cat.id}
                     className={`cat-btn ${category === cat.id ? "cat-active" : ""}`}
-                    onClick={() => setCategory(cat.id)}
+                    onClick={() => setInventoryFilters(previous => ({ ...previous, category: cat.id }))}
                   >
                     <span className="cat-label">{cat.label}</span>
                     <span className="cat-count">
@@ -2965,43 +2976,16 @@ if (typeof s.autoDiagEnabled === "boolean") {
                 </div>
               )}
 
-              <div className="toolbar">
-                <SearchBar
-                  placeholder="Search items…"
-                  value={search}
-                  onChange={setSearch}
-                />
-              </div>
-              <div className="filter-bar">
-                <button className={`fchip ${filterOwned?"fchip-on":""}`} onClick={()=>setFilterOwned(v=>!v)}>Owned</button>
-                <button className={`fchip ${filterRecent?"fchip-on":""}`} onClick={()=>setFilterRecent(v=>{ const next = !v; if (next) { setSortMode("recent"); } else { setSortMode(prevSortRef.current); } return next; })}>Changed recently</button>
-                <button className={`fchip ${filterPrime?"fchip-on":""}`} onClick={()=>setFilterPrime(v=>!v)}>Prime</button>
-                <button className={`fchip ${filterVaulted?"fchip-on":""}`} onClick={()=>setFilterVaulted(v=>!v)}>🔒 Vaulted</button>
-                <button className={`fchip ${filterUnvaulted?"fchip-on":""}`} onClick={()=>setFilterUnvaulted(v=>!v)}>🔓 Unvaulted</button>
-                {apiModCopies.length > 0 && (<>
-                  <span className="fbar-sep"/>
-                  <span className="fbar-label">Rank:</span>
-                  <button className={`fchip ${filterRank==="unranked"?"fchip-on":""}`} onClick={()=>setFilterRank(v=>v==="unranked"?null:"unranked")}>Unranked</button>
-                  {availableRanks.map(r=>(
-                    <button key={r} className={`fchip ${filterRank===r?"fchip-on":""}`} onClick={()=>setFilterRank(v=>v===r?null:r)}>R{r}</button>
-                  ))}
-                </>)}
-                <span className="fbar-sep"/>
-                <span className="fbar-label">Sort:</span>
-                <button className={`fchip ${sortMode==="qty-desc"?"fchip-on":""}`} onClick={()=>setSortMode("qty-desc")}>Qty ↓</button>
-                <button className={`fchip ${sortMode==="qty-asc"?"fchip-on":""}`} onClick={()=>setSortMode("qty-asc")}>Qty ↑</button>
-                <button className={`fchip ${sortMode==="name-asc"?"fchip-on":""}`} onClick={()=>setSortMode("name-asc")}>A-Z</button>
-                <button className={`fchip ${sortMode==="name-desc"?"fchip-on":""}`} onClick={()=>setSortMode("name-desc")}>Z-A</button>
-                <span className="item-count-label" style={{marginLeft:"auto"}}>{visibleItems.length} item{visibleItems.length!==1?"s":""}{visibleItems.length===1000?" (capped)":""}</span>
-                <ViewToggle view={inventoryView} onChange={v => { setInventoryView(v); localStorage.setItem("ff-view-inventory", v); }} />
-                <HelpTip items={[
-                  { icon: "★",  label: "★  Mastered",  desc: "Shown above image — item levelled to rank 30" },
-                  { icon: "R5", label: "R{n}  Rank",   desc: "Shown above image — current rank, not yet mastered" },
-                  { icon: "⚒",  label: "⚒  Building",  desc: "Shown on image — currently crafting in Foundry" },
-                  { swatch: "rgba(63,185,80,.5)",  label: "Green border", desc: "Item recently gained" },
-                  { swatch: "rgba(248,81,73,.5)",  label: "Red border",   desc: "Item recently lost or consumed" },
-                ]} />
-              </div>
+              <InventoryToolbar
+                filters={inventoryFilters}
+                onFiltersChange={setInventoryFilters}
+                onToggleRecent={toggleInventoryRecent}
+                availableRanks={availableRanks}
+                showRankFilters={apiModCopies.length > 0}
+                itemCount={visibleItems.length}
+                view={inventoryView}
+                onViewChange={setInventoryViewPreference}
+              />
 
               <InventoryGrid
                 items={visibleItems}
@@ -3016,13 +3000,7 @@ if (typeof s.autoDiagEnabled === "boolean") {
                 crafting={craftingMap}
                 filterRank={filterRank}
                 onToggleFavorite={toggleFavorite}
-                onContextMenu={e => {
-                  const name = extractItemName(e);
-                  if (name) { e.preventDefault(); openCtx(e.clientX, e.clientY, [
-                    { label: "Open Wiki", action: () => openWiki(name) },
-                    { label: "Copy Wiki Link", action: () => copyWikiLink(name) },
-                  ]); }
-                }}
+                onContextMenu={handleInventoryContextMenu}
               />
 
             </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -532,6 +532,8 @@ const [blobLogEnabled, setBlobLogEnabled] = useState(false);
   const [changeLog, setChangeLog] = useState<ChangeLogEntry[]>([]);
   const [changeLogArrivalToken, setChangeLogArrivalToken] = useState(0);
   const [lastInventoryScanAt, setLastInventoryScanAt] = useState<number | null>(null);
+  const [inventoryReady, setInventoryReady] = useState(false);
+  const inventoryReadyRef = useRef(false);
   const [changeLogExpanded, setChangeLogExpanded] = useState(false);
   const [changeLogHeight, setChangeLogHeight] = useState(270);
   const [category, setCategory] = useState("all");
@@ -869,6 +871,10 @@ if (typeof s.autoDiagEnabled === "boolean") {
     const unlisten = listen<InventoryUpdate>("inventory-update", (e) => {
       const p = e.payload;
       setLastInventoryScanAt(p.scanned_at);
+      if (!inventoryReadyRef.current) {
+        inventoryReadyRef.current = true;
+        setInventoryReady(true);
+      }
       // Only replace quantities if the content actually changed.
       // The monitor loop re-emits cached state periodically; without this guard
       // every emit triggers a full 17k-item useMemo rebuild cascade.
@@ -2966,7 +2972,7 @@ if (typeof s.autoDiagEnabled === "boolean") {
 
               <InventoryGrid
                 items={visibleItems}
-                loading={false}
+                loading={!inventoryReady}
                 monitoring={monitoring}
                 view={inventoryView}
                 inventory={inventory}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-﻿import { useState, useEffect, useMemo, useCallback, useRef, memo, Component, ReactNode } from "react";
+﻿import { useState, useEffect, useMemo, useCallback, useRef, Component, ReactNode } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { getVersion } from "@tauri-apps/api/app";
 import { listen } from "@tauri-apps/api/event";
@@ -82,10 +82,12 @@ import Weapons from "./Weapons";
 import Overlay from "./Overlay";
 import ModularWindow from "./ModularWindow";
 import ChangeLog, { type ChangeLogEntry } from "./ChangeLog";
-import ItemImg from "./ItemImg";
+import InventoryGrid from "./InventoryGrid";
+import { type ViewMode, ViewToggle } from "./ViewToggle";
 import SearchBar from "./SearchBar";
 import { HelpTip } from "./HelpTip";
 import "./App.css";
+import "./InventoryGrid.css";
 
 const _winLabel = getCurrentWindow().label;
 // Support all URL formats: query string (?overlay), hash (#overlay), or window label.
@@ -202,14 +204,11 @@ const CATEGORIES = [
   { id: "Railjack",   label: "Railjack" },
 ];
 
-function fmt(n: number) { return n.toLocaleString(); }
 function fmtBytes(n: number) {
   if (n >= 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
   if (n >= 1024)        return `${Math.round(n / 1024)} KB`;
   return `${n} B`;
 }
-function deltaClass(d: number) { return d > 0 ? "delta-pos" : "delta-neg"; }
-function deltaText(d: number) { return d > 0 ? `+${fmt(d)}` : fmt(d); }
 function timeStr(ts: number, format: "auto" | "12h" | "24h" = "auto", locale = "en-US") {
   const opts: Intl.DateTimeFormatOptions = { hour: "2-digit", minute: "2-digit" };
   if (format === "12h") opts.hour12 = true;
@@ -382,252 +381,6 @@ function ModularWindowPage() {
   );
 }
 
-
-// ─── View mode ───────────────────────────────────────────────────────────────
-
-export type ViewMode = "cards" | "icons" | "text-cards" | "list" | "list-compact";
-
-const VIEW_LABELS: Record<ViewMode, string> = {
-  "cards":        "Cards (icon + text)",
-  "icons":        "Icon grid",
-  "text-cards":   "Text cards (no icons)",
-  "list":         "List with icon",
-  "list-compact": "Compact list (text only)",
-};
-
-function ViewIcon({ mode }: { mode: ViewMode }) {
-  switch (mode) {
-    case "cards": return (
-      <svg width="16" height="13" viewBox="0 0 16 13" fill="currentColor">
-        <rect x="0" y="0" width="3" height="3" rx="0.5"/><rect x="4" y="0.5" width="3.5" height="1.5" rx="0.4"/>
-        <rect x="9" y="0" width="3" height="3" rx="0.5"/><rect x="13" y="0.5" width="3" height="1.5" rx="0.4"/>
-        <rect x="0" y="5" width="3" height="3" rx="0.5"/><rect x="4" y="5.5" width="3.5" height="1.5" rx="0.4"/>
-        <rect x="9" y="5" width="3" height="3" rx="0.5"/><rect x="13" y="5.5" width="3" height="1.5" rx="0.4"/>
-        <rect x="0" y="10" width="3" height="3" rx="0.5"/><rect x="4" y="10.5" width="3.5" height="1.5" rx="0.4"/>
-        <rect x="9" y="10" width="3" height="3" rx="0.5"/><rect x="13" y="10.5" width="3" height="1.5" rx="0.4"/>
-      </svg>
-    );
-    case "icons": return (
-      <svg width="16" height="13" viewBox="0 0 16 13" fill="currentColor">
-        <rect x="0" y="0" width="4" height="4" rx="0.5"/><rect x="6" y="0" width="4" height="4" rx="0.5"/><rect x="12" y="0" width="4" height="4" rx="0.5"/>
-        <rect x="0" y="5" width="4" height="4" rx="0.5"/><rect x="6" y="5" width="4" height="4" rx="0.5"/><rect x="12" y="5" width="4" height="4" rx="0.5"/>
-        <rect x="0" y="10" width="4" height="4" rx="0.5"/><rect x="6" y="10" width="4" height="4" rx="0.5"/><rect x="12" y="10" width="4" height="4" rx="0.5"/>
-      </svg>
-    );
-    case "text-cards": return (
-      <svg width="16" height="13" viewBox="0 0 16 13" fill="currentColor">
-        <rect x="0" y="0" width="7" height="1.5" rx="0.4"/><rect x="0" y="2.5" width="5" height="1" rx="0.4"/>
-        <rect x="9" y="0" width="7" height="1.5" rx="0.4"/><rect x="9" y="2.5" width="5" height="1" rx="0.4"/>
-        <rect x="0" y="5" width="7" height="1.5" rx="0.4"/><rect x="0" y="7.5" width="5" height="1" rx="0.4"/>
-        <rect x="9" y="5" width="7" height="1.5" rx="0.4"/><rect x="9" y="7.5" width="5" height="1" rx="0.4"/>
-        <rect x="0" y="10" width="7" height="1.5" rx="0.4"/><rect x="0" y="12" width="5" height="1" rx="0.4"/>
-        <rect x="9" y="10" width="7" height="1.5" rx="0.4"/><rect x="9" y="12" width="5" height="1" rx="0.4"/>
-      </svg>
-    );
-    case "list": return (
-      <svg width="16" height="13" viewBox="0 0 16 13" fill="currentColor">
-        <rect x="0" y="0" width="2.5" height="2.5" rx="0.4"/><rect x="4" y="0.5" width="12" height="1.5" rx="0.4"/>
-        <rect x="0" y="3.5" width="2.5" height="2.5" rx="0.4"/><rect x="4" y="4" width="12" height="1.5" rx="0.4"/>
-        <rect x="0" y="7" width="2.5" height="2.5" rx="0.4"/><rect x="4" y="7.5" width="12" height="1.5" rx="0.4"/>
-        <rect x="0" y="10.5" width="2.5" height="2.5" rx="0.4"/><rect x="4" y="11" width="12" height="1.5" rx="0.4"/>
-      </svg>
-    );
-    case "list-compact": return (
-      <svg width="16" height="13" viewBox="0 0 16 13" fill="currentColor">
-        <rect x="0" y="0" width="16" height="1.5" rx="0.4"/>
-        <rect x="0" y="2.5" width="11" height="1.5" rx="0.4"/>
-        <rect x="0" y="5" width="16" height="1.5" rx="0.4"/>
-        <rect x="0" y="7.5" width="13" height="1.5" rx="0.4"/>
-        <rect x="0" y="10" width="16" height="1.5" rx="0.4"/>
-        <rect x="0" y="12" width="10" height="1" rx="0.4"/>
-      </svg>
-    );
-  }
-}
-
-export function ViewToggle({ view, onChange }: { view: ViewMode; onChange: (v: ViewMode) => void }) {
-  const modes: ViewMode[] = ["cards", "icons", "text-cards", "list", "list-compact"];
-  return (
-    <div className="view-toggle">
-      {modes.map(m => (
-        <button key={m} className={`view-btn${view === m ? " view-btn-active" : ""}`}
-          title={VIEW_LABELS[m]} onClick={() => onChange(m)}>
-          <ViewIcon mode={m} />
-        </button>
-      ))}
-    </div>
-  );
-}
-
-// ─── Memoized inventory card components ──────────────────────────────────────
-
-interface InvModCardProps {
-  unique_name: string;
-  name: string;
-  category: string;
-  image_name?: string | null;
-  ranks: { rank: number; count: number }[];
-  total: number;
-  view: ViewMode;
-}
-const InvModCard = memo(function InvModCard({ unique_name, name, category, image_name, ranks, total, view }: InvModCardProps) {
-  if (view === "icons") {
-    return (
-      <div key={unique_name} className="inv-card inv-card-icon-only" title={`${name} ×${fmt(total)}`}>
-        <ItemImg imageName={image_name ?? undefined} category={category} size={52} />
-      </div>
-    );
-  }
-  if (view === "list" || view === "list-compact") {
-    return (
-      <div key={unique_name} className="inv-card inv-card-row">
-        {view === "list" && <div className="inv-row-icon"><ItemImg imageName={image_name ?? undefined} category={category} size={20} /></div>}
-        <div className="inv-row-name">{name}</div>
-        <div className="inv-row-cat">{category}</div>
-        <div className="inv-row-qty">{fmt(total)}</div>
-      </div>
-    );
-  }
-  return (
-    <div key={unique_name} className="inv-card inv-card-mod">
-      {view !== "text-cards" && (
-        <div className="inv-card-img-wrap">
-          <ItemImg imageName={image_name ?? undefined} category={category} size={40} />
-        </div>
-      )}
-      <div className="inv-card-name">{name}</div>
-      <div className="inv-card-cat">{category}</div>
-      <div className="mod-rank-table">
-        {ranks.map(r => (
-          <div key={r.rank} className={`mod-rank-row${r.count === 0 ? " mod-rank-zero" : ""}`}>
-            <span className="mod-rank-label">R{r.rank}</span>
-            <span className="mod-rank-count">{r.count}</span>
-          </div>
-        ))}
-      </div>
-      <div className="inv-card-qty mod-total">{fmt(total)}</div>
-    </div>
-  );
-}, (prev, next) =>
-  prev.view === next.view &&
-  prev.unique_name === next.unique_name &&
-  prev.name === next.name &&
-  prev.total === next.total &&
-  prev.image_name === next.image_name &&
-  prev.ranks.length === next.ranks.length &&
-  prev.ranks.every((r, i) => r.rank === next.ranks[i].rank && r.count === next.ranks[i].count)
-);
-
-interface InvCardProps {
-  unique_name: string;
-  name: string;
-  category: string;
-  image_name?: string | null;
-  qty: number;
-  isFavorite: boolean;
-  changedAt: number | undefined;
-  recentDelta: number | null;
-  craftJobName: string | null;
-  masteryRank: number | undefined;
-  onToggleFavorite: (id: string) => void;
-  view: ViewMode;
-}
-const InvCard = memo(function InvCard({
-  unique_name, name, category, image_name, qty,
-  isFavorite, changedAt, recentDelta, craftJobName, masteryRank, onToggleFavorite, view,
-}: InvCardProps) {
-  const nowSec = Date.now() / 1000;
-  const secAgo = changedAt != null ? nowSec - changedAt : null;
-  const isRecent = secAgo !== null && secAgo < 300;
-  const isZero = qty === 0 && !craftJobName;
-  const isMastered = masteryRank != null && masteryRank >= 30;
-  const showRank = masteryRank != null && masteryRank > 0;
-  const recentLabel = secAgo !== null ? (Math.floor(secAgo / 60) === 0 ? "· now" : `· ${Math.floor(secAgo / 60)}m`) : null;
-  const baseClass = `inv-card${isZero ? " inv-card-zero" : ""}${isRecent ? (recentDelta != null && recentDelta > 0 ? " inv-card-gained" : " inv-card-lost") : ""}`;
-
-  if (view === "icons") {
-    return (
-      <div className={`${baseClass} inv-card-icon-only`} title={`${name} (${fmt(qty)})`}>
-        <ItemImg imageName={image_name ?? undefined} category={category} size={52} />
-      </div>
-    );
-  }
-  if (view === "list" || view === "list-compact") {
-    return (
-      <div className={`${baseClass} inv-card-row`}>
-        <button className={`inv-fav-star-row ${isFavorite ? "active" : ""}`}
-          title={isFavorite ? "Remove from Modular Window" : "Add to Modular Window"}
-          onClick={e => { e.stopPropagation(); onToggleFavorite(unique_name); }}>
-          {isFavorite ? "★" : "☆"}
-        </button>
-        {view === "list" && (
-          <div className="inv-row-icon">
-            <ItemImg imageName={image_name ?? undefined} category={category} size={20} />
-            {craftJobName && <span className="inv-foundry-icon-row" title={`Building — ${craftJobName}`}>⚒</span>}
-          </div>
-        )}
-        <div className="inv-row-name">
-          {name}
-          {isRecent && <span className="item-updated">{recentLabel}</span>}
-        </div>
-        <div className="inv-row-cat">{category}</div>
-        <div className="inv-row-qty">
-          {fmt(qty)}
-          {isRecent && recentDelta != null && <span className={`item-delta ${deltaClass(recentDelta)}`}>{deltaText(recentDelta)}</span>}
-        </div>
-      </div>
-    );
-  }
-  return (
-    <div className={baseClass}>
-      <button
-        className={`inv-fav-star ${isFavorite ? "active" : ""}`}
-        title={isFavorite ? "Remove from Modular Window" : "Add to Modular Window"}
-        onClick={e => { e.stopPropagation(); onToggleFavorite(unique_name); }}
-      >{isFavorite ? "★" : "☆"}</button>
-      <div className="inv-mastery-row">
-        {isMastered
-          ? <span className="inv-mastery-star" title="Mastered">★</span>
-          : showRank
-            ? <span className="inv-mastery-rank" title={`Rank ${masteryRank}`}>R{masteryRank}</span>
-            : null}
-      </div>
-      {view !== "text-cards" && (
-        <div className="inv-card-img-wrap">
-          <ItemImg imageName={image_name ?? undefined} category={category} size={48} />
-          {craftJobName && <span className="inv-foundry-icon" title={`Building — ${craftJobName}`}>⚒</span>}
-        </div>
-      )}
-      <div className="inv-card-name">
-        {name}
-        {isRecent && <span className="item-updated">{recentLabel}</span>}
-      </div>
-      <div className="inv-card-cat">{category}</div>
-      <div className={`inv-card-qty ${isZero ? "inv-card-qty-zero" : ""}`}>
-        {fmt(qty)}
-        {isRecent && recentDelta != null && (
-          <span className={`item-delta ${deltaClass(recentDelta)}`}>{deltaText(recentDelta)}</span>
-        )}
-      </div>
-    </div>
-  );
-}, (prev, next) => {
-  if (prev.view !== next.view) return false;
-  if (
-    prev.unique_name !== next.unique_name ||
-    prev.qty !== next.qty ||
-    prev.isFavorite !== next.isFavorite ||
-    prev.image_name !== next.image_name ||
-    prev.masteryRank !== next.masteryRank ||
-    prev.craftJobName !== next.craftJobName ||
-    prev.recentDelta !== next.recentDelta ||
-    prev.changedAt !== next.changedAt
-  ) return false;
-  // Recently-changed items must re-render so elapsed time stays fresh
-  const nowSec = Date.now() / 1000;
-  if (prev.changedAt != null && nowSec - prev.changedAt < 300) return false;
-  return true;
-});
 
 // Feature 3 — api.warframe.com/api/inventory.php
 // DE confirmed third-party tools are used "at your own risk" but could not clarify
@@ -3209,62 +2962,27 @@ if (typeof s.autoDiagEnabled === "boolean") {
                 ]} />
               </div>
 
-              <div className={`item-grid item-grid-${inventoryView}`}
-                   onContextMenu={e => {
-                     const name = extractItemName(e);
-                     if (name) { e.preventDefault(); openCtx(e.clientX, e.clientY, [
-                       { label: "Open Wiki", action: () => openWiki(name) },
-                       { label: "Copy Wiki Link", action: () => copyWikiLink(name) },
-                     ]); }
-                   }}>
-                {visibleItems.length === 0 ? (
-                  <div className="empty-msg" style={{gridColumn:"1/-1"}}>
-                    {monitoring
-                      ? "No items found. Complete a mission or visit a relay to sync inventory."
-                      : "Start the monitor to begin tracking your inventory."}
-                  </div>
-                ) : (
-                  visibleItems.flatMap(item => {
-                    // Mods & Arcanes: single card with inline rank breakdown
-                    if ((item.category === "Mods" || item.category === "Arcanes") && modCopiesMap[item.unique_name]) {
-                      const copies = modCopiesMap[item.unique_name];
-                      const byRank: Record<number, number> = {};
-                      for (const c of copies) byRank[c.rank ?? 0] = (byRank[c.rank ?? 0] ?? 0) + c.count;
-                      const maxRank = Math.max(...Object.keys(byRank).map(Number));
-                      const ranks = Array.from({ length: maxRank + 1 }, (_, r) => ({ rank: r, count: byRank[r] ?? 0 })).filter(r => r.count > 0);
-                      if (filterRank !== null) {
-                        const targetRank = filterRank === "unranked" ? 0 : filterRank as number;
-                        if ((byRank[targetRank] ?? 0) === 0) return [];
-                      }
-                      const total = Object.values(byRank).reduce((a, b) => a + b, 0);
-                      return [(
-                        <InvModCard key={item.unique_name}
-                          unique_name={item.unique_name} name={item.name}
-                          category={item.category} image_name={item.image_name}
-                          ranks={ranks} total={total} view={inventoryView} />
-                      )];
-                    }
-
-                    // Normal item card
-                    const changedAt = lastChanged[item.unique_name];
-                    const recentChange = changedAt != null ? changeLogMap.get(item.unique_name) : undefined;
-                    const craftJob = craftingMap.get(item.unique_name);
-                    return [(
-                      <InvCard key={item.unique_name}
-                        unique_name={item.unique_name} name={item.name}
-                        category={item.category} image_name={item.image_name}
-                        qty={item.qty}
-                        isFavorite={favoritesSet.has(item.unique_name)}
-                        changedAt={changedAt}
-                        recentDelta={recentChange?.delta ?? null}
-                        craftJobName={craftJob?.item_name ?? null}
-                        masteryRank={inventory[item.unique_name]?.mastery_rank}
-                        onToggleFavorite={toggleFavorite}
-                        view={inventoryView} />
-                    )];
-                  })
-                )}
-              </div>
+              <InventoryGrid
+                items={visibleItems}
+                loading={false}
+                monitoring={monitoring}
+                view={inventoryView}
+                inventory={inventory}
+                modCopies={modCopiesMap}
+                favorites={favoritesSet}
+                lastChanged={lastChanged}
+                changes={changeLogMap}
+                crafting={craftingMap}
+                filterRank={filterRank}
+                onToggleFavorite={toggleFavorite}
+                onContextMenu={e => {
+                  const name = extractItemName(e);
+                  if (name) { e.preventDefault(); openCtx(e.clientX, e.clientY, [
+                    { label: "Open Wiki", action: () => openWiki(name) },
+                    { label: "Copy Wiki Link", action: () => copyWikiLink(name) },
+                  ]); }
+                }}
+              />
 
             </div>
           </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1767,9 +1767,11 @@ if (typeof s.autoDiagEnabled === "boolean") {
   const favoritesSet = useMemo(() => new Set(favorites), [favorites]);
 
   const changeLogMap = useMemo(() => {
-    const m = new Map<string, ChangeLogEntry>();
+    const m = new Map<string, ChangeLogEntry[]>();
     for (const c of changeLog) {
-      if (!m.has(c.unique_name)) m.set(c.unique_name, c);
+      const arr = m.get(c.unique_name);
+      if (arr) arr.push(c);
+      else m.set(c.unique_name, [c]);
     }
     return m;
   }, [changeLog]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1809,7 +1809,7 @@ if (typeof s.autoDiagEnabled === "boolean") {
       out.push({ ...i, qty });
     }
     out.sort((a, b) => {
-      if (sortMode === "recent") {
+      if (sortMode === "recent" || filterRecent) {
         const at = lastChanged[a.unique_name] ?? 0;
         const bt = lastChanged[b.unique_name] ?? 0;
         return bt - at || a.name.localeCompare(b.name);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -711,6 +711,7 @@ const [blobLogEnabled, setBlobLogEnabled] = useState(false);
     // Fire-and-forget: populates WFM_TOP_CACHE so the Statistics tab is instant
     invoke("get_wfm_top_items").catch(() => {});
     invoke<string>("get_img_cache_dir").then(setImgCacheDir).catch(() => {});
+    invoke("prewarm_image_cache").catch(() => {});
   }, []); // eslint-disable-line
 
   // ── WFM: intercept window close to go invisible first ─────────────────────

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,6 +83,7 @@ import Overlay from "./Overlay";
 import ModularWindow from "./ModularWindow";
 import ChangeLog, { type ChangeLogEntry } from "./ChangeLog";
 import InventoryGrid from "./InventoryGrid";
+import InventoryBatchPreview from "./InventoryBatchPreview";
 import { type ViewMode, ViewToggle } from "./ViewToggle";
 import SearchBar from "./SearchBar";
 import { HelpTip } from "./HelpTip";
@@ -591,6 +592,7 @@ const [blobLogEnabled, setBlobLogEnabled] = useState(false);
   const [rawScanSize,    setRawScanSize]    = useState(0);
   const [probeSize,      setProbeSize]      = useState(0);
   const [debugCatEnabled,    setDebugCatEnabled]    = useState(false);
+  const [showInventoryBatchPreview, setShowInventoryBatchPreview] = useState(false);
   const [unmatchedPathsSize, setUnmatchedPathsSize] = useState(0);
   // "scanning" while blob capture is running, "done" briefly after it finishes
   const [blobStage, setBlobStage] = useState<"scanning" | "done" | null>(null);
@@ -828,8 +830,17 @@ if (typeof s.autoDiagEnabled === "boolean") {
     }).catch(() => {});
 
     invoke<string>("get_system_locale").then(loc => { if (loc) setSystemLocale(loc); }).catch(() => {});
+    invoke<string | null>("get_player_name").then(name => { if (name) setPlayerName(name); }).catch(() => {});
     invoke<CatalogItem[]>("get_all_items").then(items => { setCatalog(items); catalogRef.current = items; });
-    invoke<Record<string, number>>("get_current_quantities").then(setQuantities);
+    invoke<Record<string, number>>("get_current_quantities")
+      .then(setQuantities)
+      .catch(() => {})
+      .finally(() => {
+        if (!inventoryReadyRef.current) {
+          inventoryReadyRef.current = true;
+          setInventoryReady(true);
+        }
+      });
     invoke<number>("get_diag_folder_size").then(setDiagFolderSize).catch(() => {});
     invoke<ChangeLogEntry[]>("get_change_log", { limit: 200 }).then(log => {
       setChangeLog(log);
@@ -1784,6 +1795,9 @@ if (typeof s.autoDiagEnabled === "boolean") {
 
   const visibleItems = useMemo(() => {
     const q = search.toLowerCase();
+    // Changelog order map: lower index = more recent position in changelog
+    const changeOrder = new Map<string, number>();
+    changeLog.forEach((c, i) => { if (!changeOrder.has(c.unique_name)) changeOrder.set(c.unique_name, i); });
     const out: (CatalogItem & { qty: number })[] = [];
     for (const i of catalog) {
       if (i.name === "Blueprint") continue;
@@ -1812,7 +1826,11 @@ if (typeof s.autoDiagEnabled === "boolean") {
       if (sortMode === "recent" || filterRecent) {
         const at = lastChanged[a.unique_name] ?? 0;
         const bt = lastChanged[b.unique_name] ?? 0;
-        return bt - at || a.name.localeCompare(b.name);
+        if (bt !== at) return bt - at;
+        // Tiebreak by changelog arrival order (lower index = more recent)
+        const ai = changeOrder.get(a.unique_name) ?? Infinity;
+        const bi = changeOrder.get(b.unique_name) ?? Infinity;
+        return ai - bi || a.name.localeCompare(b.name);
       }
       const aOwned = a.qty > 0 ? 1 : 0;
       const bOwned = b.qty > 0 ? 1 : 0;
@@ -1823,7 +1841,7 @@ if (typeof s.autoDiagEnabled === "boolean") {
       return b.qty - a.qty || a.name.localeCompare(b.name);
     });
     return out.slice(0, 1000);
-  }, [catalog, inventory, category, search, filterOwned, filterRecent, filterPrime, filterVaulted, filterUnvaulted, filterRank, sortMode, lastChanged, modCopiesMap]); // eslint-disable-line
+  }, [catalog, inventory, category, search, filterOwned, filterRecent, filterPrime, filterVaulted, filterUnvaulted, filterRank, sortMode, lastChanged, modCopiesMap, changeLog]); // eslint-disable-line
 
   const resetInventoryFilters = ({
     recent,
@@ -2556,6 +2574,17 @@ if (typeof s.autoDiagEnabled === "boolean") {
                   </div>
 
                   <div className="settings-section">
+                    <div className="settings-section-title">Inventory Preview</div>
+                    <div className="settings-row">
+                      <div className="settings-row-info">
+                        <span className="settings-row-label">Incoming Batch</span>
+                        <span className="settings-row-desc">Preview gained, lost, crafting, and mod rank changes without modifying your inventory.</span>
+                      </div>
+                      <button className="btn-secondary" onClick={() => { setShowInventoryBatchPreview(true); setShowSettings(false); }}>Preview</button>
+                    </div>
+                  </div>
+
+                  <div className="settings-section">
                     <div className="settings-section-title">Diagnostics</div>
                     <div className="debug-table">
 
@@ -2822,6 +2851,8 @@ if (typeof s.autoDiagEnabled === "boolean") {
           </div>
         </div>
       )}
+
+      {showInventoryBatchPreview && <InventoryBatchPreview onClose={() => setShowInventoryBatchPreview(false)} />}
 
       <div className="body">
 

--- a/src/ChangeLog.css
+++ b/src/ChangeLog.css
@@ -69,6 +69,7 @@
 .log-name-group { display: flex; align-items: center; gap: 6px; }
 .log-name-link { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; padding: 0; border: none; background: none; color: var(--text); cursor: pointer; font: inherit; text-align: left; }
 .log-name-link:hover { color: var(--accent); text-decoration: underline; }
+.log-rank-badge { font-size: 9px; font-weight: 700; color: var(--accent); background: rgba(88,166,255,.12); padding: 1px 4px; border-radius: 3px; }
 .log-cat { max-width: 100px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--muted); font-size: 9px; font-weight: 600; text-transform: uppercase; letter-spacing: .03em; }
 .log-category-link { padding: 0; border: none; background: none; cursor: pointer; font-family: inherit; }
 .log-category-link:hover, .log-category-link:focus-visible { color: var(--accent); text-decoration: underline; outline: none; }

--- a/src/ChangeLog.css
+++ b/src/ChangeLog.css
@@ -46,7 +46,7 @@
 .log-arrival-notice { display: flex; align-items: center; gap: 6px; color: var(--muted); font-size: 10px; font-weight: 600; text-transform: none; letter-spacing: 0; white-space: nowrap; animation: log-arrival-enter .18s ease-out both; }
 .log-status-divider { color: var(--muted); font-size: 11px; font-weight: 400; }
 .log-last-scan { color: var(--muted); font-size: 10px; font-weight: 400; text-transform: none; letter-spacing: 0; white-space: nowrap; }
-.log-feed { position: relative; z-index: 1; align-self: center; width: min(680px, calc(100% - 220px)); overflow: hidden; }
+.log-feed { position: relative; z-index: 1; align-self: flex-end; width: min(680px, calc(100% - 250px)); margin-right: 12px; overflow: hidden; }
 .log-feed { animation: log-feed-cycle 4.5s ease both; }
 .log-feed-row.inv-card { position: relative; border: none; background: transparent; cursor: pointer; }
 .log-feed-row.inv-card:hover { background: transparent; }
@@ -90,9 +90,12 @@
 }
 @media (max-width: 600px) {
   .log-header { padding-left: 8px; padding-right: 8px; gap: 5px; }
-  .log-feed { width: min(420px, calc(100% - 132px)); }
+  .log-feed { margin-right: 8px; }
   .log-change-qty { min-width: 0; }
   .log-range { max-width: 96px; overflow: hidden; text-overflow: ellipsis; }
+}
+@media (max-width: 480px) {
+  .log-feed { display: none; }
 }
 .log-empty { display: block; padding: 12px 16px; color: var(--muted); font-size: 12px; }
 

--- a/src/ChangeLog.css
+++ b/src/ChangeLog.css
@@ -65,7 +65,7 @@
 .log-row-arrival-wrap { display: grid; grid-template-rows: minmax(0, 0fr); overflow: hidden; opacity: 0; animation: log-row-arrive .16s ease-out both; }
 .log-row-arrival-wrap > .log-item-row { min-height: 30px; }
 .log-item-row.log-time-break { border-top: 3px solid var(--border); }
-.log-item-row svg.item-img-fallback { width: 20px; height: 20px; }
+.log-item-row svg.img-fallback { width: 20px; height: 20px; }
 .log-name-group { display: flex; align-items: center; gap: 6px; }
 .log-name-link { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; padding: 0; border: none; background: none; color: var(--text); cursor: pointer; font: inherit; text-align: left; }
 .log-name-link:hover { color: var(--accent); text-decoration: underline; }

--- a/src/ChangeLog.tsx
+++ b/src/ChangeLog.tsx
@@ -33,6 +33,7 @@ export interface ChangeLogEntry {
   new_qty: number;
   delta: number;
   timestamp: number;
+  rank?: number | null;
 }
 
 export interface ChangeLogCatalogItem {

--- a/src/ChangeLog.tsx
+++ b/src/ChangeLog.tsx
@@ -110,6 +110,7 @@ function ChangeRow({
       </div>
       <div className="inv-row-name log-name-group">
         <button className="log-name-link" onClick={e => { e.stopPropagation(); onItemClick(); }}>{name}</button>
+        {change.rank != null && <span className="log-rank-badge">R{change.rank}</span>}
         <button className="log-cat log-category-link" onClick={e => { e.stopPropagation(); onCategoryClick(category); }}>{category}</button>
       </div>
       <div className="inv-row-qty log-change-qty">

--- a/src/ChangeLog.tsx
+++ b/src/ChangeLog.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import ItemImg from "./ItemImg";
 import SearchBar from "./SearchBar";
+import { useContextMenu, CtxMenu, openWiki, copyWikiLink } from "./CtxMenu";
 import "./ChangeLog.css";
 
 export const CHANGE_BATCH_GAP_SECONDS = 8;
@@ -81,7 +82,7 @@ function changeKey(change: ChangeLogEntry) {
 }
 
 function ChangeRow({
-  change, item, clockFormat, systemLocale, onItemClick, onCategoryClick, onFeedExpand, timeBreak = false, feed = false,
+  change, item, clockFormat, systemLocale, onItemClick, onCategoryClick, onFeedExpand, onContextMenu, timeBreak = false, feed = false,
 }: {
   change: ChangeLogEntry;
   item?: ChangeLogCatalogItem;
@@ -90,6 +91,7 @@ function ChangeRow({
   onItemClick: () => void;
   onCategoryClick: (category: string) => void;
   onFeedExpand?: () => void;
+  onContextMenu?: (e: React.MouseEvent) => void;
   timeBreak?: boolean;
   feed?: boolean;
 }) {
@@ -98,6 +100,7 @@ function ChangeRow({
   return (
     <div
       className={`inv-card inv-card-row log-item-row${feed ? " log-feed-row" : ""}${timeBreak ? " log-time-break" : ""}`}
+      onContextMenu={onContextMenu}
     >
       {onFeedExpand && <button className="log-feed-open" onClick={onFeedExpand} aria-label="Open change log" />}
       <span className="log-time">{timeStr(change.timestamp, clockFormat, systemLocale)}</span>
@@ -209,6 +212,21 @@ export default function ChangeLog({
   const [search, setSearch] = useState("");
   const catalogById = useMemo(() => new Map(catalog.map(item => [item.unique_name, item])), [catalog]);
   const latestBatch = useMemo(() => getLatestChangeBatch(changes), [changes]);
+  const { ctxMenu, open: openCtx, close: closeCtx } = useContextMenu();
+
+  const handleContextMenu = (e: React.MouseEvent) => {
+    const card = (e.target as HTMLElement).closest(".inv-card");
+    if (!card) return;
+    const nameEl = card.querySelector(".log-name-link");
+    const name = nameEl?.textContent?.trim();
+    if (name) {
+      e.preventDefault();
+      openCtx(e.clientX, e.clientY, [
+        { label: "Open Wiki", action: () => openWiki(name) },
+        { label: "Copy Wiki Link", action: () => copyWikiLink(name) },
+      ]);
+    }
+  };
   const filteredChanges = useMemo(() => {
     const query = search.trim().toLocaleLowerCase();
     if (!query) return changes;
@@ -291,6 +309,7 @@ export default function ChangeLog({
           onItemClick={() => onItemClick(feedChange.unique_name)}
           onCategoryClick={onCategoryClick}
           onFeedExpand={() => onExpandedChange(true)}
+          onContextMenu={handleContextMenu}
           feed
         />
       </div>}
@@ -317,6 +336,7 @@ export default function ChangeLog({
                   systemLocale={systemLocale}
                   onItemClick={() => onItemClick(change.unique_name)}
                   onCategoryClick={onCategoryClick}
+                  onContextMenu={handleContextMenu}
                   timeBreak={index > 0 && filteredChanges[index - 1].timestamp - change.timestamp > CHANGE_BATCH_GAP_SECONDS}
                 />
               );
@@ -327,6 +347,7 @@ export default function ChangeLog({
           </div>
         </div>
       )}
+      {ctxMenu && <CtxMenu state={ctxMenu} onClose={closeCtx} />}
     </div>
   );
 }

--- a/src/CtxMenu.tsx
+++ b/src/CtxMenu.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 
 interface CtxMenuItem {
@@ -27,15 +27,15 @@ export function useContextMenu() {
     };
   }, [ctxMenu]);
 
-  const open = (x: number, y: number, items: CtxMenuItem[]) => {
+  const open = useCallback((x: number, y: number, items: CtxMenuItem[]) => {
     const menuW = 180;
     const menuH = items.length * 30 + 8;
     const maxX = window.innerWidth - menuW;
     const maxY = window.innerHeight - menuH;
     setCtxMenu({ x: Math.min(x, maxX), y: Math.min(y, maxY), items });
-  };
+  }, []);
 
-  const close = () => setCtxMenu(null);
+  const close = useCallback(() => setCtxMenu(null), []);
 
   return { ctxMenu, open, close };
 }

--- a/src/Foundry.tsx
+++ b/src/Foundry.tsx
@@ -2,8 +2,9 @@ import { useState, useEffect, useMemo, useCallback, memo, startTransition, useRe
 import { invoke } from "@tauri-apps/api/core";
 import { ImgCacheDirContext } from "./ImgCacheDir";
 import { HelpTip } from "./HelpTip";
-import type { InventoryItem, ViewMode } from "./App";
-import { ViewToggle } from "./App";
+import type { InventoryItem } from "./App";
+import type { ViewMode } from "./ViewToggle";
+import { ViewToggle } from "./ViewToggle";
 import sentientIcon from "./assets/SentientFactionIcon.webp";
 import formaIcon from "./assets/forma-icon.png";
 

--- a/src/Foundry.tsx
+++ b/src/Foundry.tsx
@@ -234,7 +234,7 @@ function ItemImg({ imageName, category, size = 40 }: { imageName?: string; categ
 
   useEffect(() => {
     if (ref.current?.complete) ref.current.classList.add("img-loaded");
-  });
+  }, []);
 
   if (!imageName || cdnFailed)
     return <span className="img-fallback" style={{ ...style, fontSize: size * 0.35 }}>{category[0].toUpperCase()}</span>;

--- a/src/Foundry.tsx
+++ b/src/Foundry.tsx
@@ -237,13 +237,13 @@ function ItemImg({ imageName, category, size = 40 }: { imageName?: string; categ
   });
 
   if (!imageName || cdnFailed)
-    return <span className="item-img-fallback" style={{ ...style, fontSize: size * 0.35 }}>{category[0].toUpperCase()}</span>;
+    return <span className="img-fallback" style={{ ...style, fontSize: size * 0.35 }}>{category[0].toUpperCase()}</span>;
   const useLocal = Boolean(baseUrl) && !localFailed;
   const src = useLocal
     ? `${baseUrl}/${imageName}`
     : `https://cdn.warframestat.us/img/${imageName}`;
   return (
-    <img ref={ref} className="item-img" style={style} src={src}
+    <img ref={ref} className="img" style={style} src={src}
       alt="" loading="lazy"
       onError={() => useLocal ? setLocalFailed(true) : setCdnFailed(true)}
       onLoad={() => ref.current?.classList.add("img-loaded")} />

--- a/src/Foundry.tsx
+++ b/src/Foundry.tsx
@@ -229,7 +229,13 @@ function ItemImg({ imageName, category, size = 40 }: { imageName?: string; categ
   const baseUrl = useContext(ImgCacheDirContext);
   const [localFailed, setLocalFailed] = useState(false);
   const [cdnFailed,   setCdnFailed]   = useState(false);
+  const ref = useRef<HTMLImageElement>(null);
   const style = { width: size, height: size, flexShrink: 0 };
+
+  useEffect(() => {
+    if (ref.current?.complete) ref.current.classList.add("img-loaded");
+  });
+
   if (!imageName || cdnFailed)
     return <span className="item-img-fallback" style={{ ...style, fontSize: size * 0.35 }}>{category[0].toUpperCase()}</span>;
   const useLocal = Boolean(baseUrl) && !localFailed;
@@ -237,9 +243,10 @@ function ItemImg({ imageName, category, size = 40 }: { imageName?: string; categ
     ? `${baseUrl}/${imageName}`
     : `https://cdn.warframestat.us/img/${imageName}`;
   return (
-    <img className="item-img" style={style} src={src}
+    <img ref={ref} className="item-img" style={style} src={src}
       alt="" loading="lazy"
-      onError={() => useLocal ? setLocalFailed(true) : setCdnFailed(true)} />
+      onError={() => useLocal ? setLocalFailed(true) : setCdnFailed(true)}
+      onLoad={() => ref.current?.classList.add("img-loaded")} />
   );
 }
 

--- a/src/ImgCacheDir.ts
+++ b/src/ImgCacheDir.ts
@@ -1,56 +1,5 @@
-import { createContext, useCallback, useRef, useState } from "react";
+import { createContext } from "react";
 
 /** Absolute path to the local image cache directory (%LOCALAPPDATA%\warframe-companion\img_cache).
  *  Empty string = not yet known (images fall back to CDN). Set once on app startup. */
 export const ImgCacheDirContext = createContext<string>("");
-
-const CDN_PREFIX = "https://cdn.warframestat.us/img/";
-
-/** Build the CDN URL for an image name (e.g. "ash-prime.png" → CDN URL). */
-export function cdnUrl(imageName?: string): string | undefined {
-  if (!imageName) return undefined;
-  return `${CDN_PREFIX}${imageName}`;
-}
-
-/**
- * Given a primary base URL and a list of fallback candidates (undefined entries
- * are skipped), return the deduplicated list of URLs to try in order.
- */
-export function cdnCandidates(
-  baseUrl: string,
-  urls: (string | undefined)[]
-): string[] {
-  const seen = new Set<string>();
-  const result: string[] = [];
-  for (const u of [baseUrl, ...urls]) {
-    if (u && !seen.has(u)) {
-      seen.add(u);
-      result.push(u);
-    }
-  }
-  return result;
-}
-
-/**
- * Walk a list of image URLs in priority order: try each in sequence on error.
- * Returns { src, onError } to spread onto an <img>.
- */
-export function useImgLadder(urls: (string | undefined)[]): {
-  src: string | undefined;
-  onError: () => void;
-} {
-  const candidates = urls.filter(Boolean) as string[];
-  const indexRef = useRef(0);
-  const [src, setSrc] = useState<string | undefined>(candidates[0]);
-
-  const onError = useCallback(() => {
-    indexRef.current += 1;
-    if (indexRef.current < candidates.length) {
-      setSrc(candidates[indexRef.current]);
-    } else {
-      setSrc(undefined);
-    }
-  }, [candidates.join(",")]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  return { src, onError };
-}

--- a/src/InventoryBatchPreview.css
+++ b/src/InventoryBatchPreview.css
@@ -1,0 +1,41 @@
+.inventory-preview-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 350;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: rgba(0, 0, 0, 0.7);
+}
+
+.inventory-preview {
+  width: min(760px, 95vw);
+  max-height: min(620px, 90vh);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6);
+}
+
+.inventory-preview-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.inventory-preview-header > div:first-child { flex: 1; min-width: 0; }
+.inventory-preview-header strong { display: block; font-size: 13px; }
+.inventory-preview-header span { display: block; margin-top: 2px; color: var(--muted); font-size: 11px; }
+.inventory-preview-states { display: flex; flex-wrap: wrap; gap: 4px; padding: 8px 12px; border-bottom: 1px solid var(--border); }
+.inventory-preview .item-grid { min-height: 0; }
+
+@media (max-width: 600px) {
+  .inventory-preview-overlay { padding: 8px; }
+  .inventory-preview-header { padding: 10px; }
+}

--- a/src/InventoryBatchPreview.tsx
+++ b/src/InventoryBatchPreview.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import InventoryGrid from "./InventoryGrid";
 import { ViewToggle, type ViewMode } from "./ViewToggle";
 import "./InventoryBatchPreview.css";
@@ -23,8 +23,12 @@ export default function InventoryBatchPreview({ onClose }: InventoryBatchPreview
   const [view, setView] = useState<ViewMode>("cards");
   const [favorites, setFavorites] = useState<Set<string>>(new Set());
   const [previewState, setPreviewState] = useState<PreviewState>("all");
+  const dialogRef = useRef<HTMLElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
   const now = Math.floor(Date.now() / 1000);
   const expired = previewState === "expired";
+  const changeTimestamp = now - (expired ? 301 : 0);
   const items = [
     { unique_name: "preview-gained", name: "New resource stack", category: "Resources", qty: 12, state: "gained" },
     { unique_name: "preview-lost", name: "Consumed component", category: "Misc", qty: 0, state: "lost" },
@@ -33,23 +37,52 @@ export default function InventoryBatchPreview({ onClose }: InventoryBatchPreview
     { unique_name: "preview-mod-gained", name: "Ranked mod gain", category: "Mods", qty: 3, state: "mod-gained" },
   ];
 
-  const changes = new Map([
-    ["preview-gained", [{ delta: 12 }]],
-    ["preview-lost", [{ delta: -3 }]],
-    ["preview-mod-transfer", [{ rank: 0, delta: -1 }, { rank: 5, delta: 1 }]],
-    ["preview-mod-gained", [{ rank: 3, delta: 3 }]],
+  const changes = new Map<string, { delta: number; rank?: number; timestamp: number }[]>([
+    ["preview-gained", [{ delta: 12, timestamp: changeTimestamp }]],
+    ["preview-lost", [{ delta: -3, timestamp: changeTimestamp }]],
+    ["preview-mod-transfer", [{ rank: 0, delta: -1, timestamp: changeTimestamp }, { rank: 5, delta: 1, timestamp: changeTimestamp }]],
+    ["preview-mod-gained", [{ rank: 3, delta: 3, timestamp: changeTimestamp }]],
   ]);
+
+  useEffect(() => {
+    previousFocusRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    closeButtonRef.current?.focus();
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab" || !dialogRef.current) return;
+      const focusable = dialogRef.current.querySelectorAll<HTMLElement>("button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex='-1'])");
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (!first || !last) return;
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      previousFocusRef.current?.focus();
+    };
+  }, [onClose]);
 
   return (
     <div className="inventory-preview-overlay" onClick={onClose}>
-      <section className="inventory-preview" onClick={event => event.stopPropagation()} aria-label="Inventory change preview">
+      <section ref={dialogRef} className="inventory-preview" onClick={event => event.stopPropagation()} role="dialog" aria-modal="true" aria-label="Inventory change preview">
         <header className="inventory-preview-header">
           <div>
             <strong>Incoming inventory batch preview</strong>
             <span>{expired ? "Recent indicators have expired." : "This does not change inventory data."}</span>
           </div>
           <ViewToggle view={view} onChange={setView} />
-          <button className="craft-detail-close" onClick={onClose} aria-label="Close preview">x</button>
+          <button ref={closeButtonRef} className="craft-detail-close" onClick={onClose} aria-label="Close preview">x</button>
         </header>
         <div className="inventory-preview-states" aria-label="Preview state">
           {PREVIEW_STATES.map(([state, label]) => (
@@ -75,10 +108,10 @@ export default function InventoryBatchPreview({ onClose }: InventoryBatchPreview
           }}
           favorites={favorites}
           lastChanged={{
-            "preview-gained": now - (expired ? 301 : 0),
-            "preview-lost": now - (expired ? 301 : 0),
-            "preview-mod-transfer": now - (expired ? 301 : 0),
-            "preview-mod-gained": now - (expired ? 301 : 0),
+            "preview-gained": changeTimestamp,
+            "preview-lost": changeTimestamp,
+            "preview-mod-transfer": changeTimestamp,
+            "preview-mod-gained": changeTimestamp,
           }}
           changes={changes}
           crafting={new Map([["preview-crafting", { item_name: "Building item" }]])}

--- a/src/InventoryBatchPreview.tsx
+++ b/src/InventoryBatchPreview.tsx
@@ -1,0 +1,96 @@
+import { useState } from "react";
+import InventoryGrid from "./InventoryGrid";
+import { ViewToggle, type ViewMode } from "./ViewToggle";
+import "./InventoryBatchPreview.css";
+
+interface InventoryBatchPreviewProps {
+  onClose: () => void;
+}
+
+const PREVIEW_STATES = [
+  ["all", "All incoming"],
+  ["gained", "Gained"],
+  ["lost", "Lost"],
+  ["crafting", "Crafting"],
+  ["mod-transfer", "Rank transfer"],
+  ["mod-gained", "Rank gain"],
+  ["expired", "After 5 min"],
+] as const;
+
+type PreviewState = typeof PREVIEW_STATES[number][0];
+
+export default function InventoryBatchPreview({ onClose }: InventoryBatchPreviewProps) {
+  const [view, setView] = useState<ViewMode>("cards");
+  const [favorites, setFavorites] = useState<Set<string>>(new Set());
+  const [previewState, setPreviewState] = useState<PreviewState>("all");
+  const now = Math.floor(Date.now() / 1000);
+  const expired = previewState === "expired";
+  const items = [
+    { unique_name: "preview-gained", name: "New resource stack", category: "Resources", qty: 12, state: "gained" },
+    { unique_name: "preview-lost", name: "Consumed component", category: "Misc", qty: 0, state: "lost" },
+    { unique_name: "preview-crafting", name: "Building item", category: "Primary", qty: 1, state: "crafting" },
+    { unique_name: "preview-mod-transfer", name: "Rank transfer", category: "Mods", qty: 2, state: "mod-transfer" },
+    { unique_name: "preview-mod-gained", name: "Ranked mod gain", category: "Mods", qty: 3, state: "mod-gained" },
+  ];
+
+  const changes = new Map([
+    ["preview-gained", [{ delta: 12 }]],
+    ["preview-lost", [{ delta: -3 }]],
+    ["preview-mod-transfer", [{ rank: 0, delta: -1 }, { rank: 5, delta: 1 }]],
+    ["preview-mod-gained", [{ rank: 3, delta: 3 }]],
+  ]);
+
+  return (
+    <div className="inventory-preview-overlay" onClick={onClose}>
+      <section className="inventory-preview" onClick={event => event.stopPropagation()} aria-label="Inventory change preview">
+        <header className="inventory-preview-header">
+          <div>
+            <strong>Incoming inventory batch preview</strong>
+            <span>{expired ? "Recent indicators have expired." : "This does not change inventory data."}</span>
+          </div>
+          <ViewToggle view={view} onChange={setView} />
+          <button className="craft-detail-close" onClick={onClose} aria-label="Close preview">x</button>
+        </header>
+        <div className="inventory-preview-states" aria-label="Preview state">
+          {PREVIEW_STATES.map(([state, label]) => (
+            <button
+              key={state}
+              className={`fchip${previewState === state ? " fchip-on" : ""}`}
+              onClick={() => setPreviewState(state)}
+            >{label}</button>
+          ))}
+        </div>
+        <InventoryGrid
+          items={items.filter(item => previewState === "all" || expired || item.state === previewState)}
+          loading={false}
+          monitoring
+          view={view}
+          inventory={{
+            "preview-gained": { mastery_rank: 30 },
+            "preview-crafting": { mastery_rank: 14 },
+          }}
+          modCopies={{
+            "preview-mod-transfer": [{ rank: 5, count: 2 }],
+            "preview-mod-gained": [{ rank: 3, count: 3 }],
+          }}
+          favorites={favorites}
+          lastChanged={{
+            "preview-gained": now - (expired ? 301 : 0),
+            "preview-lost": now - (expired ? 301 : 0),
+            "preview-mod-transfer": now - (expired ? 301 : 0),
+            "preview-mod-gained": now - (expired ? 301 : 0),
+          }}
+          changes={changes}
+          crafting={new Map([["preview-crafting", { item_name: "Building item" }]])}
+          filterRank={null}
+          onToggleFavorite={id => setFavorites(previous => {
+            const next = new Set(previous);
+            if (next.has(id)) next.delete(id);
+            else next.add(id);
+            return next;
+          })}
+        />
+      </section>
+    </div>
+  );
+}

--- a/src/InventoryFilters.ts
+++ b/src/InventoryFilters.ts
@@ -1,0 +1,25 @@
+export type InventorySortMode = "qty-desc" | "qty-asc" | "name-asc" | "name-desc" | "recent";
+
+export interface InventoryFilters {
+  category: string;
+  search: string;
+  filterOwned: boolean;
+  filterRecent: boolean;
+  filterPrime: boolean;
+  filterVaulted: boolean;
+  filterUnvaulted: boolean;
+  filterRank: number | "unranked" | null;
+  sortMode: InventorySortMode;
+}
+
+export const INVENTORY_FILTERS_DEFAULT: InventoryFilters = {
+  category: "all",
+  search: "",
+  filterOwned: false,
+  filterRecent: false,
+  filterPrime: false,
+  filterVaulted: false,
+  filterUnvaulted: false,
+  filterRank: null,
+  sortMode: "qty-desc",
+};

--- a/src/InventoryGrid.css
+++ b/src/InventoryGrid.css
@@ -132,7 +132,7 @@
   cursor: pointer; border-radius: 8px;
 }
 .item-grid-icons .inv-card-icon-only img,
-.item-grid-icons .inv-card-icon-only .item-img { width: 56px !important; height: 56px !important; }
+.item-grid-icons .inv-card-icon-only .img { width: 56px !important; height: 56px !important; }
 
 /* text-cards: keep grid, just no image area — handled inline */
 
@@ -156,7 +156,7 @@
 .inv-fav-star-row:hover { color: rgba(240,192,64,.8); }
 .inv-fav-star-row.active { color: #f0c040; }
 .inv-row-icon { width: 22px; height: 22px; flex-shrink: 0; position: relative; display: flex; align-items: center; }
-.inv-row-icon img, .inv-row-icon .item-img { width: 20px !important; height: 20px !important; }
+.inv-row-icon img, .inv-row-icon .img { width: 20px !important; height: 20px !important; }
 .inv-foundry-icon-row { position: absolute; top: -4px; right: -6px; font-size: 9px; }
 .inv-row-name { flex: 1; min-width: 0; font-size: 12px; font-weight: 500; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .inv-row-cat  { width: 90px; flex-shrink: 0; font-size: 10px; color: var(--muted); text-align: right; text-transform: uppercase; letter-spacing: .03em; }

--- a/src/InventoryGrid.css
+++ b/src/InventoryGrid.css
@@ -54,6 +54,7 @@
 .inv-card-zero  { opacity: .35; }
 .inv-card-gained { border-left: 2px solid var(--green); background: rgba(63,185,80,.04); }
 .inv-card-lost   { border-left: 2px solid var(--red);   background: rgba(248,81,73,.04); }
+.inv-card-mixed  { border-left: 2px solid #e0973e; background: rgba(224,151,62,.04); }
 
 /* ── Mastery row ───────────────────────────────────────────────────────────── */
 
@@ -92,7 +93,7 @@
 .inv-card-mod .inv-card-cat  { text-align: left; }
 .mod-rank-table {
   width: 100%; margin-top: 5px;
-  display: grid; grid-template-columns: 1fr 1fr;
+  display: grid; grid-template-columns: 1fr auto;
   gap: 1px 6px;
 }
 .mod-rank-row {
@@ -106,10 +107,13 @@
   font-size: 10px; font-weight: 700; color: var(--text);
   font-variant-numeric: tabular-nums; text-align: right;
 }
+.mod-rank-value { display: flex; align-items: center; gap: 4px; justify-content: flex-end; }
 .mod-rank-delta {
   font-size: 10px; font-weight: 600;
-  margin-left: 4px;
+  padding: 0 3px; border-radius: 2px;
 }
+.mod-rank-delta.log-positive { color: var(--green); background: rgba(63,185,80,.12); }
+.mod-rank-delta.log-negative { color: var(--red); background: rgba(248,81,73,.12); }
 .mod-rank-zero .mod-rank-label,
 .mod-rank-zero .mod-rank-count { color: rgba(139,148,158,.3); }
 .inv-card-mod .mod-total {

--- a/src/InventoryGrid.css
+++ b/src/InventoryGrid.css
@@ -1,0 +1,177 @@
+/* ── Inventory grid ─────────────────────────────────────────────────────────── */
+
+.item-grid {
+  flex: 1;
+  overflow-y: auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+  gap: 8px;
+  padding: 10px 12px;
+  align-content: start;
+}
+
+/* ── Card base ─────────────────────────────────────────────────────────────── */
+
+.inv-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 6px 6px 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  cursor: default;
+  transition: border-color .12s;
+  min-width: 0;
+  position: relative;
+}
+
+.inv-fav-star {
+  position: absolute;
+  top: 2px;
+  left: 4px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 11px;
+  color: rgba(255,255,255,.25);
+  line-height: 1;
+  padding: 0;
+  z-index: 2;
+  transition: color .1s;
+}
+.inv-fav-star:hover { color: rgba(240,192,64,.8); }
+.inv-fav-star.active { color: #f0c040; }
+.inv-card:hover { border-color: rgba(56, 139, 253, .5); }
+.inv-card-zero  { opacity: .35; }
+.inv-card-gained { border-left: 2px solid var(--green); background: rgba(63,185,80,.04); }
+.inv-card-lost   { border-left: 2px solid var(--red);   background: rgba(248,81,73,.04); }
+
+/* ── Mastery row ───────────────────────────────────────────────────────────── */
+
+.inv-mastery-row  { height: 18px; display: flex; align-items: center; justify-content: center; width: 100%; }
+.inv-mastery-star { font-size: 13px; color: #f0c040; line-height: 1; }
+.inv-mastery-rank { font-size: 10px; font-weight: 600; color: var(--muted); background: rgba(255,255,255,.06); border-radius: 3px; padding: 1px 5px; }
+
+/* ── Image + foundry icon ──────────────────────────────────────────────────── */
+
+.inv-card-img-wrap { position: relative; width: 48px; height: 48px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; }
+.inv-foundry-icon  { position: absolute; top: -5px; right: -7px; font-size: 13px; filter: drop-shadow(0 0 3px rgba(0,0,0,.9)); }
+
+/* ── Card text ─────────────────────────────────────────────────────────────── */
+
+.inv-card-name {
+  font-size: 11px; font-weight: 500; text-align: center;
+  line-height: 1.3; overflow: hidden;
+  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
+  width: 100%;
+}
+.inv-card-cat {
+  font-size: 9px; font-weight: 600; text-transform: uppercase; letter-spacing: .04em;
+  color: rgba(139,148,158,.6); text-align: center; width: 100%;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  margin-top: -1px;
+}
+.inv-card-meta { display: flex; gap: 3px; flex-wrap: wrap; justify-content: center; }
+.inv-card-qty      { font-size: 15px; font-weight: 700; color: var(--text); font-variant-numeric: tabular-nums; display: flex; align-items: center; gap: 4px; }
+.inv-card-qty-zero { color: var(--muted); }
+
+/* ── Mod rank breakdown card ───────────────────────────────────────────────── */
+
+.inv-card-mod { align-items: flex-start; padding: 8px 10px 8px; min-width: 140px; max-width: 200px; }
+.inv-card-mod .inv-card-img-wrap { width: 40px; height: 40px; }
+.inv-card-mod .inv-card-name { text-align: left; font-size: 12px; }
+.inv-card-mod .inv-card-cat  { text-align: left; }
+.mod-rank-table {
+  width: 100%; margin-top: 5px;
+  display: grid; grid-template-columns: 1fr 1fr;
+  gap: 1px 6px;
+}
+.mod-rank-row {
+  display: contents;
+}
+.mod-rank-label {
+  font-size: 10px; font-weight: 600; color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+.mod-rank-count {
+  font-size: 10px; font-weight: 700; color: var(--text);
+  font-variant-numeric: tabular-nums; text-align: right;
+}
+.mod-rank-zero .mod-rank-label,
+.mod-rank-zero .mod-rank-count { color: rgba(139,148,158,.3); }
+.inv-card-mod .mod-total {
+  font-size: 12px; font-weight: 700; margin-top: 4px;
+  border-top: 1px solid var(--border); padding-top: 3px; width: 100%;
+  display: flex; justify-content: space-between; color: var(--text);
+}
+.inv-card-mod .mod-total::before { content: "Total"; font-size: 10px; font-weight: 600; color: var(--muted); }
+
+/* ── Empty state ───────────────────────────────────────────────────────────── */
+
+.empty-msg { padding: 40px 24px; color: var(--muted); text-align: center; line-height: 1.6; }
+
+/* ── Delta + recent indicators ─────────────────────────────────────────────── */
+
+.item-updated    { font-size: 10px; color: var(--muted); white-space: nowrap; }
+.item-delta { font-size: 12px; font-weight: 600; flex-shrink: 0; padding: 1px 6px; border-radius: 4px; }
+.delta-pos { color: var(--green); background: rgba(63,185,80,.12); }
+.delta-neg { color: var(--red); background: rgba(248,81,73,.12); }
+
+/* ── Inventory view modes ──────────────────────────────────────────────────── */
+
+/* icons */
+.item-grid.item-grid-icons {
+  grid-template-columns: repeat(auto-fill, 76px);
+  gap: 6px;
+}
+.item-grid-icons .inv-card-icon-only {
+  width: 76px; height: 76px; padding: 6px;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer; border-radius: 8px;
+}
+.item-grid-icons .inv-card-icon-only img,
+.item-grid-icons .inv-card-icon-only .item-img { width: 56px !important; height: 56px !important; }
+
+/* text-cards: keep grid, just no image area — handled inline */
+
+/* list + list-compact */
+.item-grid.item-grid-list,
+.item-grid.item-grid-list-compact {
+  display: flex; flex-direction: column; gap: 1px; padding: 4px 0;
+  grid-template-columns: none;
+}
+.inv-card-row {
+  display: flex; flex-direction: row; align-items: center;
+  gap: 8px; padding: 4px 12px; border-radius: 0;
+  border-bottom: 1px solid rgba(48,54,61,.35);
+  min-height: 30px;
+}
+.inv-fav-star-row {
+  background: none; border: none; cursor: pointer;
+  font-size: 11px; color: rgba(255,255,255,.25); padding: 0; flex-shrink: 0;
+  line-height: 1; transition: color .1s;
+}
+.inv-fav-star-row:hover { color: rgba(240,192,64,.8); }
+.inv-fav-star-row.active { color: #f0c040; }
+.inv-row-icon { width: 22px; height: 22px; flex-shrink: 0; position: relative; display: flex; align-items: center; }
+.inv-row-icon img, .inv-row-icon .item-img { width: 20px !important; height: 20px !important; }
+.inv-foundry-icon-row { position: absolute; top: -4px; right: -6px; font-size: 9px; }
+.inv-row-name { flex: 1; min-width: 0; font-size: 12px; font-weight: 500; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.inv-row-cat  { width: 90px; flex-shrink: 0; font-size: 10px; color: var(--muted); text-align: right; text-transform: uppercase; letter-spacing: .03em; }
+.inv-row-qty  { width: 60px; flex-shrink: 0; text-align: right; font-size: 13px; font-weight: 700; color: var(--text); display: flex; align-items: center; justify-content: flex-end; gap: 4px; }
+
+/* ── Loading skeleton ──────────────────────────────────────────────────────── */
+
+.inventory-skeleton {
+  min-height: 120px;
+  background: linear-gradient(90deg, var(--surface) 25%, rgba(255,255,255,.04) 50%, var(--surface) 75%);
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.5s ease-in-out infinite;
+}
+
+@keyframes skeleton-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}

--- a/src/InventoryGrid.css
+++ b/src/InventoryGrid.css
@@ -106,6 +106,10 @@
   font-size: 10px; font-weight: 700; color: var(--text);
   font-variant-numeric: tabular-nums; text-align: right;
 }
+.mod-rank-delta {
+  font-size: 10px; font-weight: 600;
+  margin-left: 4px;
+}
 .mod-rank-zero .mod-rank-label,
 .mod-rank-zero .mod-rank-count { color: rgba(139,148,158,.3); }
 .inv-card-mod .mod-total {

--- a/src/InventoryGrid.css
+++ b/src/InventoryGrid.css
@@ -8,6 +8,9 @@
   gap: 8px;
   padding: 10px 12px;
   align-content: start;
+  /* Mod cards can have more rank rows; fill their shared grid row to keep gutters stable. */
+  align-items: stretch;
+  justify-items: stretch;
 }
 
 /* ── Card base ─────────────────────────────────────────────────────────────── */
@@ -25,6 +28,10 @@
   transition: border-color .12s;
   min-width: 0;
   position: relative;
+  align-self: stretch;
+  justify-self: stretch;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .inv-fav-star {
@@ -79,7 +86,7 @@
 
 /* ── Mod rank breakdown card ───────────────────────────────────────────────── */
 
-.inv-card-mod { align-items: flex-start; padding: 8px 10px 8px; min-width: 140px; max-width: 200px; }
+.inv-card-mod { align-items: flex-start; padding: 8px 10px 8px; }
 .inv-card-mod .inv-card-img-wrap { width: 40px; height: 40px; }
 .inv-card-mod .inv-card-name { text-align: left; font-size: 12px; }
 .inv-card-mod .inv-card-cat  { text-align: left; }

--- a/src/InventoryGrid.tsx
+++ b/src/InventoryGrid.tsx
@@ -25,7 +25,7 @@ interface InventoryGridProps {
   modCopies: Record<string, { rank: number | null; count: number }[]>;
   favorites: Set<string>;
   lastChanged: Record<string, number>;
-  changes: Map<string, { delta: number }>;
+  changes: Map<string, { delta: number; rank?: number | null }[]>;
   crafting: Map<string, { item_name: string }>;
   filterRank: number | "unranked" | null;
   onToggleFavorite: (id: string) => void;
@@ -44,8 +44,9 @@ interface InvModCardProps {
   view: ViewMode;
   changedAt?: number;
   recentDelta?: number | null;
+  rankDeltas?: { rank: number; delta: number }[];
 }
-const InvModCard = memo(function InvModCard({ unique_name, name, category, image_name, ranks, total, view, changedAt, recentDelta }: InvModCardProps) {
+const InvModCard = memo(function InvModCard({ unique_name, name, category, image_name, ranks, total, view, changedAt, recentDelta, rankDeltas }: InvModCardProps) {
   const nowSec = Date.now() / 1000;
   const secAgo = changedAt != null ? nowSec - changedAt : null;
   const isRecent = secAgo !== null && secAgo < 300;
@@ -78,12 +79,20 @@ const InvModCard = memo(function InvModCard({ unique_name, name, category, image
       <div className="inv-card-name">{name}</div>
       <div className="inv-card-cat">{category}</div>
       <div className="mod-rank-table">
-        {ranks.map(r => (
-          <div key={r.rank} className={`mod-rank-row${r.count === 0 ? " mod-rank-zero" : ""}`}>
-            <span className="mod-rank-label">R{r.rank}</span>
-            <span className="mod-rank-count">{r.count}</span>
-          </div>
-        ))}
+        {ranks.map(r => {
+          const rankDelta = rankDeltas?.find(rd => rd.rank === r.rank);
+          return (
+            <div key={r.rank} className={`mod-rank-row${r.count === 0 ? " mod-rank-zero" : ""}`}>
+              <span className="mod-rank-label">R{r.rank}</span>
+              <span className="mod-rank-count">{r.count}</span>
+              {rankDelta && (
+                <span className={`mod-rank-delta ${rankDelta.delta > 0 ? "log-positive" : "log-negative"}`}>
+                  {rankDelta.delta > 0 ? "+1" : "-1"}
+                </span>
+              )}
+            </div>
+          );
+        })}
       </div>
       <div className="inv-card-qty mod-total">{fmt(total)}</div>
     </div>
@@ -97,7 +106,8 @@ const InvModCard = memo(function InvModCard({ unique_name, name, category, image
   prev.ranks.length === next.ranks.length &&
   prev.ranks.every((r, i) => r.rank === next.ranks[i].rank && r.count === next.ranks[i].count) &&
   prev.changedAt === next.changedAt &&
-  prev.recentDelta === next.recentDelta
+  prev.recentDelta === next.recentDelta &&
+  prev.rankDeltas === next.rankDeltas
 );
 
 interface InvCardProps {
@@ -245,19 +255,23 @@ export default memo(function InventoryGrid({
               if ((byRank[targetRank] ?? 0) === 0) return [];
             }
             const total = Object.values(byRank).reduce((a, b) => a + b, 0);
+            const changeEntries = lastChanged[item.unique_name] != null ? changes.get(item.unique_name) : undefined;
+            const rankDeltas = changeEntries?.filter(c => c.rank != null).map(c => ({ rank: c.rank!, delta: c.delta })) ?? [];
             return [(
               <InvModCard key={item.unique_name}
                 unique_name={item.unique_name} name={item.name}
                 category={item.category} image_name={item.image_name}
                 ranks={ranks} total={total} view={view}
                 changedAt={lastChanged[item.unique_name]}
-                recentDelta={changes.get(item.unique_name)?.delta ?? null} />
+                recentDelta={changeEntries?.find(c => c.rank == null)?.delta ?? null}
+                rankDeltas={rankDeltas} />
             )];
           }
 
           // Normal item card
           const changedAt = lastChanged[item.unique_name];
-          const recentChange = changedAt != null ? changes.get(item.unique_name) : undefined;
+          const changeEntries = changedAt != null ? changes.get(item.unique_name) : undefined;
+          const recentChange = changeEntries?.find(c => c.rank == null) ?? changeEntries?.[0];
           const craftJob = crafting.get(item.unique_name);
           return [(
             <InvCard key={item.unique_name}

--- a/src/InventoryGrid.tsx
+++ b/src/InventoryGrid.tsx
@@ -42,18 +42,25 @@ interface InvModCardProps {
   ranks: { rank: number; count: number }[];
   total: number;
   view: ViewMode;
+  changedAt?: number;
+  recentDelta?: number | null;
 }
-const InvModCard = memo(function InvModCard({ unique_name, name, category, image_name, ranks, total, view }: InvModCardProps) {
+const InvModCard = memo(function InvModCard({ unique_name, name, category, image_name, ranks, total, view, changedAt, recentDelta }: InvModCardProps) {
+  const nowSec = Date.now() / 1000;
+  const secAgo = changedAt != null ? nowSec - changedAt : null;
+  const isRecent = secAgo !== null && secAgo < 300;
+  const baseClass = `inv-card${isRecent ? (recentDelta != null && recentDelta > 0 ? " inv-card-gained" : " inv-card-lost") : ""}`;
+
   if (view === "icons") {
     return (
-      <div key={unique_name} className="inv-card inv-card-icon-only" title={`${name} ×${fmt(total)}`}>
+      <div key={unique_name} className={`${baseClass} inv-card-icon-only`} title={`${name} ×${fmt(total)}`}>
         <ItemImg imageName={image_name ?? undefined} category={category} size={52} />
       </div>
     );
   }
   if (view === "list" || view === "list-compact") {
     return (
-      <div key={unique_name} className="inv-card inv-card-row">
+      <div key={unique_name} className={`${baseClass} inv-card-row`}>
         {view === "list" && <div className="inv-row-icon"><ItemImg imageName={image_name ?? undefined} category={category} size={20} /></div>}
         <div className="inv-row-name">{name}</div>
         <div className="inv-row-cat">{category}</div>
@@ -62,7 +69,7 @@ const InvModCard = memo(function InvModCard({ unique_name, name, category, image
     );
   }
   return (
-    <div key={unique_name} className="inv-card inv-card-mod">
+    <div key={unique_name} className={`${baseClass} inv-card-mod`}>
       {view !== "text-cards" && (
         <div className="inv-card-img-wrap">
           <ItemImg imageName={image_name ?? undefined} category={category} size={40} />
@@ -88,7 +95,9 @@ const InvModCard = memo(function InvModCard({ unique_name, name, category, image
   prev.total === next.total &&
   prev.image_name === next.image_name &&
   prev.ranks.length === next.ranks.length &&
-  prev.ranks.every((r, i) => r.rank === next.ranks[i].rank && r.count === next.ranks[i].count)
+  prev.ranks.every((r, i) => r.rank === next.ranks[i].rank && r.count === next.ranks[i].count) &&
+  prev.changedAt === next.changedAt &&
+  prev.recentDelta === next.recentDelta
 );
 
 interface InvCardProps {
@@ -240,7 +249,9 @@ export default memo(function InventoryGrid({
               <InvModCard key={item.unique_name}
                 unique_name={item.unique_name} name={item.name}
                 category={item.category} image_name={item.image_name}
-                ranks={ranks} total={total} view={view} />
+                ranks={ranks} total={total} view={view}
+                changedAt={lastChanged[item.unique_name]}
+                recentDelta={changes.get(item.unique_name)?.delta ?? null} />
             )];
           }
 

--- a/src/InventoryGrid.tsx
+++ b/src/InventoryGrid.tsx
@@ -50,7 +50,10 @@ const InvModCard = memo(function InvModCard({ unique_name, name, category, image
   const nowSec = Date.now() / 1000;
   const secAgo = changedAt != null ? nowSec - changedAt : null;
   const isRecent = secAgo !== null && secAgo < 300;
-  const baseClass = `inv-card${isRecent ? (recentDelta != null && recentDelta > 0 ? " inv-card-gained" : " inv-card-lost") : ""}`;
+  const hasPositive = rankDeltas != null && rankDeltas.some(d => d.delta > 0);
+  const hasNegative = rankDeltas != null && rankDeltas.some(d => d.delta < 0);
+  const mixedChange = isRecent && hasPositive && hasNegative;
+  const baseClass = `inv-card${isRecent ? (mixedChange ? " inv-card-mixed" : (recentDelta != null && recentDelta > 0 ? " inv-card-gained" : " inv-card-lost")) : ""}`;
 
   if (view === "icons") {
     return (
@@ -84,12 +87,14 @@ const InvModCard = memo(function InvModCard({ unique_name, name, category, image
           return (
             <div key={r.rank} className={`mod-rank-row${r.count === 0 ? " mod-rank-zero" : ""}`}>
               <span className="mod-rank-label">R{r.rank}</span>
-              <span className="mod-rank-count">{r.count}</span>
-              {rankDelta && (
-                <span className={`mod-rank-delta ${rankDelta.delta > 0 ? "log-positive" : "log-negative"}`}>
-                  {rankDelta.delta > 0 ? "+1" : "-1"}
-                </span>
-              )}
+              <span className="mod-rank-value">
+                <span className="mod-rank-count">{r.count}</span>
+                {isRecent && rankDelta && (
+                  <span className={`mod-rank-delta ${rankDelta.delta > 0 ? "log-positive" : "log-negative"}`}>
+                    {rankDelta.delta > 0 ? "+1" : "-1"}
+                  </span>
+                )}
+              </span>
             </div>
           );
         })}
@@ -257,13 +262,14 @@ export default memo(function InventoryGrid({
             const total = Object.values(byRank).reduce((a, b) => a + b, 0);
             const changeEntries = lastChanged[item.unique_name] != null ? changes.get(item.unique_name) : undefined;
             const rankDeltas = changeEntries?.filter(c => c.rank != null).map(c => ({ rank: c.rank!, delta: c.delta })) ?? [];
+            const totalDelta = changeEntries?.find(c => c.rank == null)?.delta ?? rankDeltas.reduce((s, d) => s + d.delta, 0);
             return [(
               <InvModCard key={item.unique_name}
                 unique_name={item.unique_name} name={item.name}
                 category={item.category} image_name={item.image_name}
                 ranks={ranks} total={total} view={view}
                 changedAt={lastChanged[item.unique_name]}
-                recentDelta={changeEntries?.find(c => c.rank == null)?.delta ?? null}
+                recentDelta={totalDelta || null}
                 rankDeltas={rankDeltas} />
             )];
           }

--- a/src/InventoryGrid.tsx
+++ b/src/InventoryGrid.tsx
@@ -25,7 +25,7 @@ interface InventoryGridProps {
   modCopies: Record<string, { rank: number | null; count: number }[]>;
   favorites: Set<string>;
   lastChanged: Record<string, number>;
-  changes: Map<string, { delta: number; rank?: number | null }[]>;
+  changes: Map<string, { delta: number; rank?: number | null; timestamp: number }[]>;
   crafting: Map<string, { item_name: string }>;
   filterRank: number | "unranked" | null;
   onToggleFavorite: (id: string) => void;
@@ -254,8 +254,10 @@ export default memo(function InventoryGrid({
             const byRank: Record<number, number> = {};
             for (const c of copies) byRank[c.rank ?? 0] = (byRank[c.rank ?? 0] ?? 0) + c.count;
             const changeEntries = lastChanged[item.unique_name] != null ? changes.get(item.unique_name) : undefined;
-            const rankDeltas = changeEntries?.filter(c => c.rank != null).map(c => ({ rank: c.rank!, delta: c.delta })) ?? [];
-            const isRecent = lastChanged[item.unique_name] != null && Date.now() / 1000 - lastChanged[item.unique_name] < 300;
+            const nowSec = Date.now() / 1000;
+            const recentChanges = changeEntries?.filter(change => nowSec - change.timestamp < 300) ?? [];
+            const rankDeltas = recentChanges.filter(c => c.rank != null).map(c => ({ rank: c.rank!, delta: c.delta }));
+            const isRecent = lastChanged[item.unique_name] != null && nowSec - lastChanged[item.unique_name] < 300;
             const ranks = [...new Set([...Object.keys(byRank).map(Number), ...rankDeltas.map(delta => delta.rank)])]
               .sort((a, b) => a - b)
               .map(rank => ({ rank, count: byRank[rank] ?? 0 }))
@@ -265,7 +267,7 @@ export default memo(function InventoryGrid({
               if ((byRank[targetRank] ?? 0) === 0) return [];
             }
             const total = Object.values(byRank).reduce((a, b) => a + b, 0);
-            const totalDelta = changeEntries?.find(c => c.rank == null)?.delta ?? rankDeltas.reduce((s, d) => s + d.delta, 0);
+            const totalDelta = recentChanges.find(c => c.rank == null)?.delta ?? rankDeltas.reduce((s, d) => s + d.delta, 0);
             return [(
               <InvModCard key={item.unique_name}
                 unique_name={item.unique_name} name={item.name}
@@ -280,7 +282,8 @@ export default memo(function InventoryGrid({
           // Normal item card
           const changedAt = lastChanged[item.unique_name];
           const changeEntries = changedAt != null ? changes.get(item.unique_name) : undefined;
-          const recentChange = changeEntries?.find(c => c.rank == null) ?? changeEntries?.[0];
+          const recentChange = changeEntries?.find(change => Date.now() / 1000 - change.timestamp < 300 && change.rank == null)
+            ?? changeEntries?.find(change => Date.now() / 1000 - change.timestamp < 300);
           const craftJob = crafting.get(item.unique_name);
           return [(
             <InvCard key={item.unique_name}

--- a/src/InventoryGrid.tsx
+++ b/src/InventoryGrid.tsx
@@ -91,7 +91,7 @@ const InvModCard = memo(function InvModCard({ unique_name, name, category, image
                 <span className="mod-rank-count">{r.count}</span>
                 {isRecent && rankDelta && (
                   <span className={`mod-rank-delta ${rankDelta.delta > 0 ? "log-positive" : "log-negative"}`}>
-                    {rankDelta.delta > 0 ? "+1" : "-1"}
+                    {rankDelta.delta > 0 ? `+${rankDelta.delta}` : rankDelta.delta}
                   </span>
                 )}
               </span>
@@ -253,15 +253,18 @@ export default memo(function InventoryGrid({
             const copies = modCopies[item.unique_name];
             const byRank: Record<number, number> = {};
             for (const c of copies) byRank[c.rank ?? 0] = (byRank[c.rank ?? 0] ?? 0) + c.count;
-            const maxRank = Math.max(...Object.keys(byRank).map(Number));
-            const ranks = Array.from({ length: maxRank + 1 }, (_, r) => ({ rank: r, count: byRank[r] ?? 0 })).filter(r => r.count > 0);
+            const changeEntries = lastChanged[item.unique_name] != null ? changes.get(item.unique_name) : undefined;
+            const rankDeltas = changeEntries?.filter(c => c.rank != null).map(c => ({ rank: c.rank!, delta: c.delta })) ?? [];
+            const isRecent = lastChanged[item.unique_name] != null && Date.now() / 1000 - lastChanged[item.unique_name] < 300;
+            const ranks = [...new Set([...Object.keys(byRank).map(Number), ...rankDeltas.map(delta => delta.rank)])]
+              .sort((a, b) => a - b)
+              .map(rank => ({ rank, count: byRank[rank] ?? 0 }))
+              .filter(r => r.count > 0 || (isRecent && rankDeltas.some(delta => delta.rank === r.rank)));
             if (filterRank !== null) {
               const targetRank = filterRank === "unranked" ? 0 : filterRank;
               if ((byRank[targetRank] ?? 0) === 0) return [];
             }
             const total = Object.values(byRank).reduce((a, b) => a + b, 0);
-            const changeEntries = lastChanged[item.unique_name] != null ? changes.get(item.unique_name) : undefined;
-            const rankDeltas = changeEntries?.filter(c => c.rank != null).map(c => ({ rank: c.rank!, delta: c.delta })) ?? [];
             const totalDelta = changeEntries?.find(c => c.rank == null)?.delta ?? rankDeltas.reduce((s, d) => s + d.delta, 0);
             return [(
               <InvModCard key={item.unique_name}

--- a/src/InventoryGrid.tsx
+++ b/src/InventoryGrid.tsx
@@ -27,7 +27,7 @@ interface InventoryGridProps {
   lastChanged: Record<string, number>;
   changes: Map<string, { delta: number }>;
   crafting: Map<string, { item_name: string }>;
-  filterRank: string | number | null;
+  filterRank: number | "unranked" | null;
   onToggleFavorite: (id: string) => void;
   onContextMenu?: (e: React.MouseEvent) => void;
 }
@@ -204,7 +204,7 @@ const InvCard = memo(function InvCard({
 
 // ─── Main grid component ────────────────────────────────────────────────────
 
-export default function InventoryGrid({
+export default memo(function InventoryGrid({
   items, loading, monitoring, view,
   inventory, modCopies, favorites, lastChanged, changes, crafting,
   filterRank, onToggleFavorite, onContextMenu,
@@ -232,7 +232,7 @@ export default function InventoryGrid({
             const maxRank = Math.max(...Object.keys(byRank).map(Number));
             const ranks = Array.from({ length: maxRank + 1 }, (_, r) => ({ rank: r, count: byRank[r] ?? 0 })).filter(r => r.count > 0);
             if (filterRank !== null) {
-              const targetRank = filterRank === "unranked" ? 0 : filterRank as number;
+              const targetRank = filterRank === "unranked" ? 0 : filterRank;
               if ((byRank[targetRank] ?? 0) === 0) return [];
             }
             const total = Object.values(byRank).reduce((a, b) => a + b, 0);
@@ -265,4 +265,4 @@ export default function InventoryGrid({
       )}
     </div>
   );
-}
+});

--- a/src/InventoryGrid.tsx
+++ b/src/InventoryGrid.tsx
@@ -1,0 +1,268 @@
+import { memo } from "react";
+import ItemImg from "./ItemImg";
+import type { ViewMode } from "./ViewToggle";
+import { fmt, deltaClass, deltaText } from "./utils";
+import "./InventoryGrid.css";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export type { ViewMode } from "./ViewToggle";
+
+export interface InventoryGridItem {
+  unique_name: string;
+  name: string;
+  category: string;
+  image_name?: string | null;
+  qty: number;
+}
+
+interface InventoryGridProps {
+  items: InventoryGridItem[];
+  loading: boolean;
+  monitoring: boolean;
+  view: ViewMode;
+  inventory: Record<string, { mastery_rank: number }>;
+  modCopies: Record<string, { rank: number | null; count: number }[]>;
+  favorites: Set<string>;
+  lastChanged: Record<string, number>;
+  changes: Map<string, { delta: number }>;
+  crafting: Map<string, { item_name: string }>;
+  filterRank: string | number | null;
+  onToggleFavorite: (id: string) => void;
+  onContextMenu?: (e: React.MouseEvent) => void;
+}
+
+// ─── Memoized inventory card components ──────────────────────────────────────
+
+interface InvModCardProps {
+  unique_name: string;
+  name: string;
+  category: string;
+  image_name?: string | null;
+  ranks: { rank: number; count: number }[];
+  total: number;
+  view: ViewMode;
+}
+const InvModCard = memo(function InvModCard({ unique_name, name, category, image_name, ranks, total, view }: InvModCardProps) {
+  if (view === "icons") {
+    return (
+      <div key={unique_name} className="inv-card inv-card-icon-only" title={`${name} ×${fmt(total)}`}>
+        <ItemImg imageName={image_name ?? undefined} category={category} size={52} />
+      </div>
+    );
+  }
+  if (view === "list" || view === "list-compact") {
+    return (
+      <div key={unique_name} className="inv-card inv-card-row">
+        {view === "list" && <div className="inv-row-icon"><ItemImg imageName={image_name ?? undefined} category={category} size={20} /></div>}
+        <div className="inv-row-name">{name}</div>
+        <div className="inv-row-cat">{category}</div>
+        <div className="inv-row-qty">{fmt(total)}</div>
+      </div>
+    );
+  }
+  return (
+    <div key={unique_name} className="inv-card inv-card-mod">
+      {view !== "text-cards" && (
+        <div className="inv-card-img-wrap">
+          <ItemImg imageName={image_name ?? undefined} category={category} size={40} />
+        </div>
+      )}
+      <div className="inv-card-name">{name}</div>
+      <div className="inv-card-cat">{category}</div>
+      <div className="mod-rank-table">
+        {ranks.map(r => (
+          <div key={r.rank} className={`mod-rank-row${r.count === 0 ? " mod-rank-zero" : ""}`}>
+            <span className="mod-rank-label">R{r.rank}</span>
+            <span className="mod-rank-count">{r.count}</span>
+          </div>
+        ))}
+      </div>
+      <div className="inv-card-qty mod-total">{fmt(total)}</div>
+    </div>
+  );
+}, (prev, next) =>
+  prev.view === next.view &&
+  prev.unique_name === next.unique_name &&
+  prev.name === next.name &&
+  prev.total === next.total &&
+  prev.image_name === next.image_name &&
+  prev.ranks.length === next.ranks.length &&
+  prev.ranks.every((r, i) => r.rank === next.ranks[i].rank && r.count === next.ranks[i].count)
+);
+
+interface InvCardProps {
+  unique_name: string;
+  name: string;
+  category: string;
+  image_name?: string | null;
+  qty: number;
+  isFavorite: boolean;
+  changedAt: number | undefined;
+  recentDelta: number | null;
+  craftJobName: string | null;
+  masteryRank: number | undefined;
+  onToggleFavorite: (id: string) => void;
+  view: ViewMode;
+}
+const InvCard = memo(function InvCard({
+  unique_name, name, category, image_name, qty,
+  isFavorite, changedAt, recentDelta, craftJobName, masteryRank, onToggleFavorite, view,
+}: InvCardProps) {
+  const nowSec = Date.now() / 1000;
+  const secAgo = changedAt != null ? nowSec - changedAt : null;
+  const isRecent = secAgo !== null && secAgo < 300;
+  const isZero = qty === 0 && !craftJobName;
+  const isMastered = masteryRank != null && masteryRank >= 30;
+  const showRank = masteryRank != null && masteryRank > 0;
+  const recentLabel = secAgo !== null ? (Math.floor(secAgo / 60) === 0 ? "· now" : `· ${Math.floor(secAgo / 60)}m`) : null;
+  const baseClass = `inv-card${isZero ? " inv-card-zero" : ""}${isRecent ? (recentDelta != null && recentDelta > 0 ? " inv-card-gained" : " inv-card-lost") : ""}`;
+
+  if (view === "icons") {
+    return (
+      <div className={`${baseClass} inv-card-icon-only`} title={`${name} (${fmt(qty)})`}>
+        <ItemImg imageName={image_name ?? undefined} category={category} size={52} />
+      </div>
+    );
+  }
+  if (view === "list" || view === "list-compact") {
+    return (
+      <div className={`${baseClass} inv-card-row`}>
+        <button className={`inv-fav-star-row ${isFavorite ? "active" : ""}`}
+          title={isFavorite ? "Remove from Modular Window" : "Add to Modular Window"}
+          onClick={e => { e.stopPropagation(); onToggleFavorite(unique_name); }}>
+          {isFavorite ? "★" : "☆"}
+        </button>
+        {view === "list" && (
+          <div className="inv-row-icon">
+            <ItemImg imageName={image_name ?? undefined} category={category} size={20} />
+            {craftJobName && <span className="inv-foundry-icon-row" title={`Building — ${craftJobName}`}>⚒</span>}
+          </div>
+        )}
+        <div className="inv-row-name">
+          {name}
+          {isRecent && <span className="item-updated">{recentLabel}</span>}
+        </div>
+        <div className="inv-row-cat">{category}</div>
+        <div className="inv-row-qty">
+          {fmt(qty)}
+          {isRecent && recentDelta != null && <span className={`item-delta ${deltaClass(recentDelta)}`}>{deltaText(recentDelta)}</span>}
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className={baseClass}>
+      <button
+        className={`inv-fav-star ${isFavorite ? "active" : ""}`}
+        title={isFavorite ? "Remove from Modular Window" : "Add to Modular Window"}
+        onClick={e => { e.stopPropagation(); onToggleFavorite(unique_name); }}
+      >{isFavorite ? "★" : "☆"}</button>
+      <div className="inv-mastery-row">
+        {isMastered
+          ? <span className="inv-mastery-star" title="Mastered">★</span>
+          : showRank
+            ? <span className="inv-mastery-rank" title={`Rank ${masteryRank}`}>R{masteryRank}</span>
+            : null}
+      </div>
+      {view !== "text-cards" && (
+        <div className="inv-card-img-wrap">
+          <ItemImg imageName={image_name ?? undefined} category={category} size={48} />
+          {craftJobName && <span className="inv-foundry-icon" title={`Building — ${craftJobName}`}>⚒</span>}
+        </div>
+      )}
+      <div className="inv-card-name">
+        {name}
+        {isRecent && <span className="item-updated">{recentLabel}</span>}
+      </div>
+      <div className="inv-card-cat">{category}</div>
+      <div className={`inv-card-qty ${isZero ? "inv-card-qty-zero" : ""}`}>
+        {fmt(qty)}
+        {isRecent && recentDelta != null && (
+          <span className={`item-delta ${deltaClass(recentDelta)}`}>{deltaText(recentDelta)}</span>
+        )}
+      </div>
+    </div>
+  );
+}, (prev, next) => {
+  if (prev.view !== next.view) return false;
+  if (
+    prev.unique_name !== next.unique_name ||
+    prev.qty !== next.qty ||
+    prev.isFavorite !== next.isFavorite ||
+    prev.image_name !== next.image_name ||
+    prev.masteryRank !== next.masteryRank ||
+    prev.craftJobName !== next.craftJobName ||
+    prev.recentDelta !== next.recentDelta ||
+    prev.changedAt !== next.changedAt
+  ) return false;
+  // Recently-changed items must re-render so elapsed time stays fresh
+  const nowSec = Date.now() / 1000;
+  if (prev.changedAt != null && nowSec - prev.changedAt < 300) return false;
+  return true;
+});
+
+// ─── Main grid component ────────────────────────────────────────────────────
+
+export default function InventoryGrid({
+  items, loading, monitoring, view,
+  inventory, modCopies, favorites, lastChanged, changes, crafting,
+  filterRank, onToggleFavorite, onContextMenu,
+}: InventoryGridProps) {
+  return (
+    <div className={`item-grid item-grid-${view}`}
+         onContextMenu={onContextMenu}>
+      {loading ? (
+        Array.from({ length: 20 }, (_, i) => (
+          <div key={i} className="inv-card inventory-skeleton" />
+        ))
+      ) : items.length === 0 ? (
+        <div className="empty-msg" style={{gridColumn:"1/-1"}}>
+          {monitoring
+            ? "No items found. Complete a mission or visit a relay to sync inventory."
+            : "Start the monitor to begin tracking your inventory."}
+        </div>
+      ) : (
+        items.flatMap(item => {
+          // Mods & Arcanes: single card with inline rank breakdown
+          if ((item.category === "Mods" || item.category === "Arcanes") && modCopies[item.unique_name]) {
+            const copies = modCopies[item.unique_name];
+            const byRank: Record<number, number> = {};
+            for (const c of copies) byRank[c.rank ?? 0] = (byRank[c.rank ?? 0] ?? 0) + c.count;
+            const maxRank = Math.max(...Object.keys(byRank).map(Number));
+            const ranks = Array.from({ length: maxRank + 1 }, (_, r) => ({ rank: r, count: byRank[r] ?? 0 })).filter(r => r.count > 0);
+            if (filterRank !== null) {
+              const targetRank = filterRank === "unranked" ? 0 : filterRank as number;
+              if ((byRank[targetRank] ?? 0) === 0) return [];
+            }
+            const total = Object.values(byRank).reduce((a, b) => a + b, 0);
+            return [(
+              <InvModCard key={item.unique_name}
+                unique_name={item.unique_name} name={item.name}
+                category={item.category} image_name={item.image_name}
+                ranks={ranks} total={total} view={view} />
+            )];
+          }
+
+          // Normal item card
+          const changedAt = lastChanged[item.unique_name];
+          const recentChange = changedAt != null ? changes.get(item.unique_name) : undefined;
+          const craftJob = crafting.get(item.unique_name);
+          return [(
+            <InvCard key={item.unique_name}
+              unique_name={item.unique_name} name={item.name}
+              category={item.category} image_name={item.image_name}
+              qty={item.qty}
+              isFavorite={favorites.has(item.unique_name)}
+              changedAt={changedAt}
+              recentDelta={recentChange?.delta ?? null}
+              craftJobName={craftJob?.item_name ?? null}
+              masteryRank={inventory[item.unique_name]?.mastery_rank}
+              onToggleFavorite={onToggleFavorite}
+              view={view} />
+          )];
+        })
+      )}
+    </div>
+  );
+}

--- a/src/InventoryToolbar.tsx
+++ b/src/InventoryToolbar.tsx
@@ -1,0 +1,63 @@
+import type { Dispatch, SetStateAction } from "react";
+import { HelpTip } from "./HelpTip";
+import type { InventoryFilters } from "./InventoryFilters";
+import SearchBar from "./SearchBar";
+import { ViewToggle, type ViewMode } from "./ViewToggle";
+
+interface InventoryToolbarProps {
+  filters: InventoryFilters;
+  onFiltersChange: Dispatch<SetStateAction<InventoryFilters>>;
+  onToggleRecent: () => void;
+  availableRanks: number[];
+  showRankFilters: boolean;
+  itemCount: number;
+  view: ViewMode;
+  onViewChange: (view: ViewMode) => void;
+}
+
+export default function InventoryToolbar({
+  filters, onFiltersChange, onToggleRecent, availableRanks, showRankFilters, itemCount, view, onViewChange,
+}: InventoryToolbarProps) {
+  const { search, filterOwned, filterRecent, filterPrime, filterVaulted, filterUnvaulted, filterRank, sortMode } = filters;
+  return (
+    <>
+      <div className="toolbar">
+        <SearchBar
+          placeholder="Search items…"
+          value={search}
+          onChange={search => onFiltersChange(previous => ({ ...previous, search }))}
+        />
+      </div>
+      <div className="filter-bar">
+        <button className={`fchip ${filterOwned ? "fchip-on" : ""}`} onClick={() => onFiltersChange(previous => ({ ...previous, filterOwned: !previous.filterOwned }))}>Owned</button>
+        <button className={`fchip ${filterRecent ? "fchip-on" : ""}`} onClick={onToggleRecent}>Changed recently</button>
+        <button className={`fchip ${filterPrime ? "fchip-on" : ""}`} onClick={() => onFiltersChange(previous => ({ ...previous, filterPrime: !previous.filterPrime }))}>Prime</button>
+        <button className={`fchip ${filterVaulted ? "fchip-on" : ""}`} onClick={() => onFiltersChange(previous => ({ ...previous, filterVaulted: !previous.filterVaulted }))}>🔒 Vaulted</button>
+        <button className={`fchip ${filterUnvaulted ? "fchip-on" : ""}`} onClick={() => onFiltersChange(previous => ({ ...previous, filterUnvaulted: !previous.filterUnvaulted }))}>🔓 Unvaulted</button>
+        {showRankFilters && <>
+          <span className="fbar-sep" />
+          <span className="fbar-label">Rank:</span>
+          <button className={`fchip ${filterRank === "unranked" ? "fchip-on" : ""}`} onClick={() => onFiltersChange(previous => ({ ...previous, filterRank: previous.filterRank === "unranked" ? null : "unranked" }))}>Unranked</button>
+          {availableRanks.map(rank => (
+            <button key={rank} className={`fchip ${filterRank === rank ? "fchip-on" : ""}`} onClick={() => onFiltersChange(previous => ({ ...previous, filterRank: previous.filterRank === rank ? null : rank }))}>R{rank}</button>
+          ))}
+        </>}
+        <span className="fbar-sep" />
+        <span className="fbar-label">Sort:</span>
+        <button className={`fchip ${sortMode === "qty-desc" ? "fchip-on" : ""}`} onClick={() => onFiltersChange(previous => ({ ...previous, sortMode: "qty-desc" }))}>Qty ↓</button>
+        <button className={`fchip ${sortMode === "qty-asc" ? "fchip-on" : ""}`} onClick={() => onFiltersChange(previous => ({ ...previous, sortMode: "qty-asc" }))}>Qty ↑</button>
+        <button className={`fchip ${sortMode === "name-asc" ? "fchip-on" : ""}`} onClick={() => onFiltersChange(previous => ({ ...previous, sortMode: "name-asc" }))}>A-Z</button>
+        <button className={`fchip ${sortMode === "name-desc" ? "fchip-on" : ""}`} onClick={() => onFiltersChange(previous => ({ ...previous, sortMode: "name-desc" }))}>Z-A</button>
+        <span className="item-count-label" style={{ marginLeft: "auto" }}>{itemCount} item{itemCount !== 1 ? "s" : ""}{itemCount === 1000 ? " (capped)" : ""}</span>
+        <ViewToggle view={view} onChange={onViewChange} />
+        <HelpTip items={[
+          { icon: "★", label: "★  Mastered", desc: "Shown above image — item levelled to rank 30" },
+          { icon: "R5", label: "R{n}  Rank", desc: "Shown above image — current rank, not yet mastered" },
+          { icon: "⚒", label: "⚒  Building", desc: "Shown on image — currently crafting in Foundry" },
+          { swatch: "rgba(63,185,80,.5)", label: "Green border", desc: "Item recently gained" },
+          { swatch: "rgba(248,81,73,.5)", label: "Red border", desc: "Item recently lost or consumed" },
+        ]} />
+      </div>
+    </>
+  );
+}

--- a/src/ItemImg.tsx
+++ b/src/ItemImg.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from "react";
+import { useContext, useState, useRef, useEffect } from "react";
 import { ImgCacheDirContext } from "./ImgCacheDir";
 
 function BlueprintIcon() {
@@ -20,18 +20,24 @@ export default function ItemImg({ imageName, category, size = 32 }: { imageName?
   const baseUrl = useContext(ImgCacheDirContext);
   const [localFailed, setLocalFailed] = useState(false);
   const [failed, setFailed] = useState(false);
+  const ref = useRef<HTMLImageElement>(null);
   const style = { width: size, height: size, flexShrink: 0 as const };
+
+  useEffect(() => {
+    if (ref.current?.complete) ref.current.classList.add("img-loaded");
+  });
+
   if (!imageName || failed) {
     if (category === "Blueprints") return <BlueprintIcon />;
     return <span className="item-img-fallback" style={{ ...style, fontSize: size * 0.35 }}>{category[0].toUpperCase()}</span>;
   }
   if (imageName.startsWith("http") || imageName.startsWith("/")) {
-    return <img className="item-img" style={style} src={imageName} alt="" loading="lazy" onError={() => setFailed(true)} />;
+    return <img ref={ref} className="item-img" style={style} src={imageName} alt="" loading="lazy" onError={() => setFailed(true)} onLoad={() => ref.current?.classList.add("img-loaded")} />;
   }
   const useLocal = Boolean(baseUrl) && !localFailed;
   const src = useLocal ? `${baseUrl}/${imageName}` : `https://cdn.warframestat.us/img/${imageName}`;
   return (
-    <img className="item-img" style={style} src={src} alt="" loading="lazy"
-      onError={() => useLocal ? setLocalFailed(true) : setFailed(true)} />
+    <img ref={ref} className="item-img" style={style} src={src} alt="" loading="lazy"
+      onError={() => useLocal ? setLocalFailed(true) : setFailed(true)} onLoad={() => ref.current?.classList.add("img-loaded")} />
   );
 }

--- a/src/ItemImg.tsx
+++ b/src/ItemImg.tsx
@@ -3,7 +3,7 @@ import { ImgCacheDirContext } from "./ImgCacheDir";
 
 function BlueprintIcon() {
   return (
-    <svg className="item-img-fallback" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg className="img-fallback" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
       <rect x="5" y="2" width="17" height="22" rx="1.5" fill="#0d1f33" stroke="#388bfd" strokeWidth="1.2"/>
       <path d="M18 2 L22 6 L18 6 Z" fill="#388bfd" opacity="0.5"/>
       <line x1="8" y1="11" x2="19" y2="11" stroke="#388bfd" strokeWidth="1" opacity="0.9"/>
@@ -29,15 +29,15 @@ export default function ItemImg({ imageName, category, size = 32 }: { imageName?
 
   if (!imageName || failed) {
     if (category === "Blueprints") return <BlueprintIcon />;
-    return <span className="item-img-fallback" style={{ ...style, fontSize: size * 0.35 }}>{category[0].toUpperCase()}</span>;
+    return <span className="img-fallback" style={{ ...style, fontSize: size * 0.35 }}>{category[0].toUpperCase()}</span>;
   }
   if (imageName.startsWith("http") || imageName.startsWith("/")) {
-    return <img ref={ref} className="item-img" style={style} src={imageName} alt="" loading="lazy" onError={() => setFailed(true)} onLoad={() => ref.current?.classList.add("img-loaded")} />;
+    return <img ref={ref} className="img" style={style} src={imageName} alt="" loading="lazy" onError={() => setFailed(true)} onLoad={() => ref.current?.classList.add("img-loaded")} />;
   }
   const useLocal = Boolean(baseUrl) && !localFailed;
   const src = useLocal ? `${baseUrl}/${imageName}` : `https://cdn.warframestat.us/img/${imageName}`;
   return (
-    <img ref={ref} className="item-img" style={style} src={src} alt="" loading="lazy"
+    <img ref={ref} className="img" style={style} src={src} alt="" loading="lazy"
       onError={() => useLocal ? setLocalFailed(true) : setFailed(true)} onLoad={() => ref.current?.classList.add("img-loaded")} />
   );
 }

--- a/src/ItemImg.tsx
+++ b/src/ItemImg.tsx
@@ -25,7 +25,7 @@ export default function ItemImg({ imageName, category, size = 32 }: { imageName?
 
   useEffect(() => {
     if (ref.current?.complete) ref.current.classList.add("img-loaded");
-  });
+  }, []);
 
   if (!imageName || failed) {
     if (category === "Blueprints") return <BlueprintIcon />;

--- a/src/RelicHelper.tsx
+++ b/src/RelicHelper.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { HelpTip } from "./HelpTip";
-import type { InventoryItem, ViewMode } from "./App";
-import { ViewToggle } from "./App";
+import type { InventoryItem } from "./App";
+import type { ViewMode } from "./ViewToggle";
+import { ViewToggle } from "./ViewToggle";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 

--- a/src/Reports.tsx
+++ b/src/Reports.tsx
@@ -275,17 +275,16 @@ function ItemImg({ imageName, size = 28 }: { imageName?: string; size?: number }
   const [localFailed, setLocalFailed] = useState(false);
   const [failed, setFailed] = useState(false);
   const ref = useRef<HTMLImageElement>(null);
-  const s: React.CSSProperties = { width: size, height: size, objectFit: "contain", flexShrink: 0, borderRadius: 3 };
 
   useEffect(() => {
-    if (ref.current?.complete) ref.current.style.opacity = "1";
-  });
+    if (ref.current?.complete) ref.current.classList.add("img-loaded");
+  }, []);
 
   if (!imageName || failed)
-    return <span style={{ ...s, background: "rgba(255,255,255,.06)", border: "1px solid #30363d", display: "inline-block" }} />;
+    return <span className="img-fallback" style={{ width: size, height: size }} />;
   const useLocal = Boolean(baseUrl) && !localFailed;
   const src = useLocal ? `${baseUrl}/${imageName}` : `https://cdn.warframestat.us/img/${imageName}`;
-  return <img ref={ref} style={{ ...s, opacity: 0, transform: "translate(-4px, -4px) scale(0.9)", transition: "opacity 0.25s ease-out, transform 0.25s ease-out" }} src={src} alt="" loading="lazy" onError={() => useLocal ? setLocalFailed(true) : setFailed(true)} onLoad={(e) => { e.currentTarget.style.opacity = "1"; e.currentTarget.style.transform = "translate(0,0) scale(1)"; }} />;
+  return <img ref={ref} className="img" style={{ width: size, height: size }} src={src} alt="" loading="lazy" onError={() => useLocal ? setLocalFailed(true) : setFailed(true)} onLoad={() => ref.current?.classList.add("img-loaded")} />;
 }
 
 interface Props {

--- a/src/Reports.tsx
+++ b/src/Reports.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useContext } from "react";
+import { useState, useEffect, useMemo, useContext, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { ImgCacheDirContext } from "./ImgCacheDir";
 import "./Reports.css";
@@ -274,12 +274,18 @@ function ItemImg({ imageName, size = 28 }: { imageName?: string; size?: number }
   const baseUrl = useContext(ImgCacheDirContext);
   const [localFailed, setLocalFailed] = useState(false);
   const [failed, setFailed] = useState(false);
+  const ref = useRef<HTMLImageElement>(null);
   const s: React.CSSProperties = { width: size, height: size, objectFit: "contain", flexShrink: 0, borderRadius: 3 };
+
+  useEffect(() => {
+    if (ref.current?.complete) ref.current.style.opacity = "1";
+  });
+
   if (!imageName || failed)
     return <span style={{ ...s, background: "rgba(255,255,255,.06)", border: "1px solid #30363d", display: "inline-block" }} />;
   const useLocal = Boolean(baseUrl) && !localFailed;
   const src = useLocal ? `${baseUrl}/${imageName}` : `https://cdn.warframestat.us/img/${imageName}`;
-  return <img style={s} src={src} alt="" loading="lazy" onError={() => useLocal ? setLocalFailed(true) : setFailed(true)} />;
+  return <img ref={ref} style={{ ...s, opacity: 0, transform: "translate(-4px, -4px) scale(0.9)", transition: "opacity 0.25s ease-out, transform 0.25s ease-out" }} src={src} alt="" loading="lazy" onError={() => useLocal ? setLocalFailed(true) : setFailed(true)} onLoad={(e) => { e.currentTarget.style.opacity = "1"; e.currentTarget.style.transform = "translate(0,0) scale(1)"; }} />;
 }
 
 interface Props {

--- a/src/Reports.tsx
+++ b/src/Reports.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useContext } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { cdnUrl, useImgLadder } from "./ImgCacheDir";
+import { ImgCacheDirContext } from "./ImgCacheDir";
 import "./Reports.css";
 
 interface WfmTopItem {
@@ -271,11 +271,15 @@ function Legend({ items }: { items: { label: string; color: string; value: numbe
 // ── Main component ───────────────────────────────────────────────────────────
 
 function ItemImg({ imageName, size = 28 }: { imageName?: string; size?: number }) {
-  const { src, onError } = useImgLadder([cdnUrl(imageName)]);
+  const baseUrl = useContext(ImgCacheDirContext);
+  const [localFailed, setLocalFailed] = useState(false);
+  const [failed, setFailed] = useState(false);
   const s: React.CSSProperties = { width: size, height: size, objectFit: "contain", flexShrink: 0, borderRadius: 3 };
-  if (!src)
+  if (!imageName || failed)
     return <span style={{ ...s, background: "rgba(255,255,255,.06)", border: "1px solid #30363d", display: "inline-block" }} />;
-  return <img key={src} style={s} src={src} alt="" loading="lazy" onError={onError} />;
+  const useLocal = Boolean(baseUrl) && !localFailed;
+  const src = useLocal ? `${baseUrl}/${imageName}` : `https://cdn.warframestat.us/img/${imageName}`;
+  return <img style={s} src={src} alt="" loading="lazy" onError={() => useLocal ? setLocalFailed(true) : setFailed(true)} />;
 }
 
 interface Props {

--- a/src/Syndicates.css
+++ b/src/Syndicates.css
@@ -169,7 +169,11 @@
   object-fit: contain;
   flex-shrink: 0;
   border-radius: 4px;
+  opacity: 0;
+  transform: translate(-4px, -4px) scale(0.9);
+  transition: opacity 0.25s ease-out, transform 0.25s ease-out;
 }
+.syn-item-img.img-loaded { opacity: 1; transform: translate(0, 0) scale(1); }
 .syn-item-img-fallback {
   width: 32px;
   height: 32px;

--- a/src/Syndicates.css
+++ b/src/Syndicates.css
@@ -163,29 +163,7 @@
 .syn-item:hover { background: var(--hover); border-color: var(--border); }
 .syn-item.missing { opacity: 0.5; }
 
-.syn-item-img {
-  width: 32px;
-  height: 32px;
-  object-fit: contain;
-  flex-shrink: 0;
-  border-radius: 4px;
-  opacity: 0;
-  transform: translate(-4px, -4px) scale(0.9);
-  transition: opacity 0.25s ease-out, transform 0.25s ease-out;
-}
-.syn-item-img.img-loaded { opacity: 1; transform: translate(0, 0) scale(1); }
-.syn-item-img-fallback {
-  width: 32px;
-  height: 32px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--bg-card);
-  border-radius: 4px;
-  font-size: 11px;
-  color: var(--text-dim);
-  flex-shrink: 0;
-}
+/* .syn-item-img, .syn-item-img-fallback removed — now in images.css */
 
 .syn-item-info { flex: 1; min-width: 0; }
 .syn-item-name {

--- a/src/Syndicates.tsx
+++ b/src/Syndicates.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useContext } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { cdnUrl, useImgLadder } from "./ImgCacheDir";
+import { ImgCacheDirContext } from "./ImgCacheDir";
 import "./Syndicates.css";
 import type { InventoryItem } from "./App";
 
@@ -103,22 +103,25 @@ const GROUP_LABELS: Record<SynGroup, string> = {
 // ── Image component ───────────────────────────────────────────────────────────
 
 function SynItemImg({ imageName, category }: { imageName?: string; category: string }) {
-  const { src, onError } = useImgLadder([cdnUrl(imageName)]);
-  if (!src) {
+  const baseUrl = useContext(ImgCacheDirContext);
+  const [localFailed, setLocalFailed] = useState(false);
+  const [failed, setFailed] = useState(false);
+  if (!imageName || failed) {
     return (
       <div className="syn-item-img-fallback">
         {category[0]?.toUpperCase() ?? "?"}
       </div>
     );
   }
+  const useLocal = Boolean(baseUrl) && !localFailed;
+  const src = useLocal ? `${baseUrl}/${imageName}` : `https://cdn.warframestat.us/img/${imageName}`;
   return (
     <img
-      key={src}
       className="syn-item-img"
       src={src}
       alt=""
       loading="lazy"
-      onError={onError}
+      onError={() => useLocal ? setLocalFailed(true) : setFailed(true)}
     />
   );
 }

--- a/src/Syndicates.tsx
+++ b/src/Syndicates.tsx
@@ -114,7 +114,7 @@ function SynItemImg({ imageName, category }: { imageName?: string; category: str
 
   if (!imageName || failed) {
     return (
-      <div className="syn-item-img-fallback">
+      <div className="img-fallback">
         {category[0]?.toUpperCase() ?? "?"}
       </div>
     );
@@ -124,7 +124,7 @@ function SynItemImg({ imageName, category }: { imageName?: string; category: str
   return (
     <img
       ref={ref}
-      className="syn-item-img"
+      className="img"
       src={src}
       alt=""
       loading="lazy"

--- a/src/Syndicates.tsx
+++ b/src/Syndicates.tsx
@@ -110,7 +110,7 @@ function SynItemImg({ imageName, category }: { imageName?: string; category: str
 
   useEffect(() => {
     if (ref.current?.complete) ref.current.classList.add("img-loaded");
-  });
+  }, []);
 
   if (!imageName || failed) {
     return (

--- a/src/Syndicates.tsx
+++ b/src/Syndicates.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useContext } from "react";
+import { useState, useEffect, useMemo, useContext, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { ImgCacheDirContext } from "./ImgCacheDir";
 import "./Syndicates.css";
@@ -106,6 +106,12 @@ function SynItemImg({ imageName, category }: { imageName?: string; category: str
   const baseUrl = useContext(ImgCacheDirContext);
   const [localFailed, setLocalFailed] = useState(false);
   const [failed, setFailed] = useState(false);
+  const ref = useRef<HTMLImageElement>(null);
+
+  useEffect(() => {
+    if (ref.current?.complete) ref.current.classList.add("img-loaded");
+  });
+
   if (!imageName || failed) {
     return (
       <div className="syn-item-img-fallback">
@@ -117,11 +123,13 @@ function SynItemImg({ imageName, category }: { imageName?: string; category: str
   const src = useLocal ? `${baseUrl}/${imageName}` : `https://cdn.warframestat.us/img/${imageName}`;
   return (
     <img
+      ref={ref}
       className="syn-item-img"
       src={src}
       alt=""
       loading="lazy"
       onError={() => useLocal ? setLocalFailed(true) : setFailed(true)}
+      onLoad={() => ref.current?.classList.add("img-loaded")}
     />
   );
 }

--- a/src/ViewToggle.tsx
+++ b/src/ViewToggle.tsx
@@ -1,0 +1,73 @@
+export type ViewMode = "cards" | "icons" | "text-cards" | "list" | "list-compact";
+
+const VIEW_LABELS: Record<ViewMode, string> = {
+  "cards":        "Cards (icon + text)",
+  "icons":        "Icon grid",
+  "text-cards":   "Text cards (no icons)",
+  "list":         "List with icon",
+  "list-compact": "Compact list (text only)",
+};
+
+function ViewIcon({ mode }: { mode: ViewMode }) {
+  switch (mode) {
+    case "cards": return (
+      <svg width="16" height="13" viewBox="0 0 16 13" fill="currentColor">
+        <rect x="0" y="0" width="3" height="3" rx="0.5"/><rect x="4" y="0.5" width="3.5" height="1.5" rx="0.4"/>
+        <rect x="9" y="0" width="3" height="3" rx="0.5"/><rect x="13" y="0.5" width="3.5" height="1.5" rx="0.4"/>
+        <rect x="0" y="5" width="3" height="3" rx="0.5"/><rect x="4" y="5.5" width="3.5" height="1.5" rx="0.4"/>
+        <rect x="9" y="5" width="3" height="3" rx="0.5"/><rect x="13" y="5.5" width="3.5" height="1.5" rx="0.4"/>
+        <rect x="0" y="10" width="3" height="3" rx="0.5"/><rect x="4" y="10.5" width="3.5" height="1.5" rx="0.4"/>
+        <rect x="9" y="10" width="3" height="3" rx="0.5"/><rect x="13" y="10.5" width="3.5" height="1.5" rx="0.4"/>
+      </svg>
+    );
+    case "icons": return (
+      <svg width="16" height="13" viewBox="0 0 16 13" fill="currentColor">
+        <rect x="0" y="0" width="4" height="4" rx="0.5"/><rect x="6" y="0" width="4" height="4" rx="0.5"/><rect x="12" y="0" width="4" height="4" rx="0.5"/>
+        <rect x="0" y="5" width="4" height="4" rx="0.5"/><rect x="6" y="5" width="4" height="4" rx="0.5"/><rect x="12" y="5" width="4" height="4" rx="0.5"/>
+        <rect x="0" y="10" width="4" height="4" rx="0.5"/><rect x="6" y="10" width="4" height="4" rx="0.5"/><rect x="12" y="10" width="4" height="4" rx="0.5"/>
+      </svg>
+    );
+    case "text-cards": return (
+      <svg width="16" height="13" viewBox="0 0 16 13" fill="currentColor">
+        <rect x="0" y="0" width="7" height="1.5" rx="0.4"/><rect x="0" y="2.5" width="5" height="1" rx="0.4"/>
+        <rect x="9" y="0" width="7" height="1.5" rx="0.4"/><rect x="9" y="2.5" width="5" height="1" rx="0.4"/>
+        <rect x="0" y="5" width="7" height="1.5" rx="0.4"/><rect x="0" y="7.5" width="5" height="1" rx="0.4"/>
+        <rect x="9" y="5" width="7" height="1.5" rx="0.4"/><rect x="9" y="7.5" width="5" height="1" rx="0.4"/>
+        <rect x="0" y="10" width="7" height="1.5" rx="0.4"/><rect x="0" y="12" width="5" height="1" rx="0.4"/>
+        <rect x="9" y="10" width="7" height="1.5" rx="0.4"/><rect x="9" y="12" width="5" height="1" rx="0.4"/>
+      </svg>
+    );
+    case "list": return (
+      <svg width="16" height="13" viewBox="0 0 16 13" fill="currentColor">
+        <rect x="0" y="0" width="2.5" height="2.5" rx="0.4"/><rect x="4" y="0.5" width="12" height="1.5" rx="0.4"/>
+        <rect x="0" y="3.5" width="2.5" height="2.5" rx="0.4"/><rect x="4" y="4" width="12" height="1.5" rx="0.4"/>
+        <rect x="0" y="7" width="2.5" height="2.5" rx="0.4"/><rect x="4" y="7.5" width="12" height="1.5" rx="0.4"/>
+        <rect x="0" y="10.5" width="2.5" height="2.5" rx="0.4"/><rect x="4" y="11" width="12" height="1.5" rx="0.4"/>
+      </svg>
+    );
+    case "list-compact": return (
+      <svg width="16" height="13" viewBox="0 0 16 13" fill="currentColor">
+        <rect x="0" y="0" width="16" height="1.5" rx="0.4"/>
+        <rect x="0" y="2.5" width="11" height="1.5" rx="0.4"/>
+        <rect x="0" y="5" width="16" height="1.5" rx="0.4"/>
+        <rect x="0" y="7.5" width="13" height="1.5" rx="0.4"/>
+        <rect x="0" y="10" width="16" height="1.5" rx="0.4"/>
+        <rect x="0" y="12" width="10" height="1" rx="0.4"/>
+      </svg>
+    );
+  }
+}
+
+export function ViewToggle({ view, onChange }: { view: ViewMode; onChange: (v: ViewMode) => void }) {
+  const modes: ViewMode[] = ["cards", "icons", "text-cards", "list", "list-compact"];
+  return (
+    <div className="view-toggle">
+      {modes.map(m => (
+        <button key={m} className={`view-btn${view === m ? " view-btn-active" : ""}`}
+          title={VIEW_LABELS[m]} onClick={() => onChange(m)}>
+          <ViewIcon mode={m} />
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/Weapons.css
+++ b/src/Weapons.css
@@ -148,7 +148,11 @@
   object-fit: contain;
   flex-shrink: 0;
   border-radius: 3px;
+  opacity: 0;
+  transform: translate(-4px, -4px) scale(0.9);
+  transition: opacity 0.25s ease-out, transform 0.25s ease-out;
 }
+.wpn-img.img-loaded { opacity: 1; transform: translate(0, 0) scale(1); }
 .wpn-img-fallback {
   width: 32px;
   height: 32px;

--- a/src/Weapons.css
+++ b/src/Weapons.css
@@ -142,29 +142,7 @@
 .wpn-item.wpn-mastered { border-color: rgba(80, 200, 120, 0.15); }
 .wpn-item.wpn-none { opacity: 0.45; }
 
-.wpn-img {
-  width: 32px;
-  height: 32px;
-  object-fit: contain;
-  flex-shrink: 0;
-  border-radius: 3px;
-  opacity: 0;
-  transform: translate(-4px, -4px) scale(0.9);
-  transition: opacity 0.25s ease-out, transform 0.25s ease-out;
-}
-.wpn-img.img-loaded { opacity: 1; transform: translate(0, 0) scale(1); }
-.wpn-img-fallback {
-  width: 32px;
-  height: 32px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--bg-card);
-  border-radius: 3px;
-  font-size: 11px;
-  color: var(--text-dim);
-  flex-shrink: 0;
-}
+/* .wpn-img, .wpn-img-fallback removed — now in images.css */
 
 .wpn-name {
   flex: 1;

--- a/src/Weapons.tsx
+++ b/src/Weapons.tsx
@@ -55,6 +55,12 @@ function WeaponImg({ imageName, name }: { imageName?: string; name: string }) {
   const baseUrl = useContext(ImgCacheDirContext);
   const [localFailed, setLocalFailed] = useState(false);
   const [failed, setFailed] = useState(false);
+  const ref = useRef<HTMLImageElement>(null);
+
+  useEffect(() => {
+    if (ref.current?.complete) ref.current.classList.add("img-loaded");
+  });
+
   if (!imageName || failed) {
     return <div className="wpn-img-fallback">{name[0]?.toUpperCase() ?? "?"}</div>;
   }
@@ -62,11 +68,13 @@ function WeaponImg({ imageName, name }: { imageName?: string; name: string }) {
   const src = useLocal ? `${baseUrl}/${imageName}` : `https://cdn.warframestat.us/img/${imageName}`;
   return (
     <img
+      ref={ref}
       className="wpn-img"
       src={src}
       alt=""
       loading="lazy"
       onError={() => useLocal ? setLocalFailed(true) : setFailed(true)}
+      onLoad={() => ref.current?.classList.add("img-loaded")}
     />
   );
 }

--- a/src/Weapons.tsx
+++ b/src/Weapons.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect, useMemo, useRef } from "react";
+import { useState, useEffect, useMemo, useRef, useContext } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { cdnUrl, useImgLadder } from "./ImgCacheDir";
+import { ImgCacheDirContext } from "./ImgCacheDir";
 import "./Weapons.css";
 import type { InventoryItem } from "./App";
 
@@ -52,18 +52,21 @@ function effectiveCap(item: WeaponItem): number {
 // ── Image ─────────────────────────────────────────────────────────────────────
 
 function WeaponImg({ imageName, name }: { imageName?: string; name: string }) {
-  const { src, onError } = useImgLadder([cdnUrl(imageName)]);
-  if (!src) {
+  const baseUrl = useContext(ImgCacheDirContext);
+  const [localFailed, setLocalFailed] = useState(false);
+  const [failed, setFailed] = useState(false);
+  if (!imageName || failed) {
     return <div className="wpn-img-fallback">{name[0]?.toUpperCase() ?? "?"}</div>;
   }
+  const useLocal = Boolean(baseUrl) && !localFailed;
+  const src = useLocal ? `${baseUrl}/${imageName}` : `https://cdn.warframestat.us/img/${imageName}`;
   return (
     <img
-      key={src}
       className="wpn-img"
       src={src}
       alt=""
       loading="lazy"
-      onError={onError}
+      onError={() => useLocal ? setLocalFailed(true) : setFailed(true)}
     />
   );
 }

--- a/src/Weapons.tsx
+++ b/src/Weapons.tsx
@@ -62,14 +62,14 @@ function WeaponImg({ imageName, name }: { imageName?: string; name: string }) {
   });
 
   if (!imageName || failed) {
-    return <div className="wpn-img-fallback">{name[0]?.toUpperCase() ?? "?"}</div>;
+    return <div className="img-fallback">{name[0]?.toUpperCase() ?? "?"}</div>;
   }
   const useLocal = Boolean(baseUrl) && !localFailed;
   const src = useLocal ? `${baseUrl}/${imageName}` : `https://cdn.warframestat.us/img/${imageName}`;
   return (
     <img
       ref={ref}
-      className="wpn-img"
+      className="img"
       src={src}
       alt=""
       loading="lazy"

--- a/src/Weapons.tsx
+++ b/src/Weapons.tsx
@@ -59,7 +59,7 @@ function WeaponImg({ imageName, name }: { imageName?: string; name: string }) {
 
   useEffect(() => {
     if (ref.current?.complete) ref.current.classList.add("img-loaded");
-  });
+  }, []);
 
   if (!imageName || failed) {
     return <div className="img-fallback">{name[0]?.toUpperCase() ?? "?"}</div>;

--- a/src/images.css
+++ b/src/images.css
@@ -1,0 +1,36 @@
+/* ── Generic image styles ───────────────────────────────────────────────────── */
+
+.img {
+  width: 32px;
+  height: 32px;
+  object-fit: contain;
+  flex-shrink: 0;
+  border-radius: 4px;
+  opacity: 0;
+  transform: translate(-4px, -4px) scale(0.9);
+  transition: opacity 0.25s ease-out, transform 0.25s ease-out;
+}
+.img.img-loaded {
+  opacity: 1;
+  transform: translate(0, 0) scale(1);
+}
+
+.img-fallback {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid #30363d;
+  color: var(--muted, #8b949e);
+  font-size: 11px;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+svg.img-fallback {
+  background: transparent;
+  border: none;
+  padding: 0;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,8 @@
+/** Format a number with locale-appropriate separators (e.g. 1234 → "1,234"). */
+export function fmt(n: number) { return n.toLocaleString(); }
+
+/** CSS class for a positive or negative delta. */
+export function deltaClass(d: number) { return d > 0 ? "delta-pos" : "delta-neg"; }
+
+/** Render a signed delta string (e.g. +5 / -3). */
+export function deltaText(d: number) { return d > 0 ? `+${fmt(d)}` : fmt(d); }


### PR DESCRIPTION
## Summary

The Inventory grid was a monolithic section inside `App.tsx`, images loaded directly from CDN without local caching, and the app flashed white on startup and close. This PR extracts the grid into a standalone component, adds local image caching with connection pooling, and fixes startup/close visual artifacts.

## What changed

- **`src/InventoryGrid.tsx`** *(new)*
  - Extracts `InventoryGrid`, `InvCard`, and `InvModCard` from `App.tsx`.
  - Memoized cards prevent unnecessary re-renders across 17k+ items.
  - Skeleton loading state shown until first monitor scan completes.

- **`src/InventoryGrid.css`** *(new)*
  - All inventory-specific styles extracted from `App.css`.
  - Grid alignment fixes: cards now stretch to fill grid cells consistently.

- **`src/ViewToggle.tsx`** *(new)*
  - Shared view-mode toggle component used by Inventory, Foundry, and Relics.
  - Exports `ViewMode` type for consistent cross-module usage.

- **`src/images.css`** *(new)*
  - Consolidated image styles: `.img`, `.img-fallback`, fade-in animation.
  - Replaces per-component `.item-img`, `.wpn-img`, `.syn-item-img` duplicates.

- **`src/utils.ts`** *(new)*
  - Shared helpers: `fmt`, `deltaClass`, `deltaText`.

- **`src/ItemImg.tsx`**
  - Uses local image cache via `ImgCacheDirContext` with CDN fallback.
  - Fade-in animation on load; instant display for cached images on remount.

- **`src/Weapons.tsx`**, **`src/Syndicates.tsx`**, **`src/Reports.tsx`**, **`src/Foundry.tsx`**
  - Migrated from `useImgLadder`/`cdnUrl` to local-first image loading.
  - Consistent fade-in animation across all tabs.

- **`src/ImgCacheDir.ts`**
  - Removed dead code: `useImgLadder`, `cdnUrl`, `cdnCandidates`.

- **`src/ChangeLog.tsx`**
  - Added right-click context menu (Open Wiki, Copy Wiki Link).

- **`src/App.tsx`**
  - Removed ~300 lines of inline inventory grid code.
  - Imports extracted components; passes data as props.
  - Prewarms all item images on startup (fire-and-forget).
  - Shows skeleton until first scan completes.

- **`src/App.css`**
  - Removed inventory-specific and duplicate view-toggle styles.

- **`index.html`**
  - Dark background on `<html>`/`<body>` to prevent white flash on startup.

- **`src-tauri/tauri.conf.json`**
  - Added `backgroundColor: "#161b22"` to prevent white flash on close.

- **`src-tauri/src/lib.rs`**
  - `prewarm_image_cache`: removed recipe-only filter, caches all items.
  - Added shared `ureq::Agent` with 10s timeout for connection pooling.
  - Added 5MB size limit on downloads to prevent memory exhaustion.

## Manual testing still recommended

- Launch the app and verify no white flash on startup or close.
- Verify inventory grid loads with skeleton, then shows items after first scan.
- Switch between Inventory, Foundry, Relics, Weapons, Syndicates — images should fade in smoothly.
- Right-click an item in the changelog — context menu should appear.
- Verify inventory cards align properly in grid view (no uneven gaps).
- Close and reopen the app — previously cached images should appear instantly.