### PR TITLE
WIP: Add support for arbitrations tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ A desktop companion for Warframe — live inventory, market prices, trading, tim
 
 ## Features
 
+### Arbitrations
+
+Browse the cached arbitration schedule up to 60 days ahead (seven by default),
+filter by farming tier, and favorite nodes. Optional alerts match favorites or
+selected tiers, with a ten-minute default lead time.
+
+Completed runs are recovered from EE.log at startup and tracked live. History
+supports deletion and analytics; Vitus values are estimates, and kill counts
+require host telemetry. An optional summary overlay closes after 12 seconds
+and is disabled by default. Parser/model attribution: [third-party notices](THIRD_PARTY_NOTICES.md).
+
 ### Live Inventory
 Reads your inventory directly from Warframe's process memory (read-only, same API as Overwolf). Instead of scanning for individual item patterns, FrameForge locates and captures the full account JSON blob that the game client holds in memory — the same authoritative data the game itself uses.
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,38 @@
+# Third-party notices
+
+FrameForge is licensed under the GPLv3 (see `LICENSE`). The components
+below were reimplemented from or derived from other projects and carry their
+original notices.
+
+## WFHelper: arbitration run parser and vitus model
+
+`src-tauri/src/arbitration.rs` reimplements the EE.log marker set, run
+counting rules and vitus-essence model of WFHelper
+(<https://github.com/WFHelper/WFHelper>, `services/arbiRunParser.ts` and
+`config/shared/arbiMath.ts`). The vitus model there follows
+<https://svesk.github.io/arbi>. The curated EE.log excerpts under
+`src-tauri/tests/fixtures/arbitration/` include WFHelper's test fixtures.
+
+```
+MIT License
+
+Copyright (c) 2026 WFHelper
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "test": "node --experimental-strip-types --test src/arbitration/*.test.ts",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "tauri": "tauri"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capability for the main window and overlay",
-  "windows": ["main", "relic-overlay", "relic-overlay-solid", "modular-popout", "wfm-login", "riven-overlay", "relic-pick-overlay", "overlay-test", "overlay-test-js"],
+  "windows": ["main", "relic-overlay", "relic-overlay-solid", "modular-popout", "wfm-login", "riven-overlay", "relic-pick-overlay", "overlay-test", "overlay-test-js", "arbitration-overlay"],
   "permissions": [
     "core:default",
     "opener:default",

--- a/src-tauri/src/arbitration.rs
+++ b/src-tauri/src/arbitration.rs
@@ -1,0 +1,1014 @@
+//! Arbitration run tracking from `EE.log`.
+//!
+//! Lines in, run events out. The parser holds no clock, does no I/O and keeps
+//! no global state, so the same code serves the live log tail and a backfill
+//! pass over a whole file.
+//!
+//! The marker set and the counting rules are a reimplementation of the
+//! MIT-licensed run parser and vitus model in WFHelper
+//! (<https://github.com/WFHelper/WFHelper>, `services/arbiRunParser.ts` and
+//! `config/shared/arbiMath.ts`). Its vitus model in turn follows
+//! svesk.github.io/arbi. See `THIRD_PARTY_NOTICES.md`.
+//!
+//! What the log can and cannot say shapes the record:
+//!
+//! - Only the host writes AI spawn lines, so a client-side run has no kill
+//!   or drone counts. `host_telemetry` says which kind a record is.
+//! - "Kills" are spawns the host logged. The log has no kill line, and in an
+//!   arbitration every spawn that is not decorative dies or ends the run.
+//! - Wave, reward and state-change lines are locale-independent; the mission
+//!   name is not, which is why the `_EliteAlert` sector suffix is the primary
+//!   arbitration marker and the "Arbitration" keyword only a fallback.
+//!
+//! Deliberately not ported: per-wave durations, the enemy-saturation
+//! histogram, squad member names and pause bookkeeping. The run record does
+//! not carry them and nothing downstream reads them yet.
+//!
+//! Deliberately different: the vitus estimate is filled for every mission
+//! type, where the original withholds it outside defense, interception and
+//! disruption. A per-run rate is the point of the record, and rotations and
+//! drones are counted the same way everywhere.
+//! TODO: the rotation-bonus term assumes three waves per rotation; survival
+//! rotations are five-minute intervals and may deserve their own factor.
+
+use chrono::{DateTime, NaiveDateTime, TimeDelta, Utc};
+use regex::Regex;
+use std::collections::HashSet;
+use std::sync::LazyLock;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MissionType {
+    Defense,
+    Interception,
+    Disruption,
+    Survival,
+    Other,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EndReason {
+    MissionEnd,
+    Aborted,
+    NewMission,
+    /// The input ended without an end marker; the run may still be going.
+    Unterminated,
+}
+
+impl MissionType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Defense => "defense",
+            Self::Interception => "interception",
+            Self::Disruption => "disruption",
+            Self::Survival => "survival",
+            Self::Other => "other",
+        }
+    }
+
+    /// An unrecognised name reads back as `Other` rather than failing, so a
+    /// database written by a later build still opens in this one.
+    pub fn from_stored(name: &str) -> Self {
+        match name {
+            "defense" => Self::Defense,
+            "interception" => Self::Interception,
+            "disruption" => Self::Disruption,
+            "survival" => Self::Survival,
+            _ => Self::Other,
+        }
+    }
+}
+
+impl EndReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::MissionEnd => "mission_end",
+            Self::Aborted => "aborted",
+            Self::NewMission => "new_mission",
+            Self::Unterminated => "unterminated",
+        }
+    }
+
+    /// A name this build does not know reads back as `Unterminated`: of the
+    /// four it is the one that claims least, where defaulting to `MissionEnd`
+    /// would report an unknown ending as a run the player completed.
+    pub fn from_stored(name: &str) -> Self {
+        match name {
+            "mission_end" => Self::MissionEnd,
+            "aborted" => Self::Aborted,
+            "new_mission" => Self::NewMission,
+            _ => Self::Unterminated,
+        }
+    }
+}
+
+/// Normal-approximation estimate of the vitus essence a run yields.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Vitus {
+    pub mean: f64,
+    pub std: f64,
+    /// `mean` over the run's combat window; 0 when the window is empty.
+    pub per_minute: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Run {
+    /// Wall clock of `run_start_sec`, when the log's boot-time header was seen.
+    pub started_at: Option<DateTime<Utc>>,
+    pub run_start_sec: f64,
+    pub run_end_sec: Option<f64>,
+    pub mission_name: String,
+    /// The mission name stripped of its arbitration decoration.
+    pub node: String,
+    /// Star chart node id such as `SolNode167`.
+    pub sol_node: Option<String>,
+    pub mission_type: MissionType,
+    /// The engine's `MT_*` type; outranks every name heuristic once seen.
+    pub mission_type_raw: Option<String>,
+    pub end_reason: EndReason,
+    /// Combat window: from the first gameplay marker to the last combat event.
+    pub duration_sec: f64,
+    pub rotations: u32,
+    /// Highest defense wave reached; 0 outside defense.
+    pub waves: u32,
+    pub waves_per_rotation: u32,
+    /// Non-decorative spawns plus drones.
+    pub kills: u32,
+    pub drone_kills: u32,
+    pub host_telemetry: bool,
+    pub vitus: Vitus,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Event {
+    RunStarted {
+        node: String,
+        mission_type: MissionType,
+        game_time_sec: f64,
+    },
+    WaveAdvanced(u32),
+    RotationAdvanced(u32),
+    AgentSpawned {
+        drone: bool,
+    },
+    RunEnded(Box<Run>),
+}
+
+// ==============================================================================
+// Vitus model
+// ==============================================================================
+
+const VITUS_DROP_CHANCE: f64 = 0.15;
+/// Chance the Retriever mod doubles a drop (4 instead of 2 vitus).
+const VITUS_RETRIEVER_CHANCE: f64 = 0.18;
+/// Chance a rotation reward is the bonus vitus bundle, per wave in the rotation.
+const ROTATION_VITUS_CHANCE: f64 = 0.1;
+
+pub fn vitus_model(rotations: u32, waves_per_rotation: u32, drones: u32) -> (f64, f64) {
+    let rotations = f64::from(rotations);
+    let waves = f64::from(waves_per_rotation);
+    let drones = f64::from(drones);
+
+    let drop_mean = 4.0 * VITUS_RETRIEVER_CHANCE + 2.0 * (1.0 - VITUS_RETRIEVER_CHANCE);
+    let drop_sq = 16.0 * VITUS_RETRIEVER_CHANCE + 4.0 * (1.0 - VITUS_RETRIEVER_CHANCE);
+    let drop_var = drop_sq - drop_mean * drop_mean;
+
+    let rot_mean = rotations + rotations * ROTATION_VITUS_CHANCE * waves;
+    let rot_var = rotations * ROTATION_VITUS_CHANCE * (1.0 - ROTATION_VITUS_CHANCE) * waves * waves;
+
+    let drops_mean = drones * VITUS_DROP_CHANCE;
+    let drops_var = drones * VITUS_DROP_CHANCE * (1.0 - VITUS_DROP_CHANCE);
+
+    let mean = rot_mean + drops_mean * drop_mean;
+    let variance = rot_var + drops_mean * drop_var + drop_mean * drop_mean * drops_var;
+    (mean, variance.max(0.0).sqrt())
+}
+
+// ==============================================================================
+// Line markers
+// ==============================================================================
+
+macro_rules! re {
+    ($name:ident, $pattern:expr) => {
+        static $name: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new($pattern).expect("pattern is a literal"));
+    };
+}
+
+re!(MISSION_NAME, r"ThemedSquadOverlay\.lua: Mission name: (.*)");
+re!(
+    AGENT_FULL,
+    r"OnAgentCreated.*?/Npc/(.+?)(\d+)\s+.*?MonitoredTicking\s+(\d+)"
+);
+re!(AGENT_NPC_NAME, r"/Npc/([A-Za-z0-9_]+)");
+re!(
+    AGENT_EXCLUDE,
+    r"(?i)Replicant|RJCrew|petavatar|VoidClone|Turret|Dropship|CatbrowPetAgent|AllyAgent"
+);
+re!(DEFENSE_WAVE, r"WaveDefend\.lua: Defense wave: (\d+)");
+re!(
+    TERRITORY_START,
+    r"(?i)TerritoryMission\.lua: .*(control|captured)"
+);
+// Selecting an arbitration logs its sector with an `_EliteAlert` suffix before
+// the localised mission name, on both the squad-overlay and map paths.
+re!(
+    PENDING_SECTOR_PLAIN,
+    r"(?:ThemedSquadOverlay\.lua: Pending mission:|MapRedux\.lua: Confirm sector) (\S+)"
+);
+re!(
+    PENDING_SECTOR_JSON,
+    r#"Set squad mission.*?"name":"([^"]+)""#
+);
+re!(ELITE_SECTOR, r"^(SolNode\d+)_EliteAlert$");
+// A mid-mission join never logs "Mission name:"; the client load is the only
+// start signal, and its sector still carries the suffix.
+re!(
+    CLIENT_MISSION_JOIN,
+    r#"Client (?:joining mission in-progress|loaded)[^{]*\{"name":"([^"]+)"\}"#
+);
+re!(
+    CACHED_MISSION_NAME,
+    r"ThemedSquadOverlay\.lua: Cached mission name=(.+) \((SolNode\d+)\)"
+);
+re!(
+    SYNC_CONSUMABLES,
+    r"SyncAutoPopulatedConsumables for mission (MT_[A-Z_]+) with location (\S+)"
+);
+re!(
+    STATE_STARTED,
+    r"Game \[Info\]: OnStateStarted, mission type=(MT_[A-Z_]+)"
+);
+
+const DRONE_AGENT: &str = "CorpusEliteShieldDroneAgent";
+const DEFENSE_REWARD: &str = "Sys [Info]: Created /Lotus/Interface/DefenseReward.swf";
+const SURVIVAL_REWARD: &str = "Sys [Info]: Created /Lotus/Interface/SurvivalReward.swf";
+const TERRITORY: &str = "Script [Info]: TerritoryMission.lua";
+const DISRUPTION_ROUND_START: &str =
+    "SentientArtifactMission.lua: Disruption: State change: ARTIFACT_ROUND";
+const DISRUPTION_ROUND_DONE: &str =
+    "SentientArtifactMission.lua: Disruption: State change: ARTIFACT_ROUND_DONE";
+// The confirmed abort and the end-of-match inventory commit are the reliable
+// ends. `EndOfMatch.lua: Initialize` and `Mission Succeeded` fire in-mission.
+const ABORT_CONFIRMED: &str = "TopMenu.lua: Abort:";
+const EOM_COMMIT: &str = "Sys [Info]: EOM missionLocationUnlocked=";
+const BOOT_TIME_UTC: &str = "[UTC: ";
+
+/// The reward UI can be created twice for one rotation.
+const REWARD_DEBOUNCE_SEC: f64 = 30.0;
+/// Mirror Defense runs two waves per rotation instead of three.
+const MIRROR_DEFENSE_NODES: [&str; 2] = ["munio", "tyana"];
+const DISRUPTION_CONDUITS_PER_ROUND: u32 = 4;
+
+/// Game-relative seconds at the head of a line. Warframe occasionally writes a
+/// stray character before the number, so leading non-digits are skipped.
+fn line_timestamp(line: &str) -> f64 {
+    let start = line
+        .find(|c: char| c.is_ascii_digit())
+        .unwrap_or(line.len());
+    let number = &line[start..];
+    let end = number
+        .find(|c: char| !c.is_ascii_digit() && c != '.')
+        .unwrap_or(number.len());
+    let number = &number[..end];
+    if number.contains('.') {
+        number.parse().unwrap_or(0.0)
+    } else {
+        0.0
+    }
+}
+
+fn is_spam(line: &str) -> bool {
+    line.contains("Game [Warning]:") || line.contains("DamagePct")
+}
+
+// ==============================================================================
+// Parser
+// ==============================================================================
+
+struct SpawnEvent {
+    name: Option<String>,
+    tick: Option<u32>,
+}
+
+struct RunState {
+    mission_name: String,
+    node: String,
+    sol_node: Option<String>,
+    mission_type: MissionType,
+    mission_type_raw: Option<String>,
+    waves_per_rotation: u32,
+    run_start_sec: f64,
+    /// Wall clock at game-time zero, snapshotted when the run started: a log
+    /// spanning several game launches carries a later header that would
+    /// otherwise redate every earlier run.
+    boot_time: Option<DateTime<Utc>>,
+    /// `OnStateStarted`, the instant gameplay begins.
+    mission_start_sec: Option<f64>,
+    /// First wave, first territory change or first disruption round.
+    precise_start_sec: Option<f64>,
+    run_end_sec: Option<f64>,
+    last_activity_sec: f64,
+    host_telemetry: bool,
+    rotations: u32,
+    last_reward_sec: f64,
+    waves: u32,
+    drone_kills: u32,
+    first_drone_sec: Option<f64>,
+    spawns: Vec<SpawnEvent>,
+}
+
+impl RunState {
+    fn activity(&mut self, ts: f64) {
+        self.last_activity_sec = self.last_activity_sec.max(ts);
+    }
+
+    fn apply_raw_type(&mut self, raw: &str) {
+        if self.mission_type_raw.is_some() {
+            return;
+        }
+        self.mission_type_raw = Some(raw.to_string());
+        self.mission_type = match raw {
+            "MT_DEFENSE" => MissionType::Defense,
+            "MT_TERRITORY" => MissionType::Interception,
+            "MT_ARTIFACT" => MissionType::Disruption,
+            "MT_SURVIVAL" => MissionType::Survival,
+            _ => MissionType::Other,
+        };
+        // Node names never say "Disruption"; the engine type is the only place
+        // the four-conduit rotation can be set.
+        if self.mission_type == MissionType::Disruption {
+            self.waves_per_rotation = DISRUPTION_CONDUITS_PER_ROUND;
+        }
+    }
+}
+
+/// Both name shapes exist: the legacy `Arbitration: Casta (Ceres)` and the
+/// current `Oestrus (Eris) - Arbitration` suffix form.
+fn classify_mission(mission_name: &str) -> (String, MissionType, u32) {
+    let node = mission_name
+        .replace("Arbitration:", "")
+        .trim()
+        .trim_end_matches("- Arbitration")
+        .trim()
+        .to_string();
+    let lower = node.to_lowercase();
+    let mirror = MIRROR_DEFENSE_NODES.iter().any(|m| lower.contains(m));
+    let mission_type = if lower.contains("defense") || mirror {
+        MissionType::Defense
+    } else if lower.contains("interception") {
+        MissionType::Interception
+    } else {
+        MissionType::Other
+    };
+    (node, mission_type, if mirror { 2 } else { 3 })
+}
+
+/// An agent name is confirmed ticking if any consecutive named pair shows its
+/// tick counter advancing; names only ever seen non-advancing are decorative.
+fn count_valid_spawns(spawns: &[SpawnEvent]) -> u32 {
+    let named: Vec<&SpawnEvent> = spawns.iter().filter(|s| s.name.is_some()).collect();
+    let mut confirmed = HashSet::new();
+    let mut suspected = HashSet::new();
+    for pair in named.windows(2) {
+        let (prev, curr) = (pair[0], pair[1]);
+        if let (Some(name), Some(prev_tick), Some(curr_tick)) = (&prev.name, prev.tick, curr.tick) {
+            if curr_tick > prev_tick {
+                confirmed.insert(name.as_str());
+            } else {
+                suspected.insert(name.as_str());
+            }
+        }
+    }
+    let decorative = |name: &str| suspected.contains(name) && !confirmed.contains(name);
+    spawns
+        .iter()
+        .filter(|s| !s.name.as_deref().is_some_and(decorative))
+        .count() as u32
+}
+
+#[derive(Default)]
+pub struct Parser {
+    /// Wall clock at game-time zero, from the log's `Current time:` header.
+    boot_time: Option<DateTime<Utc>>,
+    run: Option<RunState>,
+    /// Sector of the most recent mission select, e.g. `SolNode167_EliteAlert`.
+    pending_sector: Option<String>,
+    /// Squad-overlay mission name, the only name source when joining in progress.
+    cached_mission: Option<(String, String)>,
+}
+
+impl Parser {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn is_run_active(&self) -> bool {
+        self.run.is_some()
+    }
+
+    /// Feed one log line. A mission-name line can both close the current run
+    /// and open the next, which is why this returns a list.
+    pub fn feed_line(&mut self, line: &str) -> Vec<Event> {
+        let line = line.trim_end();
+        if line.is_empty() || is_spam(line) {
+            return Vec::new();
+        }
+        let ts = line_timestamp(line);
+
+        if let Some(utc) = line
+            .contains("Current time:")
+            .then(|| line.split_once(BOOT_TIME_UTC))
+            .flatten()
+            .and_then(|(_, rest)| rest.strip_suffix(']'))
+            .and_then(|s| NaiveDateTime::parse_from_str(s.trim(), "%a %b %e %H:%M:%S %Y").ok())
+        {
+            self.boot_time = Some(utc.and_utc());
+        }
+
+        if let Some(sector) = PENDING_SECTOR_PLAIN
+            .captures(line)
+            .or_else(|| PENDING_SECTOR_JSON.captures(line))
+        {
+            self.pending_sector = Some(sector[1].to_string());
+        }
+        if let Some(cached) = CACHED_MISSION_NAME.captures(line) {
+            self.cached_mission = Some((cached[1].trim().to_string(), cached[2].to_string()));
+        }
+
+        if self.run.is_none() {
+            if let Some(load) = CLIENT_MISSION_JOIN.captures(line) {
+                if let Some(joined) = ELITE_SECTOR.captures(&load[1]) {
+                    let sol_node = &joined[1];
+                    let name = match &self.cached_mission {
+                        Some((name, node)) if node == sol_node => name.clone(),
+                        _ => sol_node.to_string(),
+                    };
+                    self.pending_sector = Some(load[1].to_string());
+                    return vec![self.start_run(&name, ts)];
+                }
+            }
+        }
+
+        if let Some(mission) = MISSION_NAME.captures(line) {
+            let name = mission[1].trim().to_string();
+            let is_arbitration = name.contains("Arbitration")
+                || self
+                    .pending_sector
+                    .as_deref()
+                    .is_some_and(|s| ELITE_SECTOR.is_match(s));
+            let Some(run) = self.run.as_mut() else {
+                return if is_arbitration {
+                    vec![self.start_run(&name, ts)]
+                } else {
+                    Vec::new()
+                };
+            };
+            // After a host migration the log can repeat the arbitration's
+            // mission-name line with an older timestamp; that is not a new run.
+            if is_arbitration
+                && ts > 0.0
+                && run.last_activity_sec > 0.0
+                && ts < run.last_activity_sec
+            {
+                return Vec::new();
+            }
+            if ts > 0.0 {
+                run.run_end_sec = Some(ts);
+            }
+            let mut events = vec![self.end_run(EndReason::NewMission)];
+            if is_arbitration {
+                events.push(self.start_run(&name, ts));
+            }
+            return events;
+        }
+
+        let Some(run) = self.run.as_mut() else {
+            return Vec::new();
+        };
+
+        if line.contains(ABORT_CONFIRMED) || line.contains(EOM_COMMIT) {
+            if ts > 0.0 {
+                run.run_end_sec = Some(ts);
+            }
+            let reason = if line.contains(ABORT_CONFIRMED) {
+                EndReason::Aborted
+            } else {
+                EndReason::MissionEnd
+            };
+            return vec![self.end_run(reason)];
+        }
+
+        if let Some(sync) = SYNC_CONSUMABLES.captures(line) {
+            run.apply_raw_type(&sync[1]);
+            if run.sol_node.is_none() {
+                run.sol_node = Some(sync[2].to_string());
+            }
+        }
+        if let Some(state) = STATE_STARTED.captures(line) {
+            run.apply_raw_type(&state[1]);
+            if run.mission_start_sec.is_none() && ts > 0.0 {
+                run.mission_start_sec = Some(ts);
+            }
+        }
+
+        if line.contains(TERRITORY)
+            && run.mission_type_raw.is_none()
+            && run.mission_type == MissionType::Other
+        {
+            run.mission_type = MissionType::Interception;
+            run.waves_per_rotation = 3;
+        }
+
+        if let Some(wave) = DEFENSE_WAVE.captures(line) {
+            // Wave lines outrank the name heuristic, but not the engine type.
+            if run.mission_type_raw.is_none() {
+                run.mission_type = MissionType::Defense;
+            }
+            let wave: u32 = wave[1].parse().unwrap_or(0);
+            run.waves = run.waves.max(wave);
+            if ts > 0.0 {
+                run.activity(ts);
+                if run.precise_start_sec.is_none() && wave == 1 {
+                    run.precise_start_sec = Some(ts);
+                }
+            }
+            return vec![Event::WaveAdvanced(wave)];
+        }
+        if run.precise_start_sec.is_none() && ts > 0.0 && TERRITORY_START.is_match(line) {
+            run.precise_start_sec = Some(ts);
+        }
+
+        // Disruption spams the survival reward UI, so only the round state
+        // machine counts there.
+        if run.mission_type == MissionType::Disruption && ts > 0.0 {
+            if line.contains(DISRUPTION_ROUND_DONE) {
+                run.rotations += 1;
+                run.activity(ts);
+                return vec![Event::RotationAdvanced(run.rotations)];
+            }
+            if line.ends_with(DISRUPTION_ROUND_START) {
+                run.activity(ts);
+                if run.precise_start_sec.is_none() {
+                    run.precise_start_sec = Some(ts);
+                }
+                return Vec::new();
+            }
+        }
+
+        // The survival reward UI also appears in other modes (seen 25s before
+        // an interception's DefenseReward), so it only counts in survivals.
+        let survival_reward =
+            run.mission_type == MissionType::Survival && line.contains(SURVIVAL_REWARD);
+        if survival_reward || line.contains(DEFENSE_REWARD) {
+            if ts - run.last_reward_sec > REWARD_DEBOUNCE_SEC {
+                run.rotations += 1;
+                run.last_reward_sec = ts;
+                run.activity(ts);
+                return vec![Event::RotationAdvanced(run.rotations)];
+            }
+            return Vec::new();
+        }
+
+        if line.contains("OnAgentCreated") {
+            run.host_telemetry = true;
+            if line.contains(DRONE_AGENT) {
+                if ts > 0.0 {
+                    run.drone_kills += 1;
+                    run.first_drone_sec.get_or_insert(ts);
+                    run.activity(ts);
+                }
+                return vec![Event::AgentSpawned { drone: true }];
+            }
+            if AGENT_EXCLUDE.is_match(line) {
+                return Vec::new();
+            }
+            let spawn = match AGENT_FULL.captures(line) {
+                Some(full) => SpawnEvent {
+                    name: Some(full[1].to_string()),
+                    tick: full[3].parse().ok(),
+                },
+                None => SpawnEvent {
+                    name: AGENT_NPC_NAME.captures(line).map(|npc| npc[1].to_string()),
+                    tick: None,
+                },
+            };
+            run.spawns.push(spawn);
+            return vec![Event::AgentSpawned { drone: false }];
+        }
+
+        Vec::new()
+    }
+
+    pub fn finish(&mut self) -> Option<Run> {
+        self.run
+            .is_some()
+            .then(|| match self.end_run(EndReason::Unterminated) {
+                Event::RunEnded(run) => *run,
+                _ => unreachable!("end_run only builds RunEnded"),
+            })
+    }
+
+    fn start_run(&mut self, mission_name: &str, ts: f64) -> Event {
+        let (node, mission_type, waves_per_rotation) = classify_mission(mission_name);
+        // Consume the sector so a stale `_EliteAlert` cannot mark a later
+        // mission as an arbitration.
+        let sol_node = self
+            .pending_sector
+            .take()
+            .and_then(|s| ELITE_SECTOR.captures(&s).map(|c| c[1].to_string()));
+        self.run = Some(RunState {
+            mission_name: mission_name.to_string(),
+            node: node.clone(),
+            sol_node,
+            mission_type,
+            mission_type_raw: None,
+            waves_per_rotation,
+            run_start_sec: ts,
+            boot_time: self.boot_time,
+            mission_start_sec: None,
+            precise_start_sec: None,
+            run_end_sec: None,
+            last_activity_sec: ts,
+            host_telemetry: false,
+            rotations: 0,
+            last_reward_sec: 0.0,
+            waves: 0,
+            drone_kills: 0,
+            first_drone_sec: None,
+            spawns: Vec::new(),
+        });
+        Event::RunStarted {
+            node,
+            mission_type,
+            game_time_sec: ts,
+        }
+    }
+
+    fn end_run(&mut self, end_reason: EndReason) -> Event {
+        let r = self.run.take().expect("callers check a run is active");
+        let drone_kills = r.drone_kills;
+        let kills = count_valid_spawns(&r.spawns) + drone_kills;
+
+        let start_sec = r
+            .precise_start_sec
+            .or(r.first_drone_sec)
+            .or(r.mission_start_sec)
+            .unwrap_or(r.run_start_sec);
+        let mut duration_sec = (r.last_activity_sec - start_sec).max(0.0);
+        // No real combat window (an early abort; a few load-time drones can
+        // still span milliseconds): the end marker pins the mission window.
+        if duration_sec < 1.0 {
+            if let Some(end) = r.run_end_sec {
+                duration_sec = (end - start_sec).max(0.0);
+            }
+        }
+
+        let (mean, std) = vitus_model(r.rotations, r.waves_per_rotation, drone_kills);
+        let per_minute = if duration_sec > 0.0 {
+            mean / (duration_sec / 60.0)
+        } else {
+            0.0
+        };
+
+        let started_at = r.boot_time.and_then(|boot| {
+            std::time::Duration::try_from_secs_f64(r.run_start_sec)
+                .ok()
+                .and_then(|duration| TimeDelta::from_std(duration).ok())
+                .map(|d| boot + d)
+        });
+
+        Event::RunEnded(Box::new(Run {
+            started_at,
+            run_start_sec: r.run_start_sec,
+            run_end_sec: r.run_end_sec,
+            mission_name: r.mission_name,
+            node: r.node,
+            sol_node: r.sol_node,
+            mission_type: r.mission_type,
+            mission_type_raw: r.mission_type_raw,
+            end_reason,
+            duration_sec,
+            rotations: r.rotations,
+            waves: r.waves,
+            waves_per_rotation: r.waves_per_rotation,
+            kills,
+            drone_kills,
+            host_telemetry: r.host_telemetry,
+            vitus: Vitus {
+                mean,
+                std,
+                per_minute,
+            },
+        }))
+    }
+}
+
+/// Every run in a log, in order. A run still open at the end of the input is
+/// included with `EndReason::Unterminated`.
+pub fn parse_log<'a>(lines: impl IntoIterator<Item = &'a str>) -> Vec<Run> {
+    let mut parser = Parser::new();
+    let mut runs = Vec::new();
+    for line in lines {
+        for event in parser.feed_line(line) {
+            if let Event::RunEnded(run) = event {
+                runs.push(*run);
+            }
+        }
+    }
+    runs.extend(parser.finish());
+    runs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stored_names_round_trip_and_unknown_ones_claim_nothing() {
+        for reason in [
+            EndReason::MissionEnd,
+            EndReason::Aborted,
+            EndReason::NewMission,
+            EndReason::Unterminated,
+        ] {
+            assert_eq!(EndReason::from_stored(reason.as_str()), reason);
+        }
+        for mission in [
+            MissionType::Defense,
+            MissionType::Interception,
+            MissionType::Disruption,
+            MissionType::Survival,
+            MissionType::Other,
+        ] {
+            assert_eq!(MissionType::from_stored(mission.as_str()), mission);
+        }
+
+        assert_eq!(EndReason::from_stored("crashed"), EndReason::Unterminated);
+        assert_eq!(MissionType::from_stored("excavation"), MissionType::Other);
+    }
+
+    fn fixture(text: &str) -> Vec<Run> {
+        parse_log(text.lines())
+    }
+
+    fn single(text: &str) -> Run {
+        let mut runs = fixture(text);
+        assert_eq!(runs.len(), 1, "expected exactly one run, got {runs:#?}");
+        runs.remove(0)
+    }
+
+    fn close(a: f64, b: f64) -> bool {
+        (a - b).abs() < 1e-3
+    }
+
+    #[test]
+    fn completed_defense_run() {
+        let run = single(include_str!(
+            "../tests/fixtures/arbitration/stoefler-defense.txt"
+        ));
+        assert_eq!(run.node, "Stöfler (Lua)");
+        assert_eq!(run.sol_node.as_deref(), Some("SolNode305"));
+        assert_eq!(run.mission_type, MissionType::Defense);
+        assert_eq!(run.mission_type_raw.as_deref(), Some("MT_DEFENSE"));
+        assert_eq!(run.end_reason, EndReason::MissionEnd);
+        assert_eq!(run.waves, 6);
+        assert_eq!(run.rotations, 2);
+        assert_eq!(run.waves_per_rotation, 3);
+        assert_eq!(run.drone_kills, 3);
+        // Four lancers plus the kubrow that spawned while loading, plus drones.
+        assert_eq!(run.kills, 8);
+        assert!(run.host_telemetry);
+        // Wave 1 at 16786.896 to the last reward at 16936.816.
+        assert!(close(run.duration_sec, 149.92), "{}", run.duration_sec);
+        assert_eq!(
+            run.started_at.map(|t| t.to_rfc3339()).as_deref(),
+            Some("2026-07-08T02:17:25.750+00:00")
+        );
+        assert!(close(run.vitus.mean, 3.662), "{}", run.vitus.mean);
+        assert!(close(run.vitus.per_minute, 3.662 / (149.92 / 60.0)));
+    }
+
+    #[test]
+    fn aborted_run_then_non_arbitration_mission() {
+        let run = single(include_str!(
+            "../tests/fixtures/arbitration/oestrus-abort.txt"
+        ));
+        assert_eq!(run.node, "Oestrus (Eris)");
+        assert_eq!(run.mission_name, "Oestrus (Eris) - Arbitration");
+        assert_eq!(run.sol_node.as_deref(), Some("SolNode167"));
+        assert_eq!(run.mission_type, MissionType::Other);
+        assert_eq!(run.mission_type_raw.as_deref(), Some("MT_PURIFY"));
+        assert_eq!(run.end_reason, EndReason::Aborted);
+        assert_eq!(run.run_end_sec, Some(234.503));
+        assert_eq!(run.rotations, 0);
+        assert_eq!(run.drone_kills, 0);
+        // The two flight agents never tick: decorative.
+        assert_eq!(run.kills, 0);
+        // OnStateStarted at 184.403 to the abort at 234.503.
+        assert!(close(run.duration_sec, 50.1), "{}", run.duration_sec);
+        assert_eq!(
+            run.started_at.map(|t| t.to_rfc3339()).as_deref(),
+            Some("2026-07-06T09:43:29.428+00:00")
+        );
+    }
+
+    #[test]
+    fn survival_rotations() {
+        let run = single(include_str!(
+            "../tests/fixtures/arbitration/mot-survival.txt"
+        ));
+        assert_eq!(run.node, "Mot (Void)");
+        assert_eq!(run.mission_type, MissionType::Survival);
+        assert_eq!(run.end_reason, EndReason::MissionEnd);
+        assert_eq!(run.rotations, 1);
+        assert_eq!(run.waves, 0);
+        assert_eq!(run.drone_kills, 7);
+        assert_eq!(run.kills, 7);
+        // First drone at 434.607 to the last at 735.957; the in-mission
+        // EndOfMatch screens in between do not end the run.
+        assert!(close(run.duration_sec, 301.35), "{}", run.duration_sec);
+    }
+
+    // An interception where the survival reward UI popped
+    // 25s before the real rotation reward.
+    #[test]
+    fn interception_ignores_stray_survival_reward() {
+        let run = single(include_str!(
+            "../tests/fixtures/arbitration/rhea-interception.txt"
+        ));
+        assert_eq!(run.mission_type, MissionType::Interception);
+        assert_eq!(run.rotations, 1);
+        assert_eq!(run.drone_kills, 5);
+        // First point captured at 133.194 to the reward at 356.940.
+        assert!(close(run.duration_sec, 223.746), "{}", run.duration_sec);
+    }
+
+    // The four fixtures above are the original project's own excerpts; the
+    // join, mirror-defense and spam ones are composed from recorded line shapes.
+    #[test]
+    fn mid_mission_join_starts_at_the_join_point() {
+        let run = single(include_str!(
+            "../tests/fixtures/arbitration/apollo-join.txt"
+        ));
+        assert_eq!(run.node, "Apollo (Lua)");
+        assert_eq!(run.sol_node.as_deref(), Some("SolNode308"));
+        assert_eq!(run.run_start_sec, 2047.451);
+        assert_eq!(run.mission_type, MissionType::Disruption);
+        assert_eq!(run.waves_per_rotation, 4);
+        // Rounds count; the survival reward UI disruption spams does not.
+        assert_eq!(run.rotations, 2);
+        assert_eq!(run.drone_kills, 3);
+        assert_eq!(run.end_reason, EndReason::MissionEnd);
+        // First round at 2060 to the last round done at 2600.
+        assert!(close(run.duration_sec, 540.0), "{}", run.duration_sec);
+        assert_eq!(
+            run.started_at.map(|t| t.to_rfc3339()).as_deref(),
+            Some("2026-07-08T18:45:09.451+00:00")
+        );
+    }
+
+    #[test]
+    fn mirror_defense_has_two_waves_per_rotation() {
+        let run = single(include_str!(
+            "../tests/fixtures/arbitration/tyana-mirror-defense.txt"
+        ));
+        assert_eq!(run.node, "Tyana Pass (Mars)");
+        assert_eq!(run.mission_type, MissionType::Defense);
+        assert_eq!(run.waves_per_rotation, 2);
+        assert_eq!(run.waves, 4);
+        assert_eq!(run.rotations, 2);
+        assert_eq!(run.drone_kills, 2);
+        assert!(close(run.duration_sec, 240.01), "{}", run.duration_sec);
+        let (mean, _) = vitus_model(2, 2, 2);
+        assert!(close(run.vitus.mean, mean));
+        assert!(close(mean, 3.108), "{mean}");
+    }
+
+    #[test]
+    fn spam_and_decorative_agents_are_excluded() {
+        let run = single(include_str!(
+            "../tests/fixtures/arbitration/casta-defense-spam.txt"
+        ));
+        assert_eq!(run.node, "Casta (Ceres)");
+        // Three lancers and one drone. Skipped: the Game [Warning] and
+        // DamagePct lines, the turret, and the crates whose tick never advances.
+        assert_eq!(run.drone_kills, 1);
+        assert_eq!(run.kills, 4);
+        // Rewards at 355 and 360 are one rotation; the Sys [Error] mention of
+        // the reward movie is not a reward; 400 is the second rotation.
+        assert_eq!(run.rotations, 2);
+        assert_eq!(run.waves, 1);
+        assert!(close(run.duration_sec, 80.0), "{}", run.duration_sec);
+    }
+
+    #[test]
+    fn non_arbitration_missions_produce_no_records() {
+        let runs = fixture(
+            "100.000 Script [Info]: ThemedSquadOverlay.lua: Pending mission: SolNode149\n\
+             105.000 Script [Info]: ThemedSquadOverlay.lua: Mission name: Casta (Ceres)\n\
+             110.000 Game [Info]: OnStateStarted, mission type=MT_DEFENSE\n\
+             120.000 Script [Info]: WaveDefend.lua: Defense wave: 1\n\
+             200.000 Sys [Info]: Created /Lotus/Interface/DefenseReward.swf\n\
+             210.000 Sys [Info]: EOM missionLocationUnlocked=1\n\
+             300.000 Script [Info]: Client loaded {\"name\":\"SolNode308\"} with MissionInfo:\n",
+        );
+        assert!(runs.is_empty(), "{runs:#?}");
+    }
+
+    #[test]
+    fn elite_sector_marks_an_arbitration_whose_name_lacks_the_keyword() {
+        let runs = fixture(
+            "158.074 Script [Info]: ThemedSquadOverlay.lua: Pending mission: SolNode167_EliteAlert\n\
+             178.428 Script [Info]: ThemedSquadOverlay.lua: Mission name: Oestrus (Eris)\n\
+             234.503 Script [Info]: TopMenu.lua: Abort: host/no session\n\
+             255.746 Script [Info]: ThemedSquadOverlay.lua: Mission name: Isos (Eris)\n",
+        );
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].sol_node.as_deref(), Some("SolNode167"));
+        assert_eq!(runs[0].end_reason, EndReason::Aborted);
+    }
+
+    #[test]
+    fn back_to_back_arbitrations_and_host_migration_replay() {
+        let mut parser = Parser::new();
+        let name = |ts: &str, n: &str| {
+            format!("{ts} Script [Info]: ThemedSquadOverlay.lua: Mission name: {n}")
+        };
+        assert!(matches!(
+            parser.feed_line(&name("100.000", "Arbitration: Casta (Ceres)"))[..],
+            [Event::RunStarted { .. }]
+        ));
+        parser.feed_line("500.000 AI [Info]: OnAgentCreated /Npc/CorpusEliteShieldDroneAgent7 MonitoredTicking 2");
+        // Older timestamp after a migration: still the same run.
+        assert!(parser
+            .feed_line(&name("300.000", "Arbitration: Casta (Ceres)"))
+            .is_empty());
+        // The next arbitration's name line closes this run and opens the next.
+        let events = parser.feed_line(&name("600.000", "Arbitration: Casta (Ceres)"));
+        let [Event::RunEnded(first), Event::RunStarted { game_time_sec, .. }] = &events[..] else {
+            panic!("{events:#?}");
+        };
+        assert_eq!(first.end_reason, EndReason::NewMission);
+        assert_eq!(first.run_end_sec, Some(600.0));
+        assert_eq!(*game_time_sec, 600.0);
+        let last = parser.finish().expect("second run is open");
+        assert_eq!(last.end_reason, EndReason::Unterminated);
+        assert!(parser.finish().is_none());
+    }
+
+    #[test]
+    fn live_events_are_emitted_as_lines_arrive() {
+        let mut parser = Parser::new();
+        parser.feed_line("100.000 Script [Info]: ThemedSquadOverlay.lua: Mission name: Arbitration: Hydron (Sedna)");
+        assert_eq!(
+            parser.feed_line("110.000 Script [Info]: WaveDefend.lua: Defense wave: 1"),
+            vec![Event::WaveAdvanced(1)]
+        );
+        assert_eq!(
+            parser.feed_line("120.000 AI [Info]: OnAgentCreated /Npc/CorpusEliteShieldDroneAgent7 MonitoredTicking 2"),
+            vec![Event::AgentSpawned { drone: true }]
+        );
+        assert_eq!(
+            parser.feed_line("200.000 Sys [Info]: Created /Lotus/Interface/DefenseReward.swf"),
+            vec![Event::RotationAdvanced(1)]
+        );
+        assert!(parser.feed_line("210.000 Script [Info]: Dialog.lua: Dialog::CreateOkCancel(description=/Lotus/Language/Menu/AbortMissionConfirm)").is_empty());
+        assert!(parser.is_run_active());
+    }
+
+    #[test]
+    fn run_keeps_boot_time_from_its_start() {
+        let runs = fixture(
+            "0.000 Sys [Diag]: Current time: Mon Jul  6 17:46:29 2026 [UTC: Mon Jul  6 15:46:29 2026]\n\
+             10.000 Script [Info]: ThemedSquadOverlay.lua: Mission name: Arbitration: Casta (Ceres)\n\
+             20.000 Sys [Info]: EOM missionLocationUnlocked=1\n\
+             0.000 Sys [Diag]: Current time: Tue Jul  7 17:46:29 2026 [UTC: Tue Jul  7 15:46:29 2026]\n\
+             30.000 Script [Info]: ThemedSquadOverlay.lua: Mission name: Arbitration: Casta (Ceres)\n",
+        );
+        assert_eq!(runs.len(), 2);
+        assert_eq!(
+            runs[0].started_at.map(|t| t.to_rfc3339()).as_deref(),
+            Some("2026-07-06T15:46:39+00:00")
+        );
+    }
+
+    #[test]
+    fn oversized_timestamp_does_not_panic() {
+        let runs = fixture(
+            "99999999999999999999.0 Script [Info]: ThemedSquadOverlay.lua: Mission name: Arbitration: Casta (Ceres)\n\
+             100.000 Sys [Info]: EOM missionLocationUnlocked=1\n",
+        );
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].started_at, None);
+    }
+
+    #[test]
+    fn vitus_model_matches_the_reference_numbers() {
+        assert_eq!(vitus_model(0, 3, 0), (0.0, 0.0));
+        let (mean, std) = vitus_model(2, 3, 3);
+        assert!(close(mean, 3.662), "{mean}");
+        // rotation variance 1.62, drop-count variance 0.3825 scaled by the
+        // squared drop mean 5.5696, drop-value variance 0.5904 scaled by 0.45
+        assert!(close(std, (1.62 + 0.26568 + 2.130372f64).sqrt()), "{std}");
+    }
+}

--- a/src-tauri/src/arbitrations.rs
+++ b/src-tauri/src/arbitrations.rs
@@ -1,0 +1,241 @@
+//! The arbitration rotation, from the community feed at browse.wf.
+//!
+//! The feed is a plain `epoch,node` list of every rotation for years ahead.
+//! It is cached whole and windowed here, so a refresh failure still leaves a
+//! full schedule to show.
+
+use std::time::Duration;
+
+use serde::Serialize;
+
+use crate::cache;
+
+const FEED_URL: &str = "https://browse.wf/arbys.txt";
+const FEED_CACHE: &str = "arbitrations-v1.json";
+const FEED_TTL: Duration = Duration::from_secs(3600);
+const ROTATION_SECS: u64 = 3600;
+
+/// A hand-typed argument must not blank the app into a multi-month parse, so
+/// the clamp is the same both ends and enforced here, not trusted to the
+/// caller.
+const MIN_HORIZON_DAYS: u64 = 1;
+const MAX_HORIZON_DAYS: u64 = 60;
+
+fn horizon_secs(days: u64) -> u64 {
+    days.clamp(MIN_HORIZON_DAYS, MAX_HORIZON_DAYS) * 24 * 3600
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Rotation {
+    pub start: u64,
+    pub node_id: String,
+}
+
+/// Lines that do not parse are dropped rather than failing the whole feed:
+/// one bad line at the top of a year-long list must not blank the schedule.
+pub fn parse_feed(text: &str) -> Vec<Rotation> {
+    let mut rotations: Vec<Rotation> = text
+        .lines()
+        .filter_map(|line| {
+            let mut fields = line.split(',');
+            let start = fields.next()?.trim().parse().ok()?;
+            let node_id = fields.next()?.trim();
+            (!node_id.is_empty()).then(|| Rotation { start, node_id: node_id.to_string() })
+        })
+        .collect();
+    rotations.sort_by_key(|r| r.start);
+    rotations
+}
+
+/// The Arbitration Goons' rating of how well a node farms Vitus Essence,
+/// vendored from `calamity-inc/browse.wf` (`supplemental-data/arbyTiers.js`).
+/// Refresh by hand when that file changes: it moves once in a blue moon, and
+/// a runtime fetch would mean parsing JavaScript to learn a letter.
+///
+/// A node the rating does not cover is Unrated, which is not the same as bad:
+/// the list only covers nodes the rotation actually visits.
+pub fn tier(node_id: &str) -> Option<&'static str> {
+    Some(match node_id {
+        "SolNode450" | "SolNode106" | "SolNode25" | "SolNode719" | "SolNode64" => "S",
+        "SolNode147" | "SolNode23" | "SolNode172" => "A",
+        "SolNode167" | "ClanNode24" | "SolNode149" | "ClanNode22" | "ClanNode18" | "SolNode164"
+        | "SolNode707" | "SolNode211" | "SolNode42" | "SolNode195" | "SolNode408"
+        | "SolNode402" => "B",
+        "SolNode412" | "ClanNode2" | "SolNode46" | "ClanNode8" | "SolNode212" | "SolNode22"
+        | "SolNode224" | "SolNode26" | "ClanNode6" | "SolNode122" | "SolNode72" => "C",
+        "SolNode130" | "ClanNode15" | "SolNode85" | "SolNode18" | "SolNode305" | "ClanNode4"
+        | "SolNode125" => "D",
+        _ => return None,
+    })
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ScheduleEntry {
+    pub start: u64,
+    pub end: u64,
+    pub node_id: String,
+    pub node: String,
+    pub region: String,
+    pub mission_type: String,
+    pub faction: String,
+    pub tier: Option<&'static str>,
+}
+
+/// A rotation lasts until the next one in the feed, or one hour when the
+/// feed has no successor, so a gap in the feed shows as a gap and not as an
+/// arbitration that never ends.
+pub fn within_horizon(rotations: &[Rotation], now: u64, horizon: u64) -> Vec<(u64, u64, &str)> {
+    rotations
+        .iter()
+        .enumerate()
+        .map(|(i, r)| {
+            let end = rotations
+                .get(i + 1)
+                .map(|next| next.start)
+                .unwrap_or(r.start + ROTATION_SECS)
+                .min(r.start + ROTATION_SECS);
+            (r.start, end, r.node_id.as_str())
+        })
+        .filter(|(start, end, _)| *end > now && *start < now + horizon)
+        .collect()
+}
+
+fn entry(start: u64, end: u64, node_id: &str) -> ScheduleEntry {
+    // The sol-node data has no separate region field; the display name
+    // carries it in parentheses ("Hyf (Deimos)"). An id the data does not
+    // know resolves to itself, which is the whole fallback: the hour still
+    // shows, with blank region, type and faction.
+    let display = crate::resolve_node(node_id);
+    let (node, region) = display
+        .rsplit_once(" (")
+        .map(|(n, r)| (n.to_string(), r.trim_end_matches(')').to_string()))
+        .unwrap_or((display.clone(), String::new()));
+    ScheduleEntry {
+        start,
+        end,
+        node_id: node_id.to_string(),
+        node,
+        region,
+        mission_type: crate::node_mission_type(node_id),
+        faction: crate::node_enemy(node_id),
+        tier: tier(node_id),
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct Schedule {
+    pub entries: Vec<ScheduleEntry>,
+    pub source: cache::Source,
+    pub warning: Option<String>,
+}
+
+fn fetch_feed(force: bool) -> (Option<String>, cache::Source, Option<String>) {
+    let ttl = if force { Duration::ZERO } else { FEED_TTL };
+    cache::get_or_refresh(FEED_CACHE, ttl, |etag| cache::get_conditional(FEED_URL, etag))
+}
+
+pub(crate) fn refresh_feed(_app: &tauri::AppHandle, force: bool) -> Result<(), String> {
+    match fetch_feed(force) {
+        (_, _, Some(warning)) => Err(warning),
+        _ => Ok(()),
+    }
+}
+
+#[tauri::command]
+pub async fn fetch_arbitration_schedule(horizon_days: u64) -> Result<Schedule, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let (text, source, warning) = fetch_feed(false);
+        let Some(text) = text else {
+            return Err(warning.unwrap_or_else(|| "arbitration feed unavailable".to_string()));
+        };
+        let entries = within_horizon(&parse_feed(&text), cache::now_unix(), horizon_secs(horizon_days))
+            .into_iter()
+            .map(|(start, end, node_id)| entry(start, end, node_id))
+            .collect();
+        Ok(Schedule { entries, source, warning })
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rotation(start: u64, node_id: &str) -> Rotation {
+        Rotation { start, node_id: node_id.to_string() }
+    }
+
+    #[test]
+    fn feed_lines_become_rotations_in_start_order() {
+        let text = "7200,SolNode2\n3600,SolNode1\r\n10800,ClanNode10\n";
+        assert_eq!(
+            parse_feed(text),
+            vec![rotation(3600, "SolNode1"), rotation(7200, "SolNode2"), rotation(10800, "ClanNode10")]
+        );
+    }
+
+    #[test]
+    fn malformed_lines_are_skipped_not_fatal() {
+        let text = "\n3600,SolNode1\ngarbage\n,SolNode9\nnotanumber,SolNode3\n7200,\n  10800 , SolNode4 \n7200,SolNode2,extra";
+        assert_eq!(
+            parse_feed(text),
+            vec![rotation(3600, "SolNode1"), rotation(7200, "SolNode2"), rotation(10800, "SolNode4")]
+        );
+    }
+
+    #[test]
+    fn empty_feed_is_an_empty_schedule() {
+        assert!(parse_feed("").is_empty());
+        assert!(within_horizon(&[], 1000, 3 * 24 * 3600).is_empty());
+    }
+
+    #[test]
+    fn window_keeps_the_current_rotation_and_drops_finished_ones() {
+        let feed = [rotation(0, "a"), rotation(3600, "b"), rotation(7200, "c"), rotation(10800, "d")];
+        let got = within_horizon(&feed, 5000, 3600);
+        assert_eq!(got, vec![(3600, 7200, "b"), (7200, 10800, "c")]);
+    }
+
+    #[test]
+    fn a_gap_in_the_feed_ends_the_rotation_after_an_hour() {
+        let feed = [rotation(0, "a"), rotation(36000, "b")];
+        assert_eq!(within_horizon(&feed, 100, 100_000), vec![(0, 3600, "a"), (36000, 39600, "b")]);
+    }
+
+    #[test]
+    fn rated_nodes_carry_their_tier_and_the_rest_carry_none() {
+        assert_eq!(tier("SolNode450"), Some("S"));
+        assert_eq!(tier("ClanNode24"), Some("B"));
+        assert_eq!(tier("SolNode125"), Some("D"));
+        assert_eq!(tier("SolNode1"), None);
+        assert_eq!(tier(""), None);
+    }
+
+    #[test]
+    fn horizon_is_exclusive_of_rotations_starting_at_its_edge() {
+        let feed = [rotation(0, "a"), rotation(3600, "b")];
+        assert_eq!(within_horizon(&feed, 0, 3600), vec![(0, 3600, "a")]);
+    }
+
+    #[test]
+    fn a_wide_horizon_reaches_across_days_without_losing_gaps_or_ends() {
+        let mut feed: Vec<Rotation> = (0..7)
+            .map(|d| rotation(86_400 * d, &format!("n{d}")))
+            .collect();
+        feed.push(rotation(86_400 * 10, "late"));
+        let got = within_horizon(&feed, 0, 7 * 86_400);
+        assert_eq!(got.len(), 7);
+        assert_eq!(got[6], (86_400 * 6, 86_400 * 6 + 3600, "n6"));
+    }
+
+    #[test]
+    fn horizon_secs_rounds_and_clamps_to_the_1_60_day_range() {
+        assert_eq!(horizon_secs(0), 86_400);
+        assert_eq!(horizon_secs(1), 86_400);
+        assert_eq!(horizon_secs(7), 7 * 86_400);
+        assert_eq!(horizon_secs(60), 60 * 86_400);
+        assert_eq!(horizon_secs(61), 60 * 86_400);
+        assert_eq!(horizon_secs(9999), 60 * 86_400);
+    }
+}

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -1,3 +1,4 @@
+use crate::arbitration::{EndReason, Event, MissionType, Parser as ArbitrationParser, Run};
 use rusqlite::{params, Connection, Result};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -104,6 +105,39 @@ fn migrate(conn: &Connection) -> Result<()> {
     if version < 4 {
         conn.execute_batch("ALTER TABLE quantity_changes ADD COLUMN rank INTEGER;")?;
         conn.pragma_update(None, "user_version", 4)?;
+    }
+
+    if version < 5 {
+        let tx = conn.unchecked_transaction()?;
+        tx.execute_batch(
+            "CREATE TABLE IF NOT EXISTS arbitration_runs (
+                uid                TEXT    PRIMARY KEY,
+                started_at         TEXT,
+                run_start_sec      REAL    NOT NULL,
+                run_end_sec        REAL,
+                mission_name       TEXT    NOT NULL,
+                node               TEXT    NOT NULL,
+                sol_node           TEXT,
+                mission_type       TEXT    NOT NULL,
+                mission_type_raw   TEXT,
+                end_reason         TEXT    NOT NULL,
+                duration_sec       REAL    NOT NULL,
+                rotations          INTEGER NOT NULL,
+                waves              INTEGER NOT NULL,
+                waves_per_rotation INTEGER NOT NULL,
+                kills              INTEGER NOT NULL,
+                drone_kills        INTEGER NOT NULL,
+                host_telemetry     INTEGER NOT NULL,
+                vitus_mean         REAL    NOT NULL,
+                vitus_std          REAL    NOT NULL,
+                vitus_per_minute   REAL    NOT NULL,
+                deleted            INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE INDEX IF NOT EXISTS arbitration_runs_started
+                ON arbitration_runs(started_at);",
+        )?;
+        tx.pragma_update(None, "user_version", 5)?;
+        tx.commit()?;
     }
 
     // Prune entries older than 7 days so the log doesn't grow unbounded.
@@ -334,4 +368,658 @@ pub fn get_quantity_changes(conn: &Connection, limit: i64) -> Result<Vec<Quantit
         .filter_map(|r| r.ok())
         .collect();
     Ok(rows)
+}
+
+// ── Arbitration runs ──────────────────────────────────────────────────────────
+//
+// Runs arrive from two directions — the tail of a live log and a backfill pass
+// over the whole file at startup — and both go through `ArbitrationRecorder`,
+// so there is one parser and one insert. Re-reading a log the database has
+// already seen must add nothing, which is what `uid` buys.
+
+/// Identity of a run, from the two things a log fixes about it: when it began
+/// and where. Wall clock comes from the log's boot-time header; without one,
+/// game time since launch stands in.
+///
+/// ponytail: two runs on the same node at the same game-time offset in a log
+/// with no boot header collide and the second is dropped. Store a per-launch
+/// discriminator if a header-less log ever shows up in practice.
+fn run_uid(run: &Run) -> String {
+    let when = match run.started_at {
+        Some(t) => stored_timestamp(t),
+        None => format!("t{:.3}", run.run_start_sec),
+    };
+    format!("{when}\u{1f}{}", run.node)
+}
+
+/// Date ranges are compared as text in SQL, so every timestamp that reaches
+/// the column has to be written the same way: UTC, milliseconds, `Z`. Chrono's
+/// plain `to_rfc3339` writes `+00:00`, which sorts *below* the `Z` form that
+/// every other tool produces, and a bound in one form silently excludes rows
+/// stored in the other.
+fn stored_timestamp(t: chrono::DateTime<chrono::Utc>) -> String {
+    t.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+
+pub fn store_arbitration_run(conn: &Connection, run: &Run) -> Result<bool> {
+    let changed = conn.execute(
+        "INSERT OR IGNORE INTO arbitration_runs (
+             uid, started_at, run_start_sec, run_end_sec, mission_name, node,
+             sol_node, mission_type, mission_type_raw, end_reason, duration_sec,
+             rotations, waves, waves_per_rotation, kills, drone_kills,
+             host_telemetry, vitus_mean, vitus_std, vitus_per_minute)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14,
+                 ?15, ?16, ?17, ?18, ?19, ?20)",
+        params![
+            run_uid(run),
+            run.started_at.map(stored_timestamp),
+            run.run_start_sec,
+            run.run_end_sec,
+            run.mission_name,
+            run.node,
+            run.sol_node,
+            run.mission_type.as_str(),
+            run.mission_type_raw,
+            run.end_reason.as_str(),
+            run.duration_sec,
+            run.rotations,
+            run.waves,
+            run.waves_per_rotation,
+            run.kills,
+            run.drone_kills,
+            run.host_telemetry,
+            run.vitus.mean,
+            run.vitus.std,
+            run.vitus.per_minute,
+        ],
+    )?;
+    Ok(changed > 0)
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RunRecord {
+    pub uid: String,
+    pub started_at: Option<String>,
+    pub node: String,
+    /// Looked up from the run's star chart node rather than stored: the
+    /// rating is a view of the node, and a run recorded before the rating
+    /// existed still shows today's.
+    pub tier: Option<&'static str>,
+    pub mission_type: &'static str,
+    pub end_reason: &'static str,
+    pub duration_sec: f64,
+    pub rotations: u32,
+    pub waves: u32,
+    pub kills: u32,
+    pub drone_kills: u32,
+    pub vitus_mean: f64,
+    pub vitus_per_minute: f64,
+}
+
+/// Newest first. Filtering happens in the view: the whole history is small,
+/// and the filters change far more often than the data.
+///
+/// The key is read back from the row rather than re-derived, so a delete
+/// names exactly what was stored even if the derivation changes.
+pub fn list_arbitration_runs(conn: &Connection) -> Result<Vec<RunRecord>> {
+    let mut stmt = conn.prepare(
+        "SELECT uid, started_at, node, mission_type, end_reason, duration_sec,
+                rotations, waves, kills, drone_kills, vitus_mean, vitus_per_minute,
+                sol_node
+         FROM arbitration_runs
+         WHERE deleted = 0
+         ORDER BY started_at DESC, run_start_sec DESC",
+    )?;
+    let rows = stmt
+        .query_map([], |row| {
+            let mission_type: String = row.get(3)?;
+            let end_reason: String = row.get(4)?;
+            Ok(RunRecord {
+                uid: row.get(0)?,
+                started_at: row.get(1)?,
+                node: row.get(2)?,
+                tier: row
+                    .get::<_, Option<String>>(12)?
+                    .as_deref()
+                    .and_then(crate::arbitrations::tier),
+                mission_type: MissionType::from_stored(&mission_type).as_str(),
+                end_reason: EndReason::from_stored(&end_reason).as_str(),
+                duration_sec: row.get(5)?,
+                rotations: row.get(6)?,
+                waves: row.get(7)?,
+                kills: row.get(8)?,
+                drone_kills: row.get(9)?,
+                vitus_mean: row.get(10)?,
+                vitus_per_minute: row.get(11)?,
+            })
+        })?
+        .collect::<Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+pub fn delete_arbitration_run(conn: &Connection, uid: &str) -> Result<bool> {
+    let changed = conn.execute(
+        "UPDATE arbitration_runs SET deleted = 1 WHERE uid = ?1",
+        params![uid],
+    )?;
+    Ok(changed > 0)
+}
+
+/// Log text in, stored runs out, in two steps so that the database is only
+/// locked for the writes: parsing a whole log at startup takes far longer than
+/// the handful of inserts it produces, and every other query waits behind that
+/// same lock.
+///
+/// Holds the parser across calls so a run split over several reads still ends
+/// as one run.
+#[derive(Default)]
+pub struct ArbitrationRecorder {
+    parser: ArbitrationParser,
+    /// A read of the growing log ends wherever the game happened to flush, so
+    /// the last line of a chunk is often half a line. It waits here for its
+    /// other half rather than reaching the parser mangled.
+    partial: String,
+    /// Runs parsed but not yet written. The lines behind a run are consumed by
+    /// the parser as they are read and cannot be replayed, so a run whose
+    /// insert failed waits here for the next attempt instead of being lost.
+    pending: std::collections::VecDeque<Run>,
+}
+
+/// Enough runs for a long session of failed writes. Past it the oldest go,
+/// because a queue that grows for as long as the database is broken is a leak.
+///
+/// ponytail: the queue lives in memory, so a crash loses it either way, and
+/// the oldest go first on the assumption that a newer run is the one worth
+/// saving. Persist it if runs lost to a full disk turn out to matter.
+const MAX_PENDING_RUNS: usize = 256;
+
+impl ArbitrationRecorder {
+    /// A replaced log belongs to a new launch, but queued writes still belong
+    /// to history and must survive the parser reset.
+    pub fn restart(&mut self) {
+        self.parser = ArbitrationParser::new();
+        self.partial.clear();
+    }
+
+    /// Reads runs out of the text. A run still in progress is not parsed out:
+    /// it has no end and no final counts yet.
+    ///
+    /// TODO: a log that stops mid-run because the game crashed looks identical
+    /// to one whose run is still going, so that last run is never recorded.
+    /// Recovering it needs a signal that the log is finished with.
+    pub fn parse(&mut self, chunk: String) -> Vec<Run> {
+        // Taking the text whole rather than copying it in matters at startup,
+        // where the chunk is the entire log.
+        if self.partial.is_empty() {
+            self.partial = chunk;
+        } else {
+            self.partial.push_str(&chunk);
+        }
+        let Some(last_newline) = self.partial.rfind('\n') else {
+            return Vec::new();
+        };
+        let half_line = self.partial.split_off(last_newline + 1);
+        let complete = std::mem::replace(&mut self.partial, half_line);
+
+        let mut ended = Vec::new();
+        for line in complete.lines() {
+            for event in self.parser.feed_line(line) {
+                if let Event::RunEnded(run) = event {
+                    if self.pending.len() == MAX_PENDING_RUNS {
+                        self.pending.pop_front();
+                        tracing::warn!(
+                            queued = MAX_PENDING_RUNS,
+                            "arbitration run queue is full; dropping the oldest run"
+                        );
+                    }
+                    self.pending.push_back((*run).clone());
+                    ended.push(*run);
+                }
+            }
+        }
+        ended
+    }
+
+    /// Writes what `parse` found, and returns how many rows that added. A run
+    /// stays queued until its insert succeeds, so a database that is busy or
+    /// full delays runs rather than dropping them.
+    ///
+    /// One transaction for the batch, because a startup backfill's runs would
+    /// otherwise cost a disk sync each. The queue is cleared only once the
+    /// commit lands: a failure rolls the whole batch back, and the runs behind
+    /// it have to still be there for the next attempt.
+    pub fn store(&mut self, conn: &Connection) -> Result<usize> {
+        if self.pending.is_empty() {
+            return Ok(0);
+        }
+        let tx = conn.unchecked_transaction()?;
+        let mut stored = 0;
+        for run in &self.pending {
+            if store_arbitration_run(&tx, run)? {
+                stored += 1;
+            }
+        }
+        tx.commit()?;
+        self.pending.clear();
+        Ok(stored)
+    }
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq)]
+pub struct RunSummary {
+    pub node: String,
+    pub mission_type: &'static str,
+    pub duration_sec: f64,
+    pub rotations: u32,
+    pub waves: u32,
+    pub kills: u32,
+    pub drone_kills: u32,
+    pub host_telemetry: bool,
+    pub vitus_mean: f64,
+    pub vitus_per_minute: f64,
+}
+
+/// Which run, if any, the post-run overlay shows for the runs a read just
+/// ended. Only the newest is the one the player just left, and if that one
+/// was aborted an older completed run must not stand in for it.
+///
+/// `live` is false for text that may be old, such as the startup backfill: a
+/// run that ended hours ago must not put a summary over the game now.
+pub fn live_run_summary(ended: &[Run], live: bool, enabled: bool) -> Option<RunSummary> {
+    if !(live && enabled) {
+        return None;
+    }
+    ended.last().and_then(post_run_summary)
+}
+
+/// `None` unless the run ended normally: an abort, or a new mission cutting
+/// the old one off, has nothing worth putting over the game.
+pub fn post_run_summary(run: &Run) -> Option<RunSummary> {
+    if run.end_reason != EndReason::MissionEnd {
+        return None;
+    }
+    Some(RunSummary {
+        node: run.node.clone(),
+        mission_type: run.mission_type.as_str(),
+        duration_sec: run.duration_sec,
+        rotations: run.rotations,
+        waves: run.waves,
+        kills: run.kills,
+        drone_kills: run.drone_kills,
+        host_telemetry: run.host_telemetry,
+        vitus_mean: run.vitus.mean,
+        vitus_per_minute: run.vitus.per_minute,
+    })
+}
+
+#[cfg(test)]
+fn db(_name: &str) -> Connection {
+    let conn = Connection::open_in_memory().expect("in-memory database opens");
+    migrate(&conn).expect("fresh schema migrates");
+    conn
+}
+
+#[cfg(test)]
+mod arbitration_storage_tests {
+    use super::*;
+
+    const DEFENSE: &str = include_str!("../tests/fixtures/arbitration/stoefler-defense.txt");
+    const SURVIVAL: &str = include_str!("../tests/fixtures/arbitration/mot-survival.txt");
+    const ABORT: &str = include_str!("../tests/fixtures/arbitration/oestrus-abort.txt");
+
+    /// Splits the log into chunks that mostly end mid-line, the way a read of
+    /// a file the game is still writing does.
+    fn watch(conn: &Connection, log: &str, chunk_len: usize) -> usize {
+        let mut recorder = ArbitrationRecorder::default();
+        let bytes = log.as_bytes();
+        let mut stored = 0;
+        let mut at = 0;
+        while at < bytes.len() {
+            let mut end = (at + chunk_len).min(bytes.len());
+            while !log.is_char_boundary(end) {
+                end += 1;
+            }
+            recorder.parse(log[at..end].to_string());
+            stored += recorder.store(conn).expect("recording succeeds");
+            at = end;
+        }
+        stored
+    }
+
+    fn stored(conn: &Connection) -> Vec<Run> {
+        let mut stmt = conn
+            .prepare(
+                "SELECT started_at, run_start_sec, run_end_sec, mission_name, node,
+                        sol_node, mission_type, mission_type_raw, end_reason,
+                        duration_sec, rotations, waves, waves_per_rotation, kills,
+                        drone_kills, host_telemetry, vitus_mean, vitus_std,
+                        vitus_per_minute
+                 FROM arbitration_runs
+                 WHERE deleted = 0
+                 ORDER BY started_at, run_start_sec",
+            )
+            .expect("statement compiles");
+        stmt.query_map([], |row| {
+            let started_at: Option<String> = row.get(0)?;
+            let mission_type: String = row.get(6)?;
+            let end_reason: String = row.get(8)?;
+            Ok(Run {
+                started_at: started_at
+                    .and_then(|t| chrono::DateTime::parse_from_rfc3339(&t).ok())
+                    .map(|t| t.with_timezone(&chrono::Utc)),
+                run_start_sec: row.get(1)?,
+                run_end_sec: row.get(2)?,
+                mission_name: row.get(3)?,
+                node: row.get(4)?,
+                sol_node: row.get(5)?,
+                mission_type: MissionType::from_stored(&mission_type),
+                mission_type_raw: row.get(7)?,
+                end_reason: EndReason::from_stored(&end_reason),
+                duration_sec: row.get(9)?,
+                rotations: row.get(10)?,
+                waves: row.get(11)?,
+                waves_per_rotation: row.get(12)?,
+                kills: row.get(13)?,
+                host_telemetry: row.get(15)?,
+                drone_kills: row.get(14)?,
+                vitus: crate::arbitration::Vitus {
+                    mean: row.get(16)?,
+                    std: row.get(17)?,
+                    per_minute: row.get(18)?,
+                },
+            })
+        })
+        .expect("query runs")
+        .collect::<Result<Vec<_>>>()
+        .expect("rows decode")
+    }
+
+    #[test]
+    fn fresh_schema_has_soft_deletion_and_started_index() {
+        let conn = db("schema");
+        assert_eq!(
+            conn.query_row("PRAGMA user_version", [], |r| r.get::<_, i64>(0))
+                .expect("version reads"),
+            5
+        );
+        let deleted: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('arbitration_runs') WHERE name = 'deleted' AND dflt_value = '0'",
+            [], |r| r.get(0),
+        ).expect("columns read");
+        assert_eq!(deleted, 1);
+        let indexes: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM pragma_index_list('arbitration_runs') WHERE name = 'arbitration_runs_started'",
+            [], |r| r.get(0),
+        ).expect("indexes read");
+        assert_eq!(indexes, 1);
+    }
+
+    #[test]
+    fn populated_v4_upgrade_preserves_existing_records_and_schema() {
+        let conn = db("upgrade");
+        conn.execute_batch(
+            "DROP TABLE arbitration_runs;
+             PRAGMA user_version = 4;
+             INSERT INTO trades (timestamp, item_name, session_id, trade_type)
+                VALUES ('2026-07-08T12:00:00Z', 'Revenant Prime Set', 'trade-session', 'sale');
+             INSERT INTO quantity_changes (unique_name, item_name, old_qty, new_qty, delta, timestamp, rank)
+                VALUES ('/Lotus/Mods/Flow', 'Flow', 1, 2, 1, unixepoch(), 5);
+             INSERT INTO saved_rivens VALUES ('riven', 'Rubico', 'Critical', '[]', 'Keep', 4, '2026-07-08');
+             INSERT INTO tracked_items VALUES ('/Lotus/Mods/Flow', 'Flow', '2026-07-08');
+             INSERT INTO item_snapshots (unique_name, date, quantity) VALUES ('/Lotus/Mods/Flow', '2026-07-08', 2);"
+        ).expect("upstream v4 records insert");
+        migrate(&conn).expect("v4 upgrade succeeds");
+        migrate(&conn).expect("migration rerun succeeds");
+        let trades = get_trades(&conn).expect("trades read");
+        assert_eq!(trades.len(), 1);
+        assert_eq!(trades[0].session_id, "trade-session");
+        assert_eq!(trades[0].trade_type, "sale");
+        assert_eq!(
+            get_quantity_changes(&conn, 10).expect("changes read")[0].rank,
+            Some(5)
+        );
+        assert_eq!(get_saved_rivens(&conn).expect("rivens read")[0].id, "riven");
+        assert_eq!(
+            get_tracked_items(&conn).expect("tracked items read").len(),
+            1
+        );
+        assert_eq!(
+            get_snapshots(&conn, "/Lotus/Mods/Flow", None).expect("snapshots read")[0].quantity,
+            2
+        );
+        let trade_uid: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('trades') WHERE name = 'uid'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("trade columns read");
+        assert_eq!(trade_uid, 0);
+        assert_eq!(watch(&conn, DEFENSE, 97), 1);
+    }
+
+    #[test]
+    fn failed_v5_migration_rolls_back_schema_and_version() {
+        let conn = db("migration-failure");
+        conn.execute_batch(
+            "DROP TABLE arbitration_runs;
+             CREATE TABLE arbitration_runs_started (id INTEGER);
+             PRAGMA user_version = 4;",
+        )
+        .expect("index-name conflict prepares");
+        assert!(migrate(&conn).is_err());
+        assert_eq!(
+            conn.query_row("PRAGMA user_version", [], |r| r.get::<_, i64>(0))
+                .expect("version reads"),
+            4
+        );
+        let tables: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE name = 'arbitration_runs'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("schema reads");
+        assert_eq!(tables, 0);
+        conn.execute_batch("DROP TABLE arbitration_runs_started;")
+            .expect("conflict removes");
+        migrate(&conn).expect("migration retries");
+        assert_eq!(watch(&conn, DEFENSE, 97), 1);
+    }
+
+    #[test]
+    fn a_run_watched_in_chunks_is_stored_as_one_run() {
+        let conn = db("live");
+        assert_eq!(watch(&conn, DEFENSE, 97), 1);
+
+        let runs = stored(&conn);
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].node, "Stöfler (Lua)");
+        assert_eq!(
+            runs[0].end_reason,
+            crate::arbitration::EndReason::MissionEnd
+        );
+        assert_eq!(
+            runs[0].mission_type,
+            crate::arbitration::MissionType::Defense
+        );
+    }
+
+    #[test]
+    fn parse_hands_back_the_runs_that_ended_in_the_chunk() {
+        let mut recorder = ArbitrationRecorder::default();
+        let ended = recorder.parse(DEFENSE.to_string());
+        assert_eq!(ended.len(), 1);
+        let summary = post_run_summary(&ended[0]).expect("a completed run has a summary");
+        assert_eq!(summary.node, "Stöfler (Lua)");
+        assert_eq!(summary.mission_type, "defense");
+        assert!(summary.waves > 0);
+        assert!(summary.duration_sec > 0.0);
+
+        assert!(recorder.parse(String::new()).is_empty());
+    }
+
+    #[test]
+    fn only_a_normally_ended_run_has_a_summary() {
+        let mut recorder = ArbitrationRecorder::default();
+        let ended = recorder.parse(ABORT.to_string());
+        assert_eq!(ended.len(), 1);
+        assert_eq!(ended[0].end_reason, EndReason::Aborted);
+        assert!(post_run_summary(&ended[0]).is_none());
+
+        let mut cut_off = completed_run();
+        cut_off.end_reason = EndReason::NewMission;
+        assert!(post_run_summary(&cut_off).is_none());
+    }
+
+    fn completed_run() -> Run {
+        let mut recorder = ArbitrationRecorder::default();
+        recorder.parse(DEFENSE.to_string()).remove(0)
+    }
+
+    fn aborted_run() -> Run {
+        let mut recorder = ArbitrationRecorder::default();
+        recorder.parse(ABORT.to_string()).remove(0)
+    }
+
+    #[test]
+    fn the_overlay_fires_for_a_live_completed_run_only_when_enabled() {
+        let ended = [completed_run()];
+        assert!(live_run_summary(&ended, true, true).is_some());
+        assert!(live_run_summary(&ended, false, true).is_none(), "backfill");
+        assert!(
+            live_run_summary(&ended, true, false).is_none(),
+            "toggle off"
+        );
+        assert!(live_run_summary(&[], true, true).is_none());
+    }
+
+    #[test]
+    fn the_newest_run_decides_whether_the_overlay_fires() {
+        assert!(live_run_summary(&[completed_run(), aborted_run()], true, true).is_none());
+        assert!(live_run_summary(&[aborted_run(), completed_run()], true, true).is_some());
+    }
+
+    #[test]
+    fn an_aborted_run_is_stored_too() {
+        let conn = db("abort");
+        assert_eq!(watch(&conn, ABORT, 4096), 1);
+        assert_eq!(
+            stored(&conn)[0].end_reason,
+            crate::arbitration::EndReason::Aborted
+        );
+    }
+
+    #[test]
+    fn processing_the_same_log_twice_stores_nothing_the_second_time() {
+        let conn = db("idempotent");
+        assert_eq!(watch(&conn, DEFENSE, 4096), 1);
+        assert_eq!(watch(&conn, DEFENSE, 4096), 0);
+        assert_eq!(stored(&conn).len(), 1);
+    }
+
+    #[test]
+    fn a_run_still_in_progress_is_not_stored_until_it_ends() {
+        let conn = db("in-progress");
+        let cut = DEFENSE.len() / 2;
+        let head = &DEFENSE[..DEFENSE[..cut].rfind('\n').expect("the fixture has lines") + 1];
+
+        let mut recorder = ArbitrationRecorder::default();
+        recorder.parse(head.to_string());
+        assert_eq!(recorder.store(&conn).expect("recording succeeds"), 0);
+        assert!(stored(&conn).is_empty());
+
+        recorder.parse(DEFENSE[head.len()..].to_string());
+        assert_eq!(recorder.store(&conn).expect("recording succeeds"), 1);
+        assert_eq!(stored(&conn).len(), 1);
+    }
+
+    #[test]
+    fn a_listed_run_carries_the_tier_of_the_node_it_ran_on() {
+        let conn = db("run-tier");
+        watch(&conn, DEFENSE, 4096);
+        let listed = list_arbitration_runs(&conn).expect("read succeeds");
+        let run = listed.first().expect("the defense run is listed");
+        assert_eq!(run.node, "Stöfler (Lua)");
+        assert_eq!(run.tier, Some("D"));
+    }
+
+    #[test]
+    fn a_deleted_run_is_gone_and_stays_gone_across_a_backfill() {
+        let conn = db("delete");
+        watch(&conn, DEFENSE, 4096);
+        watch(&conn, SURVIVAL, 4096);
+        let listed = list_arbitration_runs(&conn).expect("read succeeds");
+        assert_eq!(listed.len(), 2);
+        assert!(listed[0].started_at > listed[1].started_at, "newest first");
+
+        let survival = listed
+            .iter()
+            .find(|r| r.node == "Mot (Void)")
+            .expect("the survival run is listed");
+        assert!(delete_arbitration_run(&conn, &survival.uid).expect("delete succeeds"));
+        assert!(!delete_arbitration_run(&conn, "no such run").expect("a miss is not an error"));
+        assert_eq!(stored(&conn).len(), 1);
+        assert_eq!(
+            list_arbitration_runs(&conn).expect("read succeeds").len(),
+            1
+        );
+        assert_eq!(stored(&conn)[0].node, "Stöfler (Lua)");
+
+        assert_eq!(watch(&conn, SURVIVAL, 4096), 0);
+        assert_eq!(stored(&conn).len(), 1);
+    }
+
+    /// The parser has already consumed the lines behind a queued run, so a
+    /// write that fails has to leave the run recoverable rather than drop it.
+    #[test]
+    fn a_run_survives_a_failed_write_and_lands_on_the_next_attempt() {
+        let conn = db("write-failure");
+        conn.execute_batch("ALTER TABLE arbitration_runs RENAME TO arbitration_runs_hidden;")
+            .expect("the table can be moved out of the way");
+
+        let mut recorder = ArbitrationRecorder::default();
+        recorder.parse(DEFENSE.to_string());
+        assert!(
+            recorder.store(&conn).is_err(),
+            "the write must fail with no table"
+        );
+
+        conn.execute_batch("ALTER TABLE arbitration_runs_hidden RENAME TO arbitration_runs;")
+            .expect("the table can be put back");
+        assert_eq!(
+            recorder.store(&conn).expect("the retry succeeds"),
+            1,
+            "the run held on across the failure"
+        );
+        assert_eq!(stored(&conn).len(), 1);
+    }
+
+    #[test]
+    fn pending_writes_survive_log_replacement() {
+        let conn = db("replacement-retry");
+        let mut recorder = ArbitrationRecorder::default();
+        recorder.parse(DEFENSE.to_string());
+        conn.execute_batch("ALTER TABLE arbitration_runs RENAME TO arbitration_runs_hidden;")
+            .expect("table hides");
+        assert!(recorder.store(&conn).is_err());
+        recorder.parse("100.000 Script [Info]: ThemedSquadOverlay.lua: Mission name: Arbitration: Casta (Ceres)\npartial".into());
+        recorder.restart();
+        assert!(recorder.parse(String::new()).is_empty());
+        assert_eq!(recorder.parse(SURVIVAL.to_string()).len(), 1);
+        conn.execute_batch("ALTER TABLE arbitration_runs_hidden RENAME TO arbitration_runs;")
+            .expect("table restores");
+        assert_eq!(recorder.store(&conn).expect("queued runs retry"), 2);
+        assert_eq!(stored(&conn).len(), 2);
+    }
+
+    #[test]
+    fn a_stored_run_equals_the_run_the_parser_produced() {
+        let whole = crate::arbitration::parse_log(DEFENSE.lines());
+        for chunk_len in [1, 13, 512, 100_000] {
+            let conn = db(&format!("boundary-{chunk_len}"));
+            watch(&conn, DEFENSE, chunk_len);
+            assert_eq!(stored(&conn), whole, "chunk length {chunk_len}");
+        }
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,9 @@ fn truncate_chars(s: &str, n: usize) -> String {
 }
 use tauri::{Emitter, Manager, State};
 
+mod arbitration;
+mod arbitrations;
+mod log_tail;
 mod cache;
 mod console_login; // [console-login feature] remove this line to drop the feature
 mod db;
@@ -244,6 +247,7 @@ pub struct AppState {
     /// Set by `poke_scan` to bypass the 5-second PID-check cooldown immediately.
     pub force_pid_check: Arc<AtomicBool>,
     /// When false, the Relic Pick Overlay is suppressed even when EE.log triggers it.
+    pub arbitration_overlay_enabled: Arc<AtomicBool>,
     pub relic_pick_overlay_enabled: Arc<AtomicBool>,
     /// When true, a parallel memory-scan thread polls Warframe's process memory for the
     /// relic reward screen open/close events instead of relying solely on EE.log.
@@ -2990,6 +2994,43 @@ fn parse_trade_dialog(raw: &str) -> Option<ParsedTrade> {
     })
 }
 
+fn record_arbitration_runs(
+    app: &tauri::AppHandle,
+    recorder: &mut db::ArbitrationRecorder,
+    chunk: String,
+    live: bool,
+) {
+    let ended = recorder.parse(chunk);
+
+    let state = app.state::<AppState>();
+    let overlay_on = state.arbitration_overlay_enabled.load(Ordering::SeqCst);
+    if let Some(summary) = db::live_run_summary(&ended, live, overlay_on) {
+        show_arbitration_overlay(app);
+        if let Err(e) = app.emit("arbitration-run-ended", &summary) {
+            warn!(error = %e, "arbitration overlay event not delivered");
+        }
+    }
+
+    let stored = {
+        let conn = match state.conn.lock() {
+            Ok(conn) => conn,
+            Err(e) => {
+                warn!(error = %e, "database lock poisoned; arbitration runs held back");
+                return;
+            }
+        };
+        recorder.store(&conn)
+    };
+    match stored {
+        Ok(0) => {}
+        Ok(stored) => {
+            info!(runs = stored, "arbitration runs recorded");
+            app.emit("arbitration-runs-changed", ()).ok();
+        }
+        Err(e) => warn!(error = %e, "storing arbitration runs failed; retrying on the next read"),
+    }
+}
+
 /// Start a lightweight EE.log watcher for features that don't need the memory scanner:
 /// riven reroll detection, trade completion detection, WFM whisper detection.
 /// Called unconditionally at app startup — EE.log is plain file I/O, not memory reading.
@@ -2999,9 +3040,20 @@ fn start_log_watcher(app: tauri::AppHandle) -> Result<(), String> {
         .map(|d| d.join("Warframe").join("EE.log"))
         .ok_or("Cannot find LocalAppData")?;
 
+    static WATCHER: log_tail::WatcherSlot = log_tail::WatcherSlot::new();
+    let Some(slot) = WATCHER.try_acquire() else { return Ok(()); };
+
     std::thread::spawn(move || {
-        use std::io::{Read, Seek, SeekFrom};
-        let mut file_pos: u64 = std::fs::metadata(&log_path).map(|m| m.len()).unwrap_or(0);
+        let _slot = slot;
+        let mut arbitration_runs = db::ArbitrationRecorder::default();
+        let mut tail = log_tail::LogTail::from_start(log_path.clone());
+        // Only arbitration consumes history; old trade prompts and reward overlays
+        // must not replay. Keep the parser so an active run can finish live.
+        if let Some(chunk) = tail.read() {
+            record_arbitration_runs(&app, &mut arbitration_runs, chunk.text, false);
+        }
+        let mut backfilled = tail.has_read();
+        let mut pending_lines = String::new();
         let mut pending_trade: Option<String> = None;
         // Cooldown: don't fire riven-screen-open again within 4 seconds of the last fire.
         // Guards against the same EE.log buffer being processed twice by React StrictMode listeners.
@@ -3031,15 +3083,28 @@ fn start_log_watcher(app: tauri::AppHandle) -> Result<(), String> {
             } else {
                 std::thread::sleep(std::time::Duration::from_millis(50));
             }
-            let Ok(mut f) = std::fs::File::open(&log_path) else { continue };
-            let len = std::fs::metadata(&log_path).map(|m| m.len()).unwrap_or(0);
-            if len < file_pos { file_pos = 0; }
-            if len == file_pos { continue; } // nothing new since last read
-            if f.seek(SeekFrom::Start(file_pos)).is_err() { continue; }
-            let mut buf = String::new();
-            if f.read_to_string(&mut buf).is_err() { continue; }
-            file_pos = len;
-            if buf.is_empty() { continue; }
+            let Some(chunk) = tail.read() else {
+                backfilled |= tail.has_read();
+                record_arbitration_runs(&app, &mut arbitration_runs, String::new(), false);
+                continue;
+            };
+            if chunk.restarted {
+                // A replacement starts a new parser but retains failed writes.
+                arbitration_runs.restart();
+                pending_lines.clear();
+                pending_trade = None;
+                last_riven_fire = None;
+                last_relic_pick_trigger = None;
+            }
+            let live = backfilled && !chunk.restarted;
+            backfilled = true;
+            let buf = chunk.text;
+            record_arbitration_runs(&app, &mut arbitration_runs, buf.clone(), live);
+            if !live { continue; }
+            pending_lines.push_str(&buf);
+            let Some(end) = pending_lines.rfind('\n') else { continue; };
+            let remainder = pending_lines.split_off(end + 1);
+            let buf = std::mem::replace(&mut pending_lines, remainder);
             let lower = buf.to_lowercase();
 
             // ── Riven reroll / unveil ─────────────────────────────────────────
@@ -4235,6 +4300,56 @@ pub struct CraftingJob {
 pub struct BlobStatusPayload {
     pub stage:   String,  // "scanning" | "done" | "error"
     pub detail:  String,  // human-readable detail
+}
+
+#[tauri::command]
+fn get_arbitration_runs(state: State<AppState>) -> Result<Vec<db::RunRecord>, String> {
+    let conn = state.conn.lock().map_err(|e| e.to_string())?;
+    db::list_arbitration_runs(&conn).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+fn delete_arbitration_run(app: tauri::AppHandle, state: State<AppState>, uid: String) -> Result<(), String> {
+    let conn = state.conn.lock().map_err(|e| e.to_string())?;
+    let deleted = db::delete_arbitration_run(&conn, &uid).map_err(|e| e.to_string())?;
+    if !deleted {
+        return Err("run not found; the history shown may be out of date".to_string());
+    }
+    app.emit("arbitration-runs-changed", ()).ok();
+    Ok(())
+}
+
+fn show_arbitration_overlay(app: &tauri::AppHandle) {
+    if let Some(win) = app.get_webview_window("arbitration-overlay") {
+        if let Err(e) = win.show() {
+            warn!(error = %e, "arbitration overlay did not show");
+        }
+    }
+}
+
+#[tauri::command]
+fn set_arbitration_overlay_enabled(state: State<AppState>, enabled: bool) {
+    state.arbitration_overlay_enabled.store(enabled, Ordering::SeqCst);
+}
+
+/// Debug: fire the post-run overlay with a made-up completed run.
+#[tauri::command]
+fn test_arbitration_overlay(app: tauri::AppHandle) -> String {
+    let summary = db::RunSummary {
+        node: "Stöfler (Lua)".into(),
+        mission_type: "defense",
+        duration_sec: 1487.0,
+        rotations: 5,
+        waves: 15,
+        kills: 612,
+        drone_kills: 23,
+        host_telemetry: true,
+        vitus_mean: 41.3,
+        vitus_per_minute: 1.67,
+    };
+    show_arbitration_overlay(&app);
+    let _ = app.emit("arbitration-run-ended", &summary);
+    "Emitted arbitration-run-ended with a sample run".to_string()
 }
 
 // ── Relic pick overlay ────────────────────────────────────────────────────────
@@ -9892,6 +10007,7 @@ pub fn run() {
             unmatched_paths_dir,
             corrections,
             force_pid_check: Arc::new(AtomicBool::new(false)),
+            arbitration_overlay_enabled: Arc::new(AtomicBool::new(false)),
             relic_pick_overlay_enabled: Arc::new(AtomicBool::new(true)),
             mem_trigger_enabled: Arc::new(AtomicBool::new(false)),
         })
@@ -10038,6 +10154,11 @@ pub fn run() {
             factory_reset,
             wfm_set_status,
             start_log_watcher,
+            arbitrations::fetch_arbitration_schedule,
+            get_arbitration_runs,
+            delete_arbitration_run,
+            set_arbitration_overlay_enabled,
+            test_arbitration_overlay,
             ocr_riven_log_error,
             start_riven_memory_watcher,
             riven_screen_visible,

--- a/src-tauri/src/log_tail.rs
+++ b/src-tauri/src/log_tail.rs
@@ -1,0 +1,371 @@
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+pub struct WatcherSlot(AtomicBool);
+
+impl WatcherSlot {
+    pub const fn new() -> Self {
+        Self(AtomicBool::new(false))
+    }
+
+    pub fn try_acquire(&self) -> Option<WatcherGuard<'_>> {
+        self.0
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .ok()
+            .map(|_| WatcherGuard(self))
+    }
+}
+
+pub struct WatcherGuard<'a>(&'a WatcherSlot);
+
+impl Drop for WatcherGuard<'_> {
+    fn drop(&mut self) {
+        self.0 .0.store(false, Ordering::Release);
+    }
+}
+
+pub struct TailChunk {
+    pub text: String,
+    /// The file this text came from is not the one the previous chunk came
+    /// from. Readers holding state across chunks must drop it.
+    pub restarted: bool,
+}
+
+#[cfg(windows)]
+type FileId = (u32, u32, u32);
+
+#[cfg(windows)]
+fn file_id(file: &std::fs::File) -> std::io::Result<FileId> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::{
+        GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION,
+    };
+
+    let mut info = std::mem::MaybeUninit::<BY_HANDLE_FILE_INFORMATION>::uninit();
+    // The handle stays open for this call; the API initializes info on success.
+    if unsafe { GetFileInformationByHandle(file.as_raw_handle() as _, info.as_mut_ptr()) } == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let info = unsafe { info.assume_init() };
+    Ok((
+        info.dwVolumeSerialNumber,
+        info.nFileIndexHigh,
+        info.nFileIndexLow,
+    ))
+}
+
+#[cfg(unix)]
+type FileId = (u64, u64, Option<std::time::SystemTime>);
+
+#[cfg(unix)]
+fn file_id(file: &std::fs::File) -> std::io::Result<FileId> {
+    use std::os::unix::fs::MetadataExt;
+    let meta = file.metadata()?;
+    Ok((meta.dev(), meta.ino(), meta.created().ok()))
+}
+
+pub struct LogTail {
+    path: PathBuf,
+    pos: u64,
+    /// Identity of the file `pos` counts into. A new launch writes a new file
+    /// at the same path, and its first bytes are a boot header that readers
+    /// must not miss.
+    file_id: Option<FileId>,
+    /// The leading bytes of a character whose remaining bytes have not been
+    /// written yet.
+    partial_char: Vec<u8>,
+    /// Set when the file changed underneath us, cleared once a chunk has
+    /// carried the fact to the caller. It outlives the read that noticed it
+    /// because that read can come back empty.
+    restarted: bool,
+}
+
+impl LogTail {
+    /// Empty logs still establish the boundary between backfill and live events.
+    pub fn has_read(&self) -> bool {
+        self.file_id.is_some()
+    }
+
+    pub fn from_start(path: PathBuf) -> Self {
+        Self {
+            path,
+            pos: 0,
+            file_id: None,
+            partial_char: Vec::new(),
+            restarted: false,
+        }
+    }
+
+    /// Starts at the end, for readers that react to events as they happen and
+    /// would fire on hours-old lines if handed the existing log.
+    pub fn from_end(path: PathBuf) -> Self {
+        let seen = std::fs::File::open(&path)
+            .ok()
+            .and_then(|file| Some((file.metadata().ok()?.len(), file_id(&file).ok()?)));
+        Self {
+            pos: seen.as_ref().map_or(0, |(len, _)| *len),
+            file_id: seen.map(|(_, id)| id),
+            path,
+            partial_char: Vec::new(),
+            restarted: false,
+        }
+    }
+
+    /// Whatever has been appended since the last call, or `None` when the file
+    /// is unreadable or has not grown.
+    pub fn read(&mut self) -> Option<TailChunk> {
+        use std::io::{Read, Seek, SeekFrom};
+
+        let mut file = std::fs::File::open(&self.path).ok()?;
+        let meta = file.metadata().ok()?;
+        // Identity and bytes must come from the same open file. A failed identity
+        // query leaves the cursor untouched so the next filesystem event can retry.
+        let id = file_id(&file).ok()?;
+        let restarted = self.file_id.is_some_and(|seen| seen != id) || meta.len() < self.pos;
+        let pos = if restarted { 0 } else { self.pos };
+        file.seek(SeekFrom::Start(pos)).ok()?;
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes).ok()?;
+
+        if restarted {
+            self.partial_char.clear();
+            self.restarted = true;
+        }
+        self.file_id = Some(id);
+        // Reading may include bytes appended after the metadata snapshot.
+        self.pos = pos + bytes.len() as u64;
+
+        let text = self.decode(&bytes);
+        if text.is_empty() {
+            return None;
+        }
+        Some(TailChunk {
+            text,
+            restarted: std::mem::take(&mut self.restarted),
+        })
+    }
+
+    /// A read can land mid-character, and a log can hold a byte that is no
+    /// character at all. The first waits for the rest of its character; the
+    /// second is dropped, because a cursor that refuses to pass one bad byte
+    /// stops delivering the file for as long as the byte is in it.
+    fn decode(&mut self, bytes: &[u8]) -> String {
+        let mut buf = std::mem::take(&mut self.partial_char);
+        buf.extend_from_slice(bytes);
+
+        let mut text = String::new();
+        let mut at = 0;
+        loop {
+            match std::str::from_utf8(&buf[at..]) {
+                Ok(rest) => {
+                    text.push_str(rest);
+                    break;
+                }
+                Err(e) => {
+                    let valid = e.valid_up_to();
+                    text.push_str(
+                        std::str::from_utf8(&buf[at..at + valid])
+                            .expect("valid_up_to reports a decodable prefix"),
+                    );
+                    match e.error_len() {
+                        Some(bad) => at += valid + bad,
+                        None => {
+                            self.partial_char = buf[at + valid..].to_vec();
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        text
+    }
+}
+
+#[cfg(test)]
+mod log_tail_tests {
+    use super::*;
+    use std::io::Write;
+    use std::path::Path;
+
+    #[test]
+    fn watcher_slot_blocks_duplicates_until_watcher_exits() {
+        let slot = WatcherSlot::new();
+        let watcher = slot.try_acquire().expect("slot starts free");
+        assert!(slot.try_acquire().is_none());
+        drop(watcher);
+        assert!(slot.try_acquire().is_some());
+    }
+
+    #[test]
+    fn empty_initial_read_establishes_backfill_boundary() {
+        let path = scratch("empty-initial.log");
+        let mut tail = LogTail::from_start(path.clone());
+        assert!(tail.read().is_none());
+        assert!(!tail.has_read());
+        append(&path, b"");
+        assert!(tail.read().is_none());
+        assert!(tail.has_read());
+    }
+
+    fn scratch(name: &str) -> PathBuf {
+        let dir = Path::new("tmp").join(format!("frameforge-tail-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp dir is always writable");
+        let path = dir.join(name);
+        let _ = std::fs::remove_file(&path);
+        path
+    }
+
+    fn append(path: &Path, bytes: &[u8]) {
+        let mut f = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .expect("scratch file is writable");
+        f.write_all(bytes).expect("scratch write succeeds");
+    }
+
+    fn text_of(tail: &mut LogTail) -> String {
+        tail.read().map(|c| c.text).unwrap_or_default()
+    }
+
+    #[test]
+    fn a_missing_file_reads_as_nothing() {
+        let mut tail = LogTail::from_start(scratch("absent.log"));
+        assert!(tail.read().is_none());
+    }
+
+    #[test]
+    fn each_line_is_delivered_exactly_once() {
+        let path = scratch("append.log");
+        append(&path, b"one\n");
+        let mut tail = LogTail::from_start(path.clone());
+        assert_eq!(text_of(&mut tail), "one\n");
+        assert!(tail.read().is_none());
+
+        append(&path, b"two\n");
+        assert_eq!(text_of(&mut tail), "two\n");
+        assert!(tail.read().is_none());
+    }
+
+    #[test]
+    fn a_character_split_across_two_reads_survives() {
+        let path = scratch("split.log");
+        let stoefler = "Stöfler\n".as_bytes();
+        let cut = 2; // mid-way through the two-byte 'ö'
+        append(&path, &stoefler[..cut + 1]);
+
+        let mut tail = LogTail::from_start(path.clone());
+        let first = text_of(&mut tail);
+        append(&path, &stoefler[cut + 1..]);
+        let second = text_of(&mut tail);
+
+        assert_eq!(format!("{first}{second}"), "Stöfler\n");
+    }
+
+    #[test]
+    fn a_byte_that_is_no_character_does_not_stall_the_cursor() {
+        let path = scratch("invalid.log");
+        append(&path, b"before\n\xffafter\n");
+
+        let mut tail = LogTail::from_start(path.clone());
+        let text = text_of(&mut tail);
+        assert!(
+            text.contains("before"),
+            "text before the bad byte is delivered"
+        );
+        assert!(text.contains("after"), "text after it is delivered too");
+        assert!(tail.read().is_none(), "the cursor moved past the bad byte");
+    }
+
+    #[test]
+    fn truncating_the_file_replays_it_and_says_so() {
+        let path = scratch("truncate.log");
+        append(&path, b"old session\n");
+        let mut tail = LogTail::from_start(path.clone());
+        assert_eq!(text_of(&mut tail), "old session\n");
+
+        std::fs::write(&path, b"new\n").expect("scratch file is writable");
+        let chunk = tail.read().expect("a truncated file reads from its start");
+        assert_eq!(chunk.text, "new\n");
+        assert!(chunk.restarted);
+    }
+
+    /// A relaunch replaces the file rather than truncating it, and the new log
+    /// can pass the old cursor before the next poll. Length alone misses that.
+    #[test]
+    fn replacing_the_file_with_a_longer_one_still_reads_as_a_restart() {
+        let path = scratch("replace.log");
+        append(&path, b"old\n");
+        let mut tail = LogTail::from_start(path.clone());
+        assert_eq!(text_of(&mut tail), "old\n");
+
+        std::fs::rename(&path, path.with_extension("old")).expect("scratch file is movable");
+        append(&path, b"a much longer new session log\n");
+
+        let chunk = tail.read().expect("a replaced file reads from its start");
+        assert_eq!(chunk.text, "a much longer new session log\n");
+        assert!(chunk.restarted);
+    }
+
+    #[test]
+    fn a_tail_that_opened_at_the_end_still_sees_a_replacement() {
+        let path = scratch("end-replace.log");
+        append(&path, b"old session\n");
+        let mut tail = LogTail::from_end(path.clone());
+        assert!(tail.read().is_none(), "nothing has been appended yet");
+
+        std::fs::rename(&path, path.with_extension("old")).expect("scratch file is movable");
+        append(&path, b"a much longer new session log\n");
+
+        let chunk = tail.read().expect("a replaced file reads from its start");
+        assert_eq!(chunk.text, "a much longer new session log\n");
+        assert!(chunk.restarted);
+    }
+
+    /// The restart has to reach the reader even when the read that noticed it
+    /// had nothing to hand over.
+    #[test]
+    fn a_restart_seen_on_an_empty_file_is_reported_with_the_next_chunk() {
+        let path = scratch("empty-restart.log");
+        append(&path, b"old\n");
+        let mut tail = LogTail::from_start(path.clone());
+        assert_eq!(text_of(&mut tail), "old\n");
+
+        std::fs::write(&path, b"").expect("scratch file is writable");
+        assert!(
+            tail.read().is_none(),
+            "an empty file has nothing to deliver"
+        );
+
+        append(&path, b"new\n");
+        let chunk = tail.read().expect("the new file has text");
+        assert_eq!(chunk.text, "new\n");
+        assert!(chunk.restarted, "the restart must not be forgotten");
+    }
+    #[test]
+    fn split_lines_are_delivered_without_inventing_newlines() {
+        let path = scratch("split-line.log");
+        append(&path, b"first\nsec");
+        let mut tail = LogTail::from_start(path.clone());
+        assert_eq!(text_of(&mut tail), "first\nsec");
+        append(&path, b"ond\n");
+        assert_eq!(text_of(&mut tail), "ond\n");
+        assert!(tail.read().is_none());
+    }
+
+    #[test]
+    fn failed_open_retains_cursor_and_partial_character() {
+        let path = scratch("retry.log");
+        append(&path, b"old\n\xc3");
+        let mut tail = LogTail::from_start(path.clone());
+        assert_eq!(text_of(&mut tail), "old\n");
+        let moved = path.with_extension("old");
+        std::fs::rename(&path, &moved).expect("scratch file is movable");
+        assert!(tail.read().is_none());
+        assert_eq!(tail.pos, 5);
+        assert_eq!(tail.partial_char, b"\xc3");
+        std::fs::rename(&moved, &path).expect("scratch file is movable");
+        append(&path, b"\xb6\n");
+        assert_eq!(text_of(&mut tail), "ö\n");
+    }
+}

--- a/src-tauri/src/refresh.rs
+++ b/src-tauri/src/refresh.rs
@@ -35,6 +35,11 @@ struct Task {
 }
 
 const TASKS: &[Task] = &[
+    Task {
+        name: "arbitrations",
+        interval: Duration::from_secs(3600),
+        run: crate::arbitrations::refresh_feed,
+    },
     // Just under the 60s frontend poll, so a window's own tick is served from
     // the cache this fills rather than from the network.
     Task {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -66,6 +66,23 @@
         "decorations": true,
         "resizable": true,
         "skipTaskbar": false
+      },
+      {
+        "label": "arbitration-overlay",
+        "url": "index.html#arbitrationoverlay",
+        "title": "FrameForge Arbitration Summary",
+        "width": 340,
+        "height": 80,
+        "x": 0,
+        "y": -3000,
+        "visible": false,
+        "transparent": true,
+        "decorations": false,
+        "shadow": false,
+        "alwaysOnTop": true,
+        "skipTaskbar": true,
+        "resizable": false,
+        "focus": false
       }
     ],
     "security": {

--- a/src-tauri/tests/fixtures/arbitration/apollo-join.txt
+++ b/src-tauri/tests/fixtures/arbitration/apollo-join.txt
@@ -1,0 +1,20 @@
+0.098 Sys [Diag]: Current time: Wed Jul  8 20:11:02 2026 [UTC: Wed Jul  8 18:11:02 2026]
+2.005 Sys [Info]: Warframe startup chatter
+2040.984 Script [Info]: ThemedSquadOverlay.lua: Cached mission name=Apollo (Lua) - Arbitration (SolNode308)
+2047.451 Script [Info]: ThemedSquadOverlay.lua: LoadLevelMsg received. Client joining mission in-progress: {"name":"SolNode308_EliteAlert"}
+2051.361 Script [Info]: Client loaded {"name":"SolNode308_EliteAlert"} with MissionInfo:
+2053.010 Sys [Info]: SyncAutoPopulatedConsumables for mission MT_ARTIFACT with location SolNode308
+2055.220 Game [Info]: OnStateStarted, mission type=MT_ARTIFACT
+2060.000 Script [Info]: SentientArtifactMission.lua: Disruption: State change: ARTIFACT_ROUND
+2071.500 AI [Info]: OnAgentCreated /Npc/CorpusEliteShieldDroneAgent12 Live 9 Spawned 2 Ticking 8 Paused 1 IgnoredTicking 6 MonitoredTicking 2 AllyLive 7 AllyActive 6 NeutralActive 0
+2090.000 Sys [Info]: Created /Lotus/Interface/SurvivalReward.swf
+2150.000 Sys [Info]: Created /Lotus/Interface/SurvivalReward.swf
+2210.000 AI [Info]: OnAgentCreated /Npc/CorpusEliteShieldDroneAgent40 Live 9 Spawned 30 Ticking 8 Paused 1 IgnoredTicking 6 MonitoredTicking 2 AllyLive 7 AllyActive 6 NeutralActive 0
+2300.000 Script [Info]: SentientArtifactMission.lua: Disruption: State change: ARTIFACT_ROUND_DONE
+2301.000 Script [Info]: SentientArtifactMission.lua: Disruption: State change: REWARDS (host)
+2320.000 Script [Info]: SentientArtifactMission.lua: Disruption: State change: INTERVAL
+2340.000 Script [Info]: SentientArtifactMission.lua: Disruption: State change: ARTIFACT_ROUND
+2400.000 AI [Info]: OnAgentCreated /Npc/CorpusEliteShieldDroneAgent77 Live 9 Spawned 60 Ticking 8 Paused 1 IgnoredTicking 6 MonitoredTicking 2 AllyLive 7 AllyActive 6 NeutralActive 0
+2600.000 Script [Info]: SentientArtifactMission.lua: Disruption: State change: ARTIFACT_ROUND_DONE
+2612.400 Script [Info]: EndOfMatch.lua: Initialize
+2612.510 Sys [Info]: EOM missionLocationUnlocked=1

--- a/src-tauri/tests/fixtures/arbitration/casta-defense-spam.txt
+++ b/src-tauri/tests/fixtures/arbitration/casta-defense-spam.txt
@@ -1,0 +1,26 @@
+0.099 Sys [Diag]: Current time: Fri Jul 10 21:30:00 2026 [UTC: Fri Jul 10 19:30:00 2026]
+2.005 Sys [Info]: Warframe startup chatter
+300.000 Script [Info]: ThemedSquadOverlay.lua: Pending mission: SolNode149_EliteAlert
+305.000 Script [Info]: ThemedSquadOverlay.lua: Mission name: Casta (Ceres) - Arbitration
+308.000 Sys [Info]: SyncAutoPopulatedConsumables for mission MT_DEFENSE with location SolNode149
+310.000 Game [Info]: OnStateStarted, mission type=MT_DEFENSE
+320.000 Script [Info]: WaveDefend.lua: Defense wave: 1
+321.000 Game [Warning]: OnAgentCreated /Npc/GrineerLancerAgent3 Live 1 Spawned 0 Ticking 1 Paused 0 IgnoredTicking 0 MonitoredTicking 1 AllyLive 4 AllyActive 4 NeutralActive 0
+321.500 AI [Info]: OnAgentCreated /Npc/GrineerLancerAgent4 DamagePct 0.5 MonitoredTicking 2
+322.000 AI [Info]: OnAgentCreated /Npc/GrineerLancerAgent5 Live 3 Spawned 2 Ticking 3 Paused 0 IgnoredTicking 0 MonitoredTicking 3 AllyLive 4 AllyActive 4 NeutralActive 0
+322.500 AI [Info]: OnAgentCreated /Npc/TurretAgent1 Live 4 Spawned 3 Ticking 4 Paused 0 IgnoredTicking 0 MonitoredTicking 4 AllyLive 4 AllyActive 4 NeutralActive 0
+323.000 AI [Info]: OnAgentCreated /Npc/GrineerLancerAgent6 Live 5 Spawned 4 Ticking 5 Paused 0 IgnoredTicking 0 MonitoredTicking 5 AllyLive 4 AllyActive 4 NeutralActive 0
+323.100 Sys [Info]: Resloader 0x000001F89DF86F50 (/Lotus/Interface/Icons/StoreIcons/Resources/CraftingComponents/Elitium.png) starting
+323.200 Sys [Info]: Created /Lotus/Interface/SurvivalReward.swf
+324.000 AI [Info]: OnAgentCreated /Npc/DecorCrateAgent1 Live 6 Spawned 5 Ticking 5 Paused 0 IgnoredTicking 1 MonitoredTicking 5 AllyLive 4 AllyActive 4 NeutralActive 0
+324.100 AI [Info]: OnAgentCreated /Npc/DecorCrateAgent2 Live 7 Spawned 6 Ticking 5 Paused 0 IgnoredTicking 2 MonitoredTicking 5 AllyLive 4 AllyActive 4 NeutralActive 0
+324.200 AI [Info]: OnAgentCreated /Npc/DecorCrateAgent3 Live 8 Spawned 7 Ticking 5 Paused 0 IgnoredTicking 3 MonitoredTicking 5 AllyLive 4 AllyActive 4 NeutralActive 0
+325.000 AI [Info]: OnAgentCreated /Npc/GrineerLancerAgent7 Live 9 Spawned 8 Ticking 6 Paused 0 IgnoredTicking 3 MonitoredTicking 5 AllyLive 4 AllyActive 4 NeutralActive 0
+326.000 AI [Info]: OnAgentCreated /Npc/CorpusEliteShieldDroneAgent8 Live 10 Spawned 9 Ticking 7 Paused 0 IgnoredTicking 3 MonitoredTicking 7 AllyLive 4 AllyActive 4 NeutralActive 0
+330.000 Script [Info]: EndOfMatch.lua: Initialize
+330.001 Script [Info]: EndOfMatch.lua: Mission Succeeded
+355.000 Sys [Info]: Created /Lotus/Interface/DefenseReward.swf
+360.000 Sys [Info]: Created /Lotus/Interface/DefenseReward.swf
+365.000 Sys [Error]: SetCallbacks on unknown clip: 'Rewards.Element.Btn', movie: '/Lotus/Interface/DefenseReward.swf'
+400.000 Sys [Info]: Created /Lotus/Interface/DefenseReward.swf
+410.000 Sys [Info]: EOM missionLocationUnlocked=1

--- a/src-tauri/tests/fixtures/arbitration/mot-survival.txt
+++ b/src-tauri/tests/fixtures/arbitration/mot-survival.txt
@@ -1,0 +1,29 @@
+0.091 Sys [Diag]: Current time: Mon Jul  6 17:46:29 2026 [UTC: Mon Jul  6 15:46:29 2026]
+2.005 Sys [Info]: Warframe startup chatter
+410.170 Script [Info]: MapRedux.lua: Confirm sector SolNode409_EliteAlert
+410.170 Net [Info]: Set squad mission: {"name":"SolNode409_EliteAlert"}
+410.170 Script [Info]: ThemedSquadOverlay.lua: Pending mission: SolNode409_EliteAlert
+415.070 Script [Info]: ThemedSquadOverlay.lua: Mission name: Mot (Void) - Arbitration
+415.071 Script [Info]: ThemedSquadOverlay.lua: Lobby::Host_StartMatch: launching level for SolNode409_EliteAlert (/Lotus/Levels/Proc/Orokin/OrokinTowerSurvivalRaid)
+418.867 Sys [Info]: SyncAutoPopulatedConsumables for mission MT_SURVIVAL with location SolNode409
+420.402 Game [Info]: OnStateStarted, mission type=MT_SURVIVAL
+432.123 Script [Info]: EndOfMatch.lua: Initialize
+432.123 Script [Info]: EndOfMatch.lua: DBG: HudVis 1
+432.123 Script [Info]: EndOfMatch.lua: Mission Succeeded
+432.123 Script [Info]: EndOfMatch.lua: EndOfMatch.lua: GiveMissionRewards. success=true
+434.607 AI [Info]: OnAgentCreated /Npc/CorpusEliteShieldDroneAgent9 Live 9 Spawned 2 Ticking 8 Paused 1 IgnoredTicking 6 MonitoredTicking 2 AllyLive 7 AllyActive 6 NeutralActive 0
+446.133 AI [Info]: OnAgentCreated /Npc/CorpusEliteShieldDroneAgent24 Live 14 Spawned 16 Ticking 13 Paused 1 IgnoredTicking 6 MonitoredTicking 7 AllyLive 7 AllyActive 6 NeutralActive 0
+469.378 AI [Info]: OnAgentCreated /Npc/CorpusEliteShieldDroneAgent51 Live 17 Spawned 42 Ticking 16 Paused 1 IgnoredTicking 6 MonitoredTicking 10 AllyLive 7 AllyActive 6 NeutralActive 0
+479.473 AI [Info]: OnAgentCreated /Npc/CorpusEliteShieldDroneAgent61 Live 18 Spawned 51 Ticking 16 Paused 1 IgnoredTicking 6 MonitoredTicking 10 AllyLive 7 AllyActive 6 NeutralActive 0
+487.040 AI [Info]: OnAgentCreated /Npc/CorpusEliteShieldDroneAgent68 Live 18 Spawned 57 Ticking 16 Paused 1 IgnoredTicking 6 MonitoredTicking 10 AllyLive 7 AllyActive 6 NeutralActive 0
+493.624 AI [Info]: OnAgentCreated /Npc/CorpusEliteShieldDroneAgent77 Live 17 Spawned 65 Ticking 12 Paused 1 IgnoredTicking 6 MonitoredTicking 6 AllyLive 7 AllyActive 6 NeutralActive 0
+577.762 Script [Info]: EndOfMatch.lua: Initialize
+577.763 Script [Info]: EndOfMatch.lua: EndOfMatch.lua: GiveMissionRewards. success=true
+735.449 Script [Info]: SurvivalMission.lua: Survival: Host - first reward
+735.449 Sys [Info]: Created /Lotus/Interface/SurvivalReward.swf
+735.449 Script [Info]: SurvivalMission.lua: Survival: Gave reward tier 1 at 300.25689697265625
+735.449 Script [Info]: SurvivalReward.lua: RewardUtilities: Gave reward tier 0
+735.957 AI [Info]: OnAgentCreated /Npc/CorpusEliteShieldDroneAgent251 Live 17 Spawned 228 Ticking 16 Paused 1 IgnoredTicking 6 MonitoredTicking 10 AllyLive 7 AllyActive 6 NeutralActive 0
+747.893 Script [Info]: EndOfMatch.lua: Initialize
+747.907 Sys [Info]: EOM missionLocationUnlocked=1
+747.907 Sys [Info]: MISSION_SCORE SolNode409 0x00000139

--- a/src-tauri/tests/fixtures/arbitration/oestrus-abort.txt
+++ b/src-tauri/tests/fixtures/arbitration/oestrus-abort.txt
@@ -1,0 +1,27 @@
+0.102 Sys [Diag]: Current time: Mon Jul  6 11:40:31 2026 [UTC: Mon Jul  6 09:40:31 2026]
+2.114 Sys [Info]: Warframe startup chatter
+158.073 Script [Info]: MapRedux.lua: Confirm sector SolNode167_EliteAlert
+158.073 Net [Info]: Set squad mission: {"name":"SolNode167_EliteAlert"}
+158.074 Script [Info]: ThemedSquadOverlay.lua: Pending mission: SolNode167_EliteAlert
+158.074 Script [Info]: ThemedSquadOverlay.lua: ShowMissionVote Oestrus (Eris) - Arbitration - Level (60-80) (SolNode167_EliteAlert) -1
+178.428 Script [Info]: ThemedSquadOverlay.lua: Mission name: Oestrus (Eris) - Arbitration
+178.428 Script [Info]: ThemedSquadOverlay.lua: Host loading {"name":"SolNode167_EliteAlert"} with MissionInfo:
+178.429 Script [Info]: ThemedSquadOverlay.lua: Lobby::Host_StartMatch: launching level for SolNode167_EliteAlert (/Lotus/Levels/Proc/Infestation/InfestedCorpusShipPurify)
+181.561 Sys [Info]: SyncAutoPopulatedConsumables for mission MT_PURIFY with location SolNode167
+184.402 Net [Info]: GameRulesImpl - changing state from SS_WAITING_FOR_PLAYERS to SS_STARTED
+184.403 Game [Info]: GameRulesImpl::StartRound()
+184.403 Game [Info]: OnStateStarted, mission type=MT_PURIFY
+197.641 AI [Info]: OnAgentCreated /Npc/FlightAgent1 Live 1 Spawned 0 Ignored Ticking 1 Paused 0 IgnoredTicking 1 MonitoredTicking 0 AllyLive 1 AllyActive 1 NeutralActive 0
+197.685 AI [Info]: OnAgentCreated /Npc/FlightAgent2 Live 2 Spawned 0 Ignored Ticking 2 Paused 0 IgnoredTicking 2 MonitoredTicking 0 AllyLive 2 AllyActive 2 NeutralActive 0
+233.756 Script [Info]: Dialog.lua: Dialog::CreateOkCancel(description=/Lotus/Language/Menu/AbortMissionConfirm, title= leftItem=/Menu/Confirm_Item_Yes, rightItem=/Menu/Confirm_Item_No)
+234.379 Script [Info]: Dialog.lua: Dialog::SendResult(4)
+234.503 Script [Info]: TopMenu.lua: Abort: host/no session
+234.503 Sys [Info]: EOM missionLocationUnlocked=1
+234.522 Net [Info]: GameRulesImpl - changing state from SS_STARTED to SS_ENDING
+234.933 Sys [Info]: Clearing gRegion and gGameRules
+241.105 Script [Info]: EndOfMatch.lua: Initialize
+250.845 Script [Info]: MapRedux.lua: Confirm sector SolNode162
+250.845 Net [Info]: Set squad mission: {"difficulty":1,"name":"SolNode162"}
+250.845 Script [Info]: ThemedSquadOverlay.lua: Pending mission: SolNode162
+255.746 Script [Info]: ThemedSquadOverlay.lua: Mission name: Isos (Eris)
+260.111 Game [Info]: OnStateStarted, mission type=MT_CAPTURE

--- a/src-tauri/tests/fixtures/arbitration/rhea-interception.txt
+++ b/src-tauri/tests/fixtures/arbitration/rhea-interception.txt
@@ -1,0 +1,26 @@
+0.095 Sys [Diag]: Current time: Tue Jul  7 17:05:40 2026 [UTC: Tue Jul  7 15:05:40 2026]
+2.005 Sys [Info]: Warframe startup chatter
+94.588 Script [Info]: MapRedux.lua: Confirm sector SolNode18_EliteAlert
+94.588 Net [Info]: Set squad mission: {"name":"SolNode18_EliteAlert"}
+94.589 Script [Info]: ThemedSquadOverlay.lua: Pending mission: SolNode18_EliteAlert
+99.488 Script [Info]: ThemedSquadOverlay.lua: Mission name: Rhea (Saturn) - Arbitration
+99.489 Script [Info]: ThemedSquadOverlay.lua: Lobby::Host_StartMatch: launching level for SolNode18_EliteAlert (/Lotus/Levels/Proc/Grineer/GrineerAsteroidInterception)
+102.433 Sys [Info]: SyncAutoPopulatedConsumables for mission MT_TERRITORY with location SolNode18
+103.240 Game [Info]: OnStateStarted, mission type=MT_TERRITORY
+104.750 AI [Info]: OnAgentCreated /Npc/CorpusEliteShieldDroneAgent7 Live 7 Spawned 6 Ticking 6 Paused 1 IgnoredTicking 0 MonitoredTicking 6 AllyLive 1 AllyActive 0 NeutralActive 0
+107.426 Script [Info]: EndOfMatch.lua: Initialize
+107.427 Script [Info]: EndOfMatch.lua: Mission Succeeded
+124.058 Script [Info]: EndOfMatch.lua: Initialize
+124.058 Script [Info]: EndOfMatch.lua: Mission Succeeded
+133.194 Script [Info]: TerritoryMission.lua: Alpha has is now under Enemy control
+133.201 AI [Info]: OnAgentCreated /Npc/CorpusEliteShieldDroneAgent17 Live 11 Spawned 9 Ticking 10 Paused 1 IgnoredTicking 6 MonitoredTicking 4 AllyLive 7 AllyActive 6 NeutralActive 0
+145.204 AI [Info]: OnAgentCreated /Npc/CorpusEliteShieldDroneAgent25 Live 13 Spawned 16 Ticking 12 Paused 1 IgnoredTicking 6 MonitoredTicking 6 AllyLive 7 AllyActive 6 NeutralActive 0
+158.402 Script [Info]: TerritoryMission.lua: Delta has is now under Enemy control
+163.207 AI [Info]: OnAgentCreated /Npc/CorpusEliteShieldDroneAgent31 Live 11 Spawned 21 Ticking 10 Paused 1 IgnoredTicking 6 MonitoredTicking 4 AllyLive 7 AllyActive 6 NeutralActive 0
+331.804 Sys [Info]: Resloader 0x000001F89DF86F50 (/Lotus/Interface/Icons/StoreIcons/Resources/CraftingComponents/Elitium.png) starting
+331.811 Sys [Info]: Created /Lotus/Interface/SurvivalReward.swf
+337.236 AI [Info]: OnAgentCreated /Npc/CorpusEliteShieldDroneAgent125 Live 12 Spawned 103 Ticking 11 Paused 1 IgnoredTicking 6 MonitoredTicking 5 AllyLive 7 AllyActive 6 NeutralActive 0
+356.940 Sys [Info]: Created /Lotus/Interface/DefenseReward.swf
+359.928 Script [Info]: EndOfMatch.lua: Initialize
+359.929 Script [Info]: EndOfMatch.lua: Mission Succeeded
+359.945 Sys [Info]: EOM missionLocationUnlocked=1

--- a/src-tauri/tests/fixtures/arbitration/stoefler-defense.txt
+++ b/src-tauri/tests/fixtures/arbitration/stoefler-defense.txt
@@ -1,0 +1,47 @@
+0.124 Sys [Diag]: Process Command-line: -windowMode:2 -shaderCache:1 -graphicsDriver:dx11 -gpuPreference:2 -cluster:public -language:en -clienttype:Steam
+0.127 Sys [Diag]: Current time: Tue Jul  7 15:40:49 2026 [UTC: Tue Jul  7 21:40:49 2026]
+2.005 Sys [Info]: Warframe startup chatter
+16590.100 Script [Info]: ThemedSquadOverlay.lua: Pending mission: SolNode305_EliteAlert
+16596.750 Script [Info]: ThemedSquadOverlay.lua: Mission name: Stöfler (Lua) - Arbitration
+16599.300 Sys [Info]: SyncAutoPopulatedConsumables for mission MT_DEFENSE with location SolNode305
+16602.801 AI [Info]: OnAgentCreated /Npc/KubrowPetAgent3 Live 3 Spawned 0 Ignored Ticking 0 Paused 0 IgnoredTicking 0 MonitoredTicking 0 AllyLive 0 AllyActive 0 NeutralActive 0
+16602.818 Game [Info]: OnStateStarted, mission type=MT_DEFENSE
+16603.889 Script [Info]: WaveDefend.lua: WaveDefend - SetupDefense
+16603.893 Script [Info]: WaveDefend.lua: Starting WaveDefense
+16759.770 Script [Info]: EndOfMatch.lua: Initialize
+16759.771 Script [Info]: EndOfMatch.lua: Mission Succeeded
+16773.916 Script [Info]: EndOfMatch.lua: Initialize
+16783.891 Script [Info]: WaveDefend.lua: Defense: Starting defense waves
+16783.893 Script [Info]: WaveDefend.lua: _SleepBetweenWaves(3)
+16786.896 Script [Info]: WaveDefend.lua: Defense wave: 1
+16786.896 Script [Info]: WaveDefend.lua: Starting wave 1, spawning a total of 44 tier-0 enemies (26 simultaneous, 0% chance of eximus)
+16790.100 AI [Info]: OnAgentCreated /Npc/ShieldLancer10 Live 5 Spawned 4 Ticking 5 Paused 0 IgnoredTicking 0 MonitoredTicking 5 AllyLive 4 AllyActive 4 NeutralActive 0
+16791.200 AI [Info]: OnAgentCreated /Npc/ShotgunLancer12 Live 6 Spawned 5 Ticking 6 Paused 0 IgnoredTicking 0 MonitoredTicking 6 AllyLive 4 AllyActive 4 NeutralActive 0
+16792.300 AI [Info]: OnAgentCreated /Npc/ShieldLancer11 Live 7 Spawned 6 Ticking 7 Paused 0 IgnoredTicking 0 MonitoredTicking 7 AllyLive 4 AllyActive 4 NeutralActive 0
+16793.400 AI [Info]: OnAgentCreated /Npc/ShotgunLancer13 Live 8 Spawned 7 Ticking 8 Paused 0 IgnoredTicking 0 MonitoredTicking 8 AllyLive 4 AllyActive 4 NeutralActive 0
+16803.047 Script [Info]: WaveDefend.lua: _SleepBetweenWaves(3)
+16806.094 Script [Info]: WaveDefend.lua: Defense wave: 2
+16806.094 Script [Info]: WaveDefend.lua: Starting wave 2, spawning a total of 52 tier-0 enemies (29 simultaneous, 2% chance of eximus)
+16808.117 AI [Info]: OnAgentCreated /Npc/CorpusEliteShieldDroneAgent67 Live 15 Spawned 53 Ticking 14 Paused 0 IgnoredTicking 5 MonitoredTicking 9 AllyLive 6 AllyActive 5 NeutralActive 0
+16808.627 AI [Info]: OnAgentCreated /Npc/CorpusEliteShieldDroneAgent70 Live 14 Spawned 55 Ticking 14 Paused 0 IgnoredTicking 6 MonitoredTicking 8 AllyLive 6 AllyActive 5 NeutralActive 0
+16813.750 AI [Info]: OnAgentCreated /Npc/CorpusEliteShieldDroneAgent79 Live 10 Spawned 62 Ticking 9 Paused 0 IgnoredTicking 6 MonitoredTicking 3 AllyLive 7 AllyActive 6 NeutralActive 0
+16828.967 Script [Info]: WaveDefend.lua: _SleepBetweenWaves(3)
+16831.973 Script [Info]: WaveDefend.lua: Defense wave: 3
+16831.973 Script [Info]: WaveDefend.lua: Starting wave 3, spawning a total of 54 tier-1 enemies (29 simultaneous, 2% chance of eximus)
+16855.930 Script [Info]: DefenseReward.lua: ScopeDebug: Hide from DefenseReward
+16855.932 Sys [Error]: SetCallbacks on unknown clip: 'Rewards.Element.Btn', movie: '/Lotus/Interface/DefenseReward.swf'
+16855.932 Sys [Info]: Created /Lotus/Interface/ProjectionsCountdown.swf
+16855.934 Sys [Info]: Created /Lotus/Interface/DefenseReward.swf
+16857.756 Script [Info]: WaveDefend.lua: _SleepBetweenWaves(3)
+16860.762 Script [Info]: WaveDefend.lua: Defense wave: 4
+16860.762 Script [Info]: WaveDefend.lua: Starting wave 4, spawning a total of 56 tier-1 enemies (29 simultaneous, 3% chance of eximus)
+!16879.863 Script [Info]: WaveDefend.lua: _SleepBetweenWaves(3)
+16882.865 Script [Info]: WaveDefend.lua: Defense wave: 5
+16882.865 Script [Info]: WaveDefend.lua: Starting wave 5, spawning a total of 59 tier-1 enemies (29 simultaneous, 3% chance of eximus)
+16907.227 Script [Info]: WaveDefend.lua: _SleepBetweenWaves(3)
+16910.236 Script [Info]: WaveDefend.lua: Defense wave: 6
+16910.236 Script [Info]: WaveDefend.lua: Starting wave 6, spawning a total of 61 tier-2 enemies (29 simultaneous, 4% chance of eximus)
+16936.807 Sys [Info]: Created /Lotus/Interface/ProjectionsCountdown.swf
+16936.816 Sys [Info]: Created /Lotus/Interface/DefenseReward.swf
+19736.500 Script [Info]: EndOfMatch.lua: Initialize
+19736.723 Sys [Info]: EOM missionLocationUnlocked=1

--- a/src-tauri/tests/fixtures/arbitration/tyana-mirror-defense.txt
+++ b/src-tauri/tests/fixtures/arbitration/tyana-mirror-defense.txt
@@ -1,0 +1,23 @@
+0.101 Sys [Diag]: Current time: Thu Jul  9 19:02:14 2026 [UTC: Thu Jul  9 17:02:14 2026]
+2.005 Sys [Info]: Warframe startup chatter
+620.300 Script [Info]: MapRedux.lua: Confirm sector SolNode30_EliteAlert
+620.300 Net [Info]: Set squad mission: {"name":"SolNode30_EliteAlert"}
+620.301 Script [Info]: ThemedSquadOverlay.lua: Pending mission: SolNode30_EliteAlert
+625.410 Script [Info]: ThemedSquadOverlay.lua: Mission name: Tyana Pass (Mars) - Arbitration
+628.900 Sys [Info]: SyncAutoPopulatedConsumables for mission MT_DEFENSE with location SolNode30
+631.200 Game [Info]: OnStateStarted, mission type=MT_DEFENSE
+640.000 Script [Info]: WaveDefend.lua: Defense wave: 1
+640.000 Script [Info]: WaveDefend.lua: Starting wave 1, spawning a total of 44 tier-0 enemies (26 simultaneous, 0% chance of eximus)
+645.000 AI [Info]: OnAgentCreated /Npc/CorpusEliteShieldDroneAgent5 Live 5 Spawned 4 Ticking 5 Paused 0 IgnoredTicking 0 MonitoredTicking 5 AllyLive 4 AllyActive 4 NeutralActive 0
+700.000 Script [Info]: WaveDefend.lua: _SleepBetweenWaves(3)
+703.000 Script [Info]: WaveDefend.lua: Defense wave: 2
+760.000 Sys [Info]: Created /Lotus/Interface/ProjectionsCountdown.swf
+760.010 Sys [Info]: Created /Lotus/Interface/DefenseReward.swf
+763.000 Script [Info]: WaveDefend.lua: Defense wave: 3
+800.000 AI [Info]: OnAgentCreated /Npc/CorpusEliteShieldDroneAgent19 Live 5 Spawned 20 Ticking 5 Paused 0 IgnoredTicking 0 MonitoredTicking 5 AllyLive 4 AllyActive 4 NeutralActive 0
+820.000 Script [Info]: WaveDefend.lua: _SleepBetweenWaves(3)
+823.000 Script [Info]: WaveDefend.lua: Defense wave: 4
+880.000 Sys [Info]: Created /Lotus/Interface/ProjectionsCountdown.swf
+880.010 Sys [Info]: Created /Lotus/Interface/DefenseReward.swf
+895.300 Script [Info]: EndOfMatch.lua: Initialize
+895.410 Sys [Info]: EOM missionLocationUnlocked=1

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,9 @@
-﻿import { useState, useEffect, useMemo, useCallback, useRef } from "react";
+import ArbitrationOverlay from "./arbitration/ArbitrationOverlay";
+import Arbitrations from "./arbitration/Arbitrations";
+import { clampLead, runAlertPass, DEFAULT_LEAD_MINS, EVAL_INTERVAL_MS, type AlertRule, type ScheduleEntry } from "./arbitration/arbitrationAlerts";
+import { sanitizeTierKeys, TIER_KEYS, type TierKey } from "./arbitration/arbitrationTiers";
+import { clampScheduleDays, DEFAULT_SCHEDULE_DAYS, useArbitrationSchedule } from "./arbitration/arbitrationSchedule";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { getVersion } from "@tauri-apps/api/app";
 import { listen } from "@tauri-apps/api/event";
@@ -135,7 +140,8 @@ const IS_MODULAR       = _params.has("modular")      || _hash === "#modular"    
 const IS_RIVEN_OVERLAY      = _params.has("rivenoverlay")      || _hash === "#rivenoverlay"      || _winLabel === "riven-overlay";
 const IS_RELIC_PICK_OVERLAY = _params.has("relicpickoverlay") || _hash === "#relicpickoverlay" || _winLabel === "relic-pick-overlay";
 const IS_OVERLAY_TEST       = _params.has("overlaytest")       || _hash === "#overlaytest"       || _winLabel === "overlay-test";
-const IS_ANY_OVERLAY = IS_OVERLAY || IS_MODULAR || IS_RIVEN_OVERLAY || IS_RELIC_PICK_OVERLAY;
+const IS_ARBITRATION_OVERLAY = _params.has("arbitrationoverlay") || _hash === "#arbitrationoverlay" || _winLabel === "arbitration-overlay";
+const IS_ANY_OVERLAY = IS_ARBITRATION_OVERLAY || IS_OVERLAY || IS_MODULAR || IS_RIVEN_OVERLAY || IS_RELIC_PICK_OVERLAY;
 
 // Overlay windows return from the router before any hook can run, which rules
 // out applying the scale from an effect.
@@ -212,6 +218,7 @@ export default function App() {
   // Isolated overlay test — no data, no events, just proves the window appears.
   if (IS_OVERLAY_TEST) return <OverlayTestPage />;
   // If we're the overlay window, render only the overlay UI
+  if (IS_ARBITRATION_OVERLAY) return <ArbitrationOverlay />;
   if (IS_OVERLAY) return <Overlay />;
   if (IS_RIVEN_OVERLAY) return <RivenOverlayWindow />;
   if (IS_RELIC_PICK_OVERLAY) return <RelicPickOverlay />;
@@ -344,6 +351,14 @@ const [blobLogEnabled, setBlobLogEnabled] = useState(false);
   const [timerFavorites, setTimerFavorites] = useState<string[]>([]);
   const [fissureWatches, setFissureWatches] = useState<FissureWatch[]>([]);
   const [fissureNotifications, setFissureNotifications] = useState(true);
+  const [arbFavorites, setArbFavorites] = useState<string[]>([]);
+  const [arbLeadMins, setArbLeadMins] = useState(DEFAULT_LEAD_MINS);
+  // The filter starts wide and the alert rule starts empty: showing every hour
+  // is what a browser is for, while alerting is opt-in.
+  const [arbTierFilter, setArbTierFilter] = useState<TierKey[]>([...TIER_KEYS]);
+  const [arbAlertTiers, setArbAlertTiers] = useState<TierKey[]>([]);
+  const [arbScheduleDays, setArbScheduleDays] = useState(DEFAULT_SCHEDULE_DAYS);
+  const [arbOverlayEnabled, setArbOverlayEnabled] = useState(false);
   const [modularWidth, setModularWidth] = useState(240);
   const [modularSectionOrder, setModularSectionOrder] = useState<string[]>([...MODULAR_SECTION_ORDER_DEFAULT]);
   const [modularPopout, setModularPopout] = useState(false);
@@ -359,7 +374,7 @@ const [blobLogEnabled, setBlobLogEnabled] = useState(false);
   // Refs so we can read the latest state in the save callback without stale closures
   const settingsLoadedRef = useRef(false);
   const settingsRef = useRef<SettingsSnapshot>({
-    overlayEnabled: true, overlayPriority: DEFAULT_RELIC_OVERLAY_PRIORITY, textScale: 1, colorblindMode: false, clockFormat: DEFAULT_CLOCK_FORMAT, companionApiEnabled: false, memoryScannerEnabled: false, blobLogEnabled: false, apiLogEnabled: false, autoDiagEnabled: false,
+    arbitrationFavorites: arbFavorites, arbitrationLeadMins: arbLeadMins, arbitrationOverlayEnabled: arbOverlayEnabled, arbitrationTierFilter: arbTierFilter, arbitrationAlertTiers: arbAlertTiers, arbitrationScheduleDays: arbScheduleDays, overlayEnabled: true, overlayPriority: DEFAULT_RELIC_OVERLAY_PRIORITY, textScale: 1, colorblindMode: false, clockFormat: DEFAULT_CLOCK_FORMAT, companionApiEnabled: false, memoryScannerEnabled: false, blobLogEnabled: false, apiLogEnabled: false, autoDiagEnabled: false,
     tracked: [] as string[], favorites: [] as string[], timerFavorites: [] as string[], fissureWatches: [] as FissureWatch[], fissureNotifications: true, modularWidth: 240,
     modularSectionOrder: ["tracking", "favorites", "timers"] as string[], modularPopout: false,
     wfmInvisibleOnStart: false, wfmInvisibleOnClose: false, wfmAutoInvisible: false, wfmAutoInvisibleMins: 30,
@@ -367,7 +382,7 @@ const [blobLogEnabled, setBlobLogEnabled] = useState(false);
     foundryPageSize: DEFAULT_FOUNDRY_PAGE_SIZE,
     memTriggerEnabled: false,
   });
-  settingsRef.current = { overlayEnabled, overlayPriority, textScale, colorblindMode, clockFormat, companionApiEnabled, memoryScannerEnabled, blobLogEnabled, apiLogEnabled, autoDiagEnabled, tracked, favorites, timerFavorites, fissureWatches, fissureNotifications, modularWidth, modularSectionOrder, modularPopout, wfmInvisibleOnStart, wfmInvisibleOnClose, wfmAutoInvisible, wfmAutoInvisibleMins, relicPickEnabled, relicPickPriority, relicPickRefinement, relicPickLines, foundryPageSize, memTriggerEnabled };
+  settingsRef.current = { arbitrationFavorites: arbFavorites, arbitrationLeadMins: arbLeadMins, arbitrationOverlayEnabled: arbOverlayEnabled, arbitrationTierFilter: arbTierFilter, arbitrationAlertTiers: arbAlertTiers, arbitrationScheduleDays: arbScheduleDays, overlayEnabled, overlayPriority, textScale, colorblindMode, clockFormat, companionApiEnabled, memoryScannerEnabled, blobLogEnabled, apiLogEnabled, autoDiagEnabled, tracked, favorites, timerFavorites, fissureWatches, fissureNotifications, modularWidth, modularSectionOrder, modularPopout, wfmInvisibleOnStart, wfmInvisibleOnClose, wfmAutoInvisible, wfmAutoInvisibleMins, relicPickEnabled, relicPickPriority, relicPickRefinement, relicPickLines, foundryPageSize, memTriggerEnabled };
 
   const saveAllSettings = useCallback(() => {
     // Until the on-disk settings have been applied, settingsRef still holds
@@ -524,6 +539,15 @@ if (typeof s.autoDiagEnabled === "boolean") {
         }
         if (Array.isArray(s.tracked)) setTracked(s.tracked);
         if (Array.isArray(s.favorites)) setFavorites(s.favorites);
+        if (Array.isArray(s.arbitrationFavorites)) setArbFavorites(s.arbitrationFavorites.filter((x: unknown) => typeof x === "string"));
+        if (typeof s.arbitrationLeadMins === "number") setArbLeadMins(clampLead(s.arbitrationLeadMins));
+        const storedFilter = sanitizeTierKeys(s.arbitrationTierFilter);
+        if (storedFilter) setArbTierFilter(storedFilter);
+        const storedAlertTiers = sanitizeTierKeys(s.arbitrationAlertTiers);
+        if (storedAlertTiers) setArbAlertTiers(storedAlertTiers);
+        if (typeof s.arbitrationScheduleDays === "number") setArbScheduleDays(clampScheduleDays(s.arbitrationScheduleDays));
+        if (typeof s.arbitrationOverlayEnabled === "boolean") { setArbOverlayEnabled(s.arbitrationOverlayEnabled); invoke("set_arbitration_overlay_enabled", { enabled: s.arbitrationOverlayEnabled }); }
+        if (Array.isArray(s.arbitrationAlertsFired)) arbFiredRef.current = s.arbitrationAlertsFired.filter((x: unknown) => typeof x === "string");
         if (Array.isArray(s.timerFavorites)) setTimerFavorites(s.timerFavorites);
         if (Array.isArray(s.fissureWatches)) {
           setFissureWatches(s.fissureWatches);
@@ -1026,7 +1050,7 @@ if (typeof s.autoDiagEnabled === "boolean") {
 
   useEffect(() => {
     if (settingsLoadedRef.current) saveAllSettings();
-  }, [tracked, favorites, timerFavorites, fissureWatches, fissureNotifications, modularWidth, memoryScannerEnabled, companionApiEnabled, blobLogEnabled, apiLogEnabled, autoDiagEnabled, modularSectionOrder, modularPopout]); // eslint-disable-line
+  }, [tracked, favorites, timerFavorites, fissureWatches, fissureNotifications, arbFavorites, arbLeadMins, arbTierFilter, arbAlertTiers, arbScheduleDays, modularWidth, memoryScannerEnabled, companionApiEnabled, blobLogEnabled, apiLogEnabled, autoDiagEnabled, modularSectionOrder, modularPopout]); // eslint-disable-line
 
   // ── Watched fissure notifications ──────────────────────────────────────────
   //
@@ -1084,6 +1108,85 @@ if (typeof s.autoDiagEnabled === "boolean") {
       void notify(`${fresh.length} new fissures`, shown.join("\n"));
     }
   }, [worldState, fissureWatches, fissureNotifications]);
+
+  // ── Arbitration alerts ─────────────────────────────────────────────────────
+  //
+  // Here rather than in Arbitrations, for the same reason the fissure alerts
+  // are: that module is unmounted whenever another one is on screen.
+
+  // Persisted, so a restart inside the lead window does not alert a second
+  // time for the same hour.
+  const arbFiredRef = useRef<string[]>([]);
+  const arbFiredDirtyRef = useRef(false);
+  const arbAlertsOn = arbFavorites.length > 0 || arbAlertTiers.length > 0;
+
+  const { schedule: arbSchedule, error: arbScheduleError } = useArbitrationSchedule(arbAlertsOn);
+
+  // The loop reads its inputs from here rather than from the effect closure, so
+  // starring a node changes what the next tick sees without tearing the timer
+  // down and starting a fresh pass on top of one already running. This effect
+  // has to stay above the loop's own, which reads the ref on its first tick.
+  const arbInputsRef = useRef({ entries: [] as ScheduleEntry[], rule: {} as AlertRule, leadMins: DEFAULT_LEAD_MINS });
+  useEffect(() => {
+    arbInputsRef.current = {
+      entries: arbSchedule?.entries ?? [],
+      rule: { favorites: arbFavorites, tiers: arbAlertTiers },
+      leadMins: arbLeadMins,
+    };
+  });
+
+  // A pass outlives its tick whenever the notification IPC is slow, and two
+  // passes reading the same fired state would raise one occurrence twice.
+  const arbCheckingRef = useRef(false);
+
+  // Held here so a denial survives Arbitrations' unmount, but written only by
+  // that module: it raises the prompt on a gesture and shows the warning.
+  const [arbPermissionDenied, setArbPermissionDenied] = useState(false);
+
+  useEffect(() => {
+    if (arbAlertsOn && arbScheduleError) {
+      console.error("arbitration schedule unavailable, alerts paused:", arbScheduleError);
+    }
+  }, [arbAlertsOn, arbScheduleError]);
+
+  useEffect(() => {
+    const check = async () => {
+      // Loading settings must finish before a pass can replace persisted keys.
+      if (!settingsLoadedRef.current || arbCheckingRef.current) return;
+      arbCheckingRef.current = true;
+      try {
+        const { entries, rule, leadMins } = arbInputsRef.current;
+        const nowMs = Date.now();
+        const fired = await runAlertPass(
+          entries, rule, leadMins, arbFiredRef.current, nowMs / 1000,
+          e => notify(
+            `Arbitration — ${e.node}${e.region ? ` (${e.region})` : ""}`,
+            `${[e.mission_type, e.faction].filter(Boolean).join(" · ")} — ${e.start * 1000 > nowMs
+              ? `starts in ${fmtMs(e.start * 1000 - nowMs)}`
+              : `under way, ${fmtMs(e.end * 1000 - nowMs)} left`}`,
+          ));
+        if (fired !== null) {
+          arbFiredRef.current = fired;
+          arbFiredDirtyRef.current = true;
+        }
+        // Keep successful handoffs in memory even if saving fails, then retry
+        // persistence on the next pass without raising the same alert again.
+        if (arbFiredDirtyRef.current) {
+          await invoke("save_settings", { json: JSON.stringify({ arbitrationAlertsFired: arbFiredRef.current }) });
+          arbFiredDirtyRef.current = false;
+        }
+      } catch (e) {
+        console.error("saving arbitration alert state failed", e);
+      } finally {
+        arbCheckingRef.current = false;
+      }
+    };
+
+    // Persistence retries must continue after the last alert rule is removed.
+    void check();
+    const poll = setInterval(check, EVAL_INTERVAL_MS);
+    return () => clearInterval(poll);
+  }, [arbAlertsOn]);
 
   // ── Modular pop-out window ─────────────────────────────────────────────────
   useEffect(() => {
@@ -1732,7 +1835,7 @@ if (typeof s.autoDiagEnabled === "boolean") {
         </div>
       </header>
 
-      <SettingsModal open={showSettings} onClose={() => setShowSettings(false)} {...{ settingsTab, setSettingsTab, foundryPageSize, setFoundryPageSize, settingsRef, saveAllSettings, memoryScannerEnabled, setMemoryScannerEnabled, modularPopout, setModularPopout, overlayStatus, overlayEnabled, setOverlayEnabled, overlayPriority, setOverlayPriority, memTriggerEnabled, setMemTriggerEnabled, relicPickEnabled, setRelicPickEnabled, relicPickPriority, setRelicPickPriority, relicPickLines, setRelicPickLines, wfmLoggedIn, wfmInvisibleOnStart, setWfmInvisibleOnStart, wfmInvisibleOnStartRef, wfmInvisibleOnClose, setWfmInvisibleOnClose, wfmInvisibleOnCloseRef, wfmAutoInvisible, setWfmAutoInvisible, wfmAutoInvisibleMins, setWfmAutoInvisibleMins, colorblindMode, setColorblindMode, textScale, setTextScale, clockFormat, setClockFormat, systemLocale, itemCount, recipeCount, handleFetch, fetching, fetchMsg, setQuantities, setApiQuantities, setApiModCopies, setScannerMods, setMasteryData, setArchonShards, setFormaData, setChangeLog, setLastChanged, setWfConnected, wfConnectedRef, setItemsRefreshKey, setClearMsg, clearMsg, blobLogEnabled, setBlobLogEnabled, blobLogSize, setBlobLogSize, companionApiEnabled, apiLogEnabled, setApiLogEnabled, apiLogSize, setApiLogSize, setShowInventoryBatchPreview, notifyTestResult, setNotifyTestResult, overlayLogCopied, setOverlayLogCopied, autoDiagEnabled, setAutoDiagEnabled, diagFolderSize, setDiagFolderSize, diagPath, diagCapturing, setDiagCapturing, setDiagPath, reloadDebugSizes, memoryProbing, setMemoryProbing, probeSize, setProbeSize, rawScanning, setRawScanning, rawScanSize, setRawScanSize, memRelicDebugRunning, setMemRelicDebugRunning, relicPickOcrResult, relicPickOcrTesting, setRelicPickOcrTesting, setRelicPickOcrResult, relicPickTestResult, relicPickTestEra, setRelicPickTestEra, setRelicPickTestResult, eeLogTail, setEeLogTail, debugCatEnabled, setDebugCatEnabled, unmatchedPathsSize, setUnmatchedPathsSize, appVersion }} />
+      <SettingsModal open={showSettings} onClose={() => setShowSettings(false)} {...{ settingsTab, setSettingsTab, foundryPageSize, setFoundryPageSize, settingsRef, saveAllSettings, memoryScannerEnabled, setMemoryScannerEnabled, modularPopout, setModularPopout, overlayStatus, overlayEnabled, setOverlayEnabled, overlayPriority, setOverlayPriority, memTriggerEnabled, setMemTriggerEnabled, relicPickEnabled, setRelicPickEnabled, relicPickPriority, setRelicPickPriority, relicPickLines, setRelicPickLines, wfmLoggedIn, wfmInvisibleOnStart, setWfmInvisibleOnStart, wfmInvisibleOnStartRef, wfmInvisibleOnClose, setWfmInvisibleOnClose, wfmInvisibleOnCloseRef, wfmAutoInvisible, setWfmAutoInvisible, wfmAutoInvisibleMins, setWfmAutoInvisibleMins, colorblindMode, setColorblindMode, textScale, setTextScale, clockFormat, setClockFormat, systemLocale, itemCount, recipeCount, handleFetch, fetching, fetchMsg, setQuantities, setApiQuantities, setApiModCopies, setScannerMods, setMasteryData, setArchonShards, setFormaData, setChangeLog, setLastChanged, setWfConnected, wfConnectedRef, setItemsRefreshKey, setClearMsg, clearMsg, blobLogEnabled, setBlobLogEnabled, blobLogSize, setBlobLogSize, companionApiEnabled, apiLogEnabled, setApiLogEnabled, apiLogSize, setApiLogSize, setShowInventoryBatchPreview, notifyTestResult, setNotifyTestResult, overlayLogCopied, setOverlayLogCopied, autoDiagEnabled, setAutoDiagEnabled, diagFolderSize, setDiagFolderSize, diagPath, diagCapturing, setDiagCapturing, setDiagPath, reloadDebugSizes, memoryProbing, setMemoryProbing, probeSize, setProbeSize, rawScanning, setRawScanning, rawScanSize, setRawScanSize, memRelicDebugRunning, setMemRelicDebugRunning, relicPickOcrResult, relicPickOcrTesting, setRelicPickOcrTesting, setRelicPickOcrResult, relicPickTestResult, relicPickTestEra, setRelicPickTestEra, setRelicPickTestResult, eeLogTail, setEeLogTail, debugCatEnabled, setDebugCatEnabled, unmatchedPathsSize, setUnmatchedPathsSize, appVersion, arbOverlayEnabled, setArbOverlayEnabled }} />
 
       {showInventoryBatchPreview && <InventoryBatchPreview onClose={closeInventoryBatchPreview} />}
 
@@ -1841,6 +1944,29 @@ if (typeof s.autoDiagEnabled === "boolean") {
               fissureNotifications={fissureNotifications}
               onFissureNotificationsChange={setFissureNotifications}
               inventory={inventory}
+            />
+          </ErrorBoundary>
+        )}
+
+        {/* ── Arbitrations module ── */}
+        {activeModule === "arbitrations" && (
+          <ErrorBoundary>
+            <Arbitrations
+              favorites={arbFavorites}
+              onToggleFavorite={id => setArbFavorites(prev =>
+                prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]
+              )}
+              leadMins={arbLeadMins}
+              onLeadChange={setArbLeadMins}
+              permissionDenied={arbPermissionDenied}
+              onPermissionChange={setArbPermissionDenied}
+              tierFilter={arbTierFilter}
+              onTierFilterChange={setArbTierFilter}
+              alertTiers={arbAlertTiers}
+              onAlertTiersChange={setArbAlertTiers}
+              scheduleDays={arbScheduleDays}
+              onScheduleDaysChange={setArbScheduleDays}
+              clockFormat={clockFormat} systemLocale={systemLocale}
             />
           </ErrorBoundary>
         )}

--- a/src/AppNavigation.tsx
+++ b/src/AppNavigation.tsx
@@ -1,4 +1,4 @@
-export type Module = "inventory" | "foundry" | "market" | "relics" | "rivens" | "timers" | "statistics" | "completionist";
+export type Module = "inventory" | "foundry" | "market" | "relics" | "rivens" | "timers" | "arbitrations" | "statistics" | "completionist";
 
 interface AppNavigationProps {
   activeModule: Module;
@@ -27,6 +27,10 @@ export default function AppNavigation({ activeModule, onModuleChange }: AppNavig
       <button className={`module-btn ${activeModule === "timers" ? "module-active" : ""}`} onClick={() => onModuleChange("timers")} title="Timers">
         <img src="/timers-icon.png" alt="" style={{ width: 24, height: 24, objectFit: "contain" }} />
         <span className="module-label">Timers</span>
+      </button>
+      <button className={`module-btn ${activeModule === "arbitrations" ? "module-active" : ""}`} onClick={() => onModuleChange("arbitrations")} title="Arbitrations">
+        <span aria-hidden style={{ width: 24, height: 24, lineHeight: "24px", fontSize: 20, textAlign: "center" }}>⚖</span>
+        <span className="module-label">Arbitrations</span>
       </button>
       <button className={`module-btn ${activeModule === "statistics" ? "module-active" : ""}`} onClick={() => onModuleChange("statistics")} title="Statistics">
         <img src="/statistics-icon.png" alt="" style={{ width: 24, height: 24, objectFit: "contain" }} />

--- a/src/SettingsModal.tsx
+++ b/src/SettingsModal.tsx
@@ -17,6 +17,7 @@ type ScannerMods = Record<string, { total: number; by_rank: Record<string, numbe
 type ArchonShards = Record<string, ArchonShard[]>;
 
 export interface SettingsModalProps {
+  arbOverlayEnabled: boolean; setArbOverlayEnabled: Setter<boolean>;
   open: boolean;
   onClose: () => void;
   settingsTab: SettingsTab;
@@ -54,7 +55,8 @@ function BulkPriceRefreshButton() {
 }
 
 export default function SettingsModal(props: SettingsModalProps) {
-  const { settingsTab, setSettingsTab, foundryPageSize, setFoundryPageSize, settingsRef, saveAllSettings, memoryScannerEnabled, setMemoryScannerEnabled, modularPopout, setModularPopout, overlayStatus, overlayEnabled, setOverlayEnabled, overlayPriority, setOverlayPriority, memTriggerEnabled, setMemTriggerEnabled, relicPickEnabled, setRelicPickEnabled, relicPickPriority, setRelicPickPriority, relicPickLines, setRelicPickLines, wfmLoggedIn, wfmInvisibleOnStart, setWfmInvisibleOnStart, wfmInvisibleOnStartRef, wfmInvisibleOnClose, setWfmInvisibleOnClose, wfmInvisibleOnCloseRef, wfmAutoInvisible, setWfmAutoInvisible, wfmAutoInvisibleMins, setWfmAutoInvisibleMins, colorblindMode, setColorblindMode, textScale, setTextScale, clockFormat, setClockFormat, systemLocale, itemCount, recipeCount, handleFetch, fetching, fetchMsg, setQuantities, setApiQuantities, setApiModCopies, setScannerMods, setMasteryData, setArchonShards, setFormaData, setChangeLog, setLastChanged, setWfConnected, wfConnectedRef, setItemsRefreshKey, setClearMsg, clearMsg, blobLogEnabled, setBlobLogEnabled, blobLogSize, setBlobLogSize, companionApiEnabled, apiLogEnabled, setApiLogEnabled, apiLogSize, setApiLogSize, setShowInventoryBatchPreview, notifyTestResult, setNotifyTestResult, overlayLogCopied, setOverlayLogCopied, autoDiagEnabled, setAutoDiagEnabled, diagFolderSize, setDiagFolderSize, diagPath, diagCapturing, setDiagCapturing, setDiagPath, reloadDebugSizes, memoryProbing, setMemoryProbing, probeSize, setProbeSize, rawScanning, setRawScanning, rawScanSize, setRawScanSize, memRelicDebugRunning, setMemRelicDebugRunning, relicPickOcrResult, relicPickOcrTesting, setRelicPickOcrTesting, setRelicPickOcrResult, relicPickTestResult, relicPickTestEra, setRelicPickTestEra, setRelicPickTestResult, eeLogTail, setEeLogTail, debugCatEnabled, setDebugCatEnabled, unmatchedPathsSize, setUnmatchedPathsSize, appVersion } = props;
+  const { settingsTab, setSettingsTab, foundryPageSize, setFoundryPageSize, settingsRef, saveAllSettings, memoryScannerEnabled, setMemoryScannerEnabled, modularPopout, setModularPopout, overlayStatus, overlayEnabled, setOverlayEnabled, overlayPriority, setOverlayPriority, memTriggerEnabled, setMemTriggerEnabled, relicPickEnabled, setRelicPickEnabled, relicPickPriority, setRelicPickPriority, relicPickLines, setRelicPickLines, wfmLoggedIn, wfmInvisibleOnStart, setWfmInvisibleOnStart, wfmInvisibleOnStartRef, wfmInvisibleOnClose, setWfmInvisibleOnClose, wfmInvisibleOnCloseRef, wfmAutoInvisible, setWfmAutoInvisible, wfmAutoInvisibleMins, setWfmAutoInvisibleMins, colorblindMode, setColorblindMode, textScale, setTextScale, clockFormat, setClockFormat, systemLocale, itemCount, recipeCount, handleFetch, fetching, fetchMsg, setQuantities, setApiQuantities, setApiModCopies, setScannerMods, setMasteryData, setArchonShards, setFormaData, setChangeLog, setLastChanged, setWfConnected, wfConnectedRef, setItemsRefreshKey, setClearMsg, clearMsg, blobLogEnabled, setBlobLogEnabled, blobLogSize, setBlobLogSize, companionApiEnabled, apiLogEnabled, setApiLogEnabled, apiLogSize, setApiLogSize, setShowInventoryBatchPreview, notifyTestResult, setNotifyTestResult, overlayLogCopied, setOverlayLogCopied, autoDiagEnabled, setAutoDiagEnabled, diagFolderSize, setDiagFolderSize, diagPath, diagCapturing, setDiagCapturing, setDiagPath, reloadDebugSizes, memoryProbing, setMemoryProbing, probeSize, setProbeSize, rawScanning, setRawScanning, rawScanSize, setRawScanSize, memRelicDebugRunning, setMemRelicDebugRunning, relicPickOcrResult, relicPickOcrTesting, setRelicPickOcrTesting, setRelicPickOcrResult, relicPickTestResult, relicPickTestEra, setRelicPickTestEra, setRelicPickTestResult, eeLogTail, setEeLogTail, debugCatEnabled, setDebugCatEnabled, unmatchedPathsSize, setUnmatchedPathsSize, appVersion, arbOverlayEnabled, setArbOverlayEnabled } = props;
+  const [arbOverlayTestResult, setArbOverlayTestResult] = useState<string | null>(null);
   if (!props.open) return null;
   const onClose = props.onClose;
   return (
@@ -334,6 +336,27 @@ export default function SettingsModal(props: SettingsModalProps) {
                         <option key={lines} value={lines}>{lines === "all" ? "All items" : lines === "best" ? "Only most valuable" : "Score summary only"}</option>
                       ))}
                     </select>
+                  </div>
+                </div>
+
+                <div className="settings-section">
+                  <div className="settings-section-title">Arbitration Summary Overlay</div>
+                  <div className="settings-row">
+                    <div className="settings-row-info">
+                      <span className="settings-row-label">Enable Overlay</span>
+                      <span className="settings-row-desc">Briefly show a completed arbitration run's numbers over the game. Runs are recorded either way.</span>
+                    </div>
+                    <button
+                      className="btn-secondary"
+                      style={{ minWidth: 64, background: arbOverlayEnabled ? "rgba(56,139,253,.15)" : undefined, borderColor: arbOverlayEnabled ? "var(--accent)" : undefined }}
+                      onClick={() => {
+                        const next = !arbOverlayEnabled;
+                        setArbOverlayEnabled(next);
+                        settingsRef.current = { ...settingsRef.current, arbitrationOverlayEnabled: next };
+                        saveAllSettings();
+                        invoke("set_arbitration_overlay_enabled", { enabled: next });
+                      }}
+                    >{arbOverlayEnabled ? "Enabled" : "Disabled"}</button>
                   </div>
                 </div>
 
@@ -788,6 +811,21 @@ export default function SettingsModal(props: SettingsModalProps) {
                       setRelicPickTestResult(null);
                       try { setRelicPickTestResult(await invoke<string>("test_relic_pick_overlay", { era: relicPickTestEra })); }
                       catch (e) { setRelicPickTestResult(`Error: ${e}`); }
+                    }}>Launch</button>
+
+                    <div className="settings-row-info">
+                      <span className="settings-row-label">Test Arbitration Summary Overlay</span>
+                      <span className="settings-row-desc">
+                        Fire the post-run overlay with a sample run. Ignores the enable setting.
+                        {arbOverlayTestResult && <span style={{ display: "block", marginTop: 2, color: "var(--accent)", fontSize: 11 }}>{arbOverlayTestResult}</span>}
+                      </span>
+                    </div>
+                    <div />
+                    <div />
+                    <button className="btn-secondary" onClick={async () => {
+                      setArbOverlayTestResult(null);
+                      try { setArbOverlayTestResult(await invoke<string>("test_arbitration_overlay")); }
+                      catch (e) { setArbOverlayTestResult(`Error: ${e}`); }
                     }}>Launch</button>
 
                     {/* EE.log tail — reveals what string to trigger on */}

--- a/src/arbitration/ArbitrationHistory.tsx
+++ b/src/arbitration/ArbitrationHistory.tsx
@@ -1,0 +1,179 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { fmtMs } from "../TimerHelper";
+import {
+  completed, filterRuns, summarize, MISSION_TYPES,
+  type Breakdown, type Filters, type MissionType, type RunRecord,
+} from "./arbitrationAnalytics";
+import Sparkline from "../shared/Sparkline";
+import { TierBadge } from "./TierSelect";
+import { formatUnixTime } from "../lib/formatters";
+import type { ClockFormat } from "../types/settings";
+import "../shared/Report.css";
+
+const RANGES: { label: string; value: number | "all" }[] = [
+  { label: "7d", value: 7 }, { label: "30d", value: 30 }, { label: "90d", value: 90 }, { label: "All", value: "all" },
+];
+
+const cap = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
+const fmtRate = (r: number | null) => (r === null ? "—" : r.toFixed(2));
+const fmtDate = (iso: string | null, format: ClockFormat, locale: string) => {
+  if (iso === null) return "unknown time";
+  const when = new Date(iso);
+  // The month name stays English; only the time follows the hour format.
+  const date = when.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  return `${date}, ${formatUnixTime(when.getTime() / 1000, format, locale)}`;
+};
+const endLabel: Record<Exclude<RunRecord["end_reason"], "mission_end">, string> = {
+  aborted: "aborted", new_mission: "left early", unterminated: "unfinished",
+};
+
+function BreakdownTable({ label, rows, name }: { label: string; rows: Breakdown[]; name: (key: string) => string }) {
+  if (rows.length === 0) return null;
+  return (
+    <div className="arb-breakdown">
+      <div className="report-stat-label">{label}</div>
+      <div className="arb-table">
+        <div className="arb-table-head"><span>{label}</span><span>Runs</span><span>Vitus</span><span>Vitus/min</span></div>
+        {rows.map(r => (
+          <div className="arb-table-row" key={r.key}>
+            <span className="arb-table-name">{name(r.key)}</span>
+            <span className="arb-table-num">{r.runs}{r.completed < r.runs && <span className="arb-muted"> ({r.runs - r.completed} incomplete)</span>}</span>
+            <span className="arb-table-num">{Math.round(r.vitus)}</span>
+            <span className="arb-table-num">{fmtRate(r.perMinute)}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+
+export default function ArbitrationHistory({ clockFormat, systemLocale }: { clockFormat: ClockFormat; systemLocale: string }) {
+  const [runs, setRuns] = useState<RunRecord[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [filters, setFilters] = useState<Filters>({ days: 30, missionType: "all" });
+  const [confirmUid, setConfirmUid] = useState<string | null>(null);
+
+  // The date window is measured from now, so the tab has to notice time
+  // passing or a run keeps sitting inside "7d" for as long as it stays open.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const tick = setInterval(() => setNow(Date.now()), 60_000);
+    return () => clearInterval(tick);
+  }, []);
+
+  const load = useCallback(() =>
+    invoke<RunRecord[]>("get_arbitration_runs")
+      .then(r => { setRuns(r); setError(null); })
+      .catch(e => setError(String(e))), []);
+
+  useEffect(() => {
+    void load();
+    const unlisten = listen("arbitration-runs-changed", () => void load());
+    return () => { void unlisten.then(fn => fn()); };
+  }, [load]);
+
+  const shown = useMemo(() => (runs ? filterRuns(runs, filters, now) : []), [runs, filters, now]);
+  const summary = useMemo(() => summarize(shown), [shown]);
+
+  const setFilter = (patch: Partial<Filters>) => {
+    setConfirmUid(null);
+    setFilters(f => ({ ...f, ...patch }));
+  };
+
+  const remove = async (uid: string) => {
+    setConfirmUid(null);
+    try {
+      await invoke("delete_arbitration_run", { uid });
+      await load();
+    } catch (e) {
+      setError(String(e));
+    }
+  };
+
+  if (error && !runs) return <div className="timer-error">{error}</div>;
+  if (!runs) return <div className="timer-loading">Loading run history…</div>;
+  if (runs.length === 0) {
+    return (
+      <div className="report-empty">
+        {error && <div className="timer-error">{error}</div>}
+        <div className="report-empty-icon">🏛️</div>
+        <div className="report-empty-title">No arbitration runs recorded yet</div>
+        <div className="report-empty-desc">
+          Runs are recorded from the game's log while FrameForge is open,
+          <br />
+          and runs from the current log are picked up on startup.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="arb-history">
+      {error && <div className="timer-error">{error}</div>}
+
+      <div className="arb-filters">
+        <div className="report-tf-btns">
+          {RANGES.map(r => (
+            <button key={r.label} className={`report-tf-btn${filters.days === r.value ? " active" : ""}`}
+              onClick={() => setFilter({ days: r.value })}>{r.label}</button>
+          ))}
+        </div>
+        <div className="report-tf-btns">
+          {(["all", ...MISSION_TYPES] as (MissionType | "all")[]).map(t => (
+            <button key={t} className={`report-tf-btn${filters.missionType === t ? " active" : ""}`}
+              onClick={() => setFilter({ missionType: t })}>{cap(t)}</button>
+          ))}
+        </div>
+        <span className="arb-muted arb-filter-count">{shown.length} of {runs.length} runs</span>
+      </div>
+
+      <div className="report-card">
+        <div className="report-stat-label">Vitus per minute, run by run</div>
+        <Sparkline values={summary.rate} empty="No completed runs in this range" />
+        <div className="report-card-stats">
+          <div className="report-stat"><span className="report-stat-label">Runs</span><span className="report-stat-value">{summary.runs}</span></div>
+          <div className="report-stat"><span className="report-stat-label">Incomplete</span><span className="report-stat-value">{summary.incomplete}</span></div>
+          <div className="report-stat"><span className="report-stat-label">Playtime (all runs)</span><span className="report-stat-value">{fmtMs(summary.playtimeSec * 1000)}</span></div>
+          <div className="report-stat"><span className="report-stat-label">Kills</span><span className="report-stat-value">{summary.kills.toLocaleString()}</span></div>
+          <div className="report-stat"><span className="report-stat-label">Vitus (est.)</span><span className="report-stat-value">{Math.round(summary.vitus)}</span></div>
+          <div className="report-stat"><span className="report-stat-label">Vitus/min</span><span className="report-stat-value">{fmtRate(summary.perMinute)}</span></div>
+        </div>
+      </div>
+
+      <BreakdownTable label="Node" rows={summary.byNode} name={k => k} />
+      <BreakdownTable label="Mission type" rows={summary.byMissionType} name={cap} />
+
+      <div className="report-stat-label">Runs</div>
+      <div className="arb-runs">
+        {shown.map(run => (
+          <div className={`arb-run${completed(run) ? "" : " arb-run-incomplete"}`} key={run.uid}>
+            <span className="arb-run-when">{fmtDate(run.started_at, clockFormat, systemLocale)}</span>
+            <span className="arb-run-main">
+              <span className="timer-name"><TierBadge tier={run.tier} />{run.node}</span>
+              <span className="arb-muted">
+                {cap(run.mission_type)}
+                {!completed(run) && <span className="arb-run-flag"> · {endLabel[run.end_reason as keyof typeof endLabel]}</span>}
+              </span>
+            </span>
+            <span className="arb-run-num">{fmtMs(run.duration_sec * 1000)}</span>
+            <span className="arb-run-num">{run.waves > 0 ? `${run.waves} waves` : `${run.rotations} rotations`}</span>
+            <span className="arb-run-num">{run.kills} kills</span>
+            <span className="arb-run-num">{fmtRate(run.vitus_per_minute)}/min</span>
+            {confirmUid === run.uid ? (
+              <span className="report-confirm-row">
+                <span className="report-confirm-msg">Delete run?</span>
+                <button className="report-confirm-yes" onClick={() => void remove(run.uid)}>Delete</button>
+                <button className="report-confirm-no" onClick={() => setConfirmUid(null)}>Cancel</button>
+              </span>
+            ) : (
+              <button className="report-remove-btn" title="Delete run" onClick={() => setConfirmUid(run.uid)}>×</button>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/arbitration/ArbitrationOverlay.css
+++ b/src/arbitration/ArbitrationOverlay.css
@@ -1,0 +1,96 @@
+body { background: transparent !important; }
+
+.aro-root {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px;
+  background: rgba(13, 17, 23, 0.92);
+  border: 1px solid rgba(210, 153, 34, 0.5);
+  border-radius: 8px;
+  font-family: inherit;
+  font-size: 12px;
+  color: var(--text, #e6edf3);
+  width: 100%;
+  box-sizing: border-box;
+  backdrop-filter: blur(4px);
+}
+
+.aro-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.aro-title {
+  font-size: 11px;
+  font-weight: 700;
+  color: #d29922;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.aro-node {
+  flex: 1;
+  font-size: 12px;
+  color: rgba(230, 237, 243, 0.75);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.aro-close {
+  background: none;
+  border: none;
+  color: rgba(230, 237, 243, 0.35);
+  font-size: 13px;
+  cursor: pointer;
+  padding: 0 2px;
+  line-height: 1;
+}
+.aro-close:hover { color: rgba(230, 237, 243, 0.85); }
+
+.aro-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 4px 8px;
+}
+
+.aro-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 4px 2px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 5px;
+}
+
+.aro-vitus {
+  grid-column: 1 / -1;
+  flex-direction: row;
+  justify-content: center;
+  align-items: baseline;
+  gap: 6px;
+  background: rgba(210, 153, 34, 0.12);
+}
+
+.aro-value {
+  font-size: 16px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+.aro-vitus .aro-value { color: #d29922; }
+
+.aro-label {
+  font-size: 10px;
+  color: rgba(230, 237, 243, 0.55);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.aro-note {
+  font-size: 10px;
+  color: rgba(230, 237, 243, 0.45);
+  text-align: center;
+}

--- a/src/arbitration/ArbitrationOverlay.tsx
+++ b/src/arbitration/ArbitrationOverlay.tsx
@@ -1,0 +1,104 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { useOverlayWindow } from "../lib/useOverlayWindow";
+import { fmtMs } from "../TimerHelper";
+import "./ArbitrationOverlay.css";
+
+interface RunSummary {
+  node:             string;
+  mission_type:     string;
+  duration_sec:     number;
+  rotations:        number;
+  waves:            number;
+  kills:            number;
+  drone_kills:      number;
+  host_telemetry:   boolean;
+  vitus_mean:       number;
+  vitus_per_minute: number;
+}
+
+const AUTO_HIDE_MS = 12_000;
+
+function isRunSummary(p: unknown): p is RunSummary {
+  const r = p as Partial<RunSummary> | null;
+  return !!r
+    && typeof r.node === "string"
+    && typeof r.mission_type === "string"
+    && typeof r.duration_sec === "number"
+    && typeof r.vitus_mean === "number"
+    && typeof r.vitus_per_minute === "number";
+}
+
+export default function ArbitrationOverlay() {
+  const [run, setRun] = useState<RunSummary | null>(null);
+  const root  = useOverlayWindow(340, "top-center");
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const hide = useCallback(() => {
+    if (timer.current) { clearTimeout(timer.current); timer.current = null; }
+    setRun(null);
+    getCurrentWindow().hide().catch(() => {});
+  }, []);
+
+  // The backend shows the window before it emits. An event that lands before
+  // this listener exists, or one that fails validation, would otherwise leave
+  // an empty window over the game with nothing to ever hide it.
+  useEffect(() => {
+    if (!run) getCurrentWindow().hide().catch(() => {});
+  }, [run]);
+
+  useEffect(() => {
+    const unEnded = listen<unknown>("arbitration-run-ended", e => {
+      if (!isRunSummary(e.payload)) return;
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(hide, AUTO_HIDE_MS);
+      setRun(e.payload);
+    });
+    return () => {
+      unEnded.then(f => f());
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, [hide]);
+
+  if (!run) return null;
+
+  const [progressValue, progressLabel] = run.mission_type === "defense"
+    ? [run.waves, "waves"]
+    : [run.rotations, run.rotations === 1 ? "rotation" : "rotations"];
+
+  return (
+    <div className="aro-root" ref={root}>
+      <div className="aro-header">
+        <span className="aro-title">Arbitration Complete</span>
+        <span className="aro-node">{run.node}</span>
+        <button className="aro-close" onClick={hide} title="Close">✕</button>
+      </div>
+      <div className="aro-stats">
+        <div className="aro-stat">
+          <span className="aro-value">{fmtMs(run.duration_sec * 1000)}</span>
+          <span className="aro-label">duration</span>
+        </div>
+        <div className="aro-stat">
+          <span className="aro-value">{progressValue}</span>
+          <span className="aro-label">{progressLabel}</span>
+        </div>
+        <div className="aro-stat">
+          <span className="aro-value">{run.host_telemetry ? run.kills : "–"}</span>
+          <span className="aro-label">kills</span>
+        </div>
+        <div className="aro-stat">
+          <span className="aro-value">{run.host_telemetry ? run.drone_kills : "–"}</span>
+          <span className="aro-label">drones</span>
+        </div>
+        <div className="aro-stat aro-vitus">
+          <span className="aro-value">{run.vitus_per_minute.toFixed(2)}</span>
+          <span className="aro-label">vitus/min · ~{Math.round(run.vitus_mean)} total</span>
+        </div>
+      </div>
+      {!run.host_telemetry && (
+        <div className="aro-note">Kill counts are only logged when hosting.</div>
+      )}
+    </div>
+  );
+}

--- a/src/arbitration/Arbitrations.css
+++ b/src/arbitration/Arbitrations.css
@@ -1,0 +1,312 @@
+.arb {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  flex: 1;
+  min-height: 0;
+}
+
+.arb-scroll {
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+  padding-bottom: 8px;
+}
+
+/* ── Run history ── */
+
+.arb-history {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.arb-filters {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+.arb-filter-count { margin-left: auto; }
+.arb-filter-sep {
+  align-self: stretch;
+  width: 1px;
+  background: var(--border);
+  opacity: 0.6;
+}
+.arb-filter-window { display: flex; align-items: center; gap: 6px; }
+.arb-window-select { position: relative; display: flex; align-items: center; }
+/* Kept in lockstep with .tier-select-btn so the native control does not read
+   as foreign next to the custom tier picker. */
+.arb-window-select-input {
+  appearance: none;
+  -webkit-appearance: none;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  color: var(--text);
+  font-size: 11px;
+  font-family: inherit;
+  padding: 3px 6px;
+  padding-right: 18px;
+  cursor: pointer;
+}
+.arb-window-select-input:hover { border-color: var(--accent); }
+.arb-window-select-input:focus-visible { outline: 1px solid var(--accent); outline-offset: 0; }
+.arb-window-select-caret {
+  position: absolute;
+  right: 6px;
+  color: var(--muted);
+  pointer-events: none;
+  font-size: 11px;
+}
+.arb-muted { font-size: 11px; color: var(--muted); }
+
+.arb-breakdown { display: flex; flex-direction: column; gap: 4px; }
+
+.arb-table {
+  background: rgba(255,255,255,.03);
+  border: 1px solid rgba(48,54,61,.4);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.arb-table-head, .arb-table-row {
+  display: grid;
+  grid-template-columns: 1fr 120px 70px 80px;
+  gap: 8px;
+  padding: 5px 10px;
+  font-size: 12px;
+}
+.arb-table-head {
+  background: rgba(255,255,255,.04);
+  border-bottom: 1px solid rgba(48,54,61,.4);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  color: var(--muted);
+}
+.arb-table-head span:not(:first-child), .arb-table-num { text-align: right; }
+.arb-table-row { border-bottom: 1px solid rgba(48,54,61,.2); }
+.arb-table-row:last-child { border-bottom: none; }
+.arb-table-row:hover { background: rgba(255,255,255,.04); }
+.arb-table-name { color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0; }
+.arb-table-num { font-variant-numeric: tabular-nums; color: var(--muted); }
+
+.arb-runs { display: flex; flex-direction: column; gap: 2px; }
+.arb-run {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 10px;
+  background: rgba(255,255,255,.03);
+  border: 1px solid rgba(48,54,61,.3);
+  border-left: 3px solid var(--green);
+  border-radius: 5px;
+  font-size: 12px;
+}
+.arb-run:hover { background: rgba(255,255,255,.06); }
+.arb-run-incomplete { border-left-color: var(--red); }
+.arb-run-incomplete .timer-name { color: var(--muted); }
+.arb-run-flag { color: var(--red); }
+.arb-run-when { font-size: 11px; color: var(--muted); font-variant-numeric: tabular-nums; min-width: 110px; flex-shrink: 0; }
+.arb-run-main { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 1px; }
+.arb-run-num { font-size: 11px; color: var(--muted); font-variant-numeric: tabular-nums; text-align: right; min-width: 64px; flex-shrink: 0; }
+
+.arb-stale {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 16px;
+  font-size: 11px;
+  color: #f0c040;
+  background: rgba(240,192,64,.08);
+  border-bottom: 1px solid rgba(240,192,64,.25);
+}
+.arb-stale button {
+  background: none;
+  border: 1px solid #f0c040;
+  color: #f0c040;
+  font-size: 11px;
+  padding: 1px 8px;
+  border-radius: 3px;
+  cursor: pointer;
+}
+
+.arb-current {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px 12px 8px;
+  border-bottom: 1px solid rgba(48,54,61,.35);
+}
+.arb-current-body { flex: 1; min-width: 0; }
+.arb-current-node { font-size: 16px; font-weight: 600; color: var(--text); }
+.arb-current-cd { text-align: right; }
+.arb-current-cd .timer-cd { font-size: 18px; }
+
+.arb-region { color: var(--muted); font-weight: 400; }
+.arb-time {
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  color: var(--muted);
+  flex-shrink: 0;
+  min-width: 48px;
+}
+.arb-detail {
+  font-size: 11px;
+  color: var(--muted);
+  flex-shrink: 0;
+  width: 210px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.arb-current .arb-detail { width: auto; }
+
+.arb-scroll .timer-row .timer-until {
+  width: 96px;
+  max-width: none;
+  text-align: right;
+}
+
+.arb-fav { background: rgba(240,192,64,.08); }
+.arb-fav:hover { background: rgba(240,192,64,.14); }
+.arb-fav .timer-name, .arb-fav .arb-current-node { color: #f0c040; }
+
+.arb-alerts {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 16px;
+  font-size: 11px;
+  color: var(--muted);
+  border-bottom: 1px solid var(--border);
+}
+
+.arb-alerts label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.arb-alerts input {
+  width: 52px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  color: var(--text);
+  font-size: 11px;
+  padding: 2px 4px;
+}
+
+.arb-alerts-denied {
+  padding: 4px 16px;
+  font-size: 11px;
+  color: #f0c040;
+}
+
+/* ── Tiers ─────────────────────────────────────────────────────────────────── */
+
+/* The letter is the rating; color only sorts the list faster, which is why
+   the badge never shrinks to a dot. */
+.tier-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  margin-right: 6px;
+  padding: 0 3px;
+  border-radius: 3px;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+  color: #0d1117;
+  flex-shrink: 0;
+}
+.tier-S { background: #f0c040; }
+.tier-A { background: #3fb950; }
+.tier-B { background: #388bfd; }
+.tier-C { background: #8b949e; }
+.tier-D { background: #6e4a9e; color: #e6edf3; }
+.tier-unrated { background: transparent; border: 1px dashed var(--border); color: var(--muted); }
+.tier-none { background: transparent; }
+
+/* An hour alerting because of its tier rather than a star: dimmer than the
+   favorite highlight, so a starred hour still stands out among them. */
+.arb-tier-alert:not(.arb-fav) { background: rgba(56,139,253,.07); }
+.arb-tier-alert:not(.arb-fav):hover { background: rgba(56,139,253,.12); }
+
+.arb-tier-filter { padding: 0 16px; }
+
+.tier-select { position: relative; display: flex; align-items: center; gap: 6px; }
+.tier-select-label { font-size: 11px; color: var(--muted); }
+
+.tier-select-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 88px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  color: var(--text);
+  font-size: 11px;
+  padding: 3px 6px;
+  cursor: pointer;
+}
+.tier-select-btn:hover, .tier-select-btn.open { border-color: var(--accent); }
+.tier-select-caret { margin-left: auto; color: var(--muted); }
+
+.tier-select-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 20;
+  min-width: 140px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 4px;
+  box-shadow: 0 6px 18px rgba(0,0,0,.45);
+}
+
+.tier-select-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 5px;
+  border-radius: 3px;
+  font-size: 11px;
+  cursor: pointer;
+}
+.tier-select-row:hover { background: rgba(255,255,255,.05); }
+.tier-select-row input { margin: 0; }
+
+.tier-select-actions {
+  display: flex;
+  gap: 4px;
+  margin-top: 4px;
+  padding-top: 4px;
+  border-top: 1px solid var(--border);
+}
+.tier-select-actions button {
+  flex: 1;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  color: var(--muted);
+  font-size: 11px;
+  padding: 2px 0;
+  cursor: pointer;
+}
+.tier-select-actions button:hover { color: var(--text); border-color: var(--accent); }

--- a/src/arbitration/Arbitrations.tsx
+++ b/src/arbitration/Arbitrations.tsx
@@ -1,0 +1,239 @@
+import { useEffect, useRef, useState } from "react";
+import { fmtMs } from "../TimerHelper";
+import { formatUnixTime } from "../lib/formatters";
+import type { ClockFormat } from "../types/settings";
+import { ensurePermission, permissionGranted } from "../lib/notify";
+import { clampLead, MAX_LEAD_MINS, MIN_LEAD_MINS, type ScheduleEntry } from "./arbitrationAlerts";
+import { useArbitrationSchedule, clampScheduleDays, SCHEDULE_DAY_OPTIONS } from "./arbitrationSchedule";
+import { tierKey, type TierKey } from "./arbitrationTiers";
+import TierSelect, { TierBadge } from "./TierSelect";
+import ArbitrationHistory from "./ArbitrationHistory";
+import "./Arbitrations.css";
+import "../shared/Report.css";
+
+// The day header always reads English like the rest of the UI; only the time
+// takes the locale-driven hour cycle.
+const dayLabel = (unix: number) =>
+  new Date(unix * 1000).toLocaleDateString("en-US", { weekday: "long", month: "short", day: "numeric" });
+
+// Favorites and lead time are owned by App: the alerts have to keep firing
+// while the user is looking at another module, and this component is unmounted
+// for all of that time. Permission state too: a denial only this component
+// knows about is invisible for as long as the user is elsewhere.
+type Props = {
+  favorites: string[];
+  onToggleFavorite: (nodeId: string) => void;
+  leadMins: number;
+  onLeadChange: (mins: number) => void;
+  permissionDenied: boolean;
+  onPermissionChange: (denied: boolean) => void;
+  tierFilter: TierKey[];
+  onTierFilterChange: (next: TierKey[]) => void;
+  alertTiers: TierKey[];
+  onAlertTiersChange: (next: TierKey[]) => void;
+  scheduleDays: number;
+  onScheduleDaysChange: (days: number) => void;
+  clockFormat: ClockFormat;
+  systemLocale: string;
+};
+
+export default function Arbitrations(props: Props) {
+  const [tab, setTab] = useState<"schedule" | "history">("schedule");
+  return (
+    <div className="arb">
+      <div className="sub-tabs">
+        <button className={tab === "schedule" ? "active" : ""} onClick={() => setTab("schedule")}>Schedule</button>
+        <button className={tab === "history" ? "active" : ""} onClick={() => setTab("history")}>Run history</button>
+      </div>
+      {tab === "schedule" ? <Schedule {...props} /> : <ArbitrationHistory clockFormat={props.clockFormat} systemLocale={props.systemLocale} />}
+    </div>
+  );
+}
+
+function Schedule({
+  favorites, onToggleFavorite, leadMins, onLeadChange, permissionDenied, onPermissionChange,
+  tierFilter, onTierFilterChange, alertTiers, onAlertTiersChange, scheduleDays, onScheduleDaysChange,
+  clockFormat, systemLocale,
+}: Props) {
+  const { schedule, error, refresh: fetchSchedule } = useArbitrationSchedule(true, scheduleDays);
+  const [now, setNow] = useState(() => Date.now());
+  const [leadDraft, setLeadDraft] = useState(String(leadMins));
+
+  useEffect(() => {
+    const tick = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(tick);
+  }, []);
+
+  useEffect(() => setLeadDraft(String(leadMins)), [leadMins]);
+
+  // The alert rule arrives from settings after mount, so this waits for it
+  // rather than reading the empty state the first render sees.
+  const alertsOn = favorites.length > 0 || alertTiers.length > 0;
+  const askedRef = useRef(false);
+  useEffect(() => {
+    if (!alertsOn || askedRef.current) return;
+    askedRef.current = true;
+    void ensurePermission().then(granted => onPermissionChange(!granted));
+  }, [alertsOn]);
+
+  // Permission is granted in system settings, so the app hears about it by
+  // getting the window back, not by anything happening inside it. Read-only:
+  // a dialog raised by a focus event is one the user did nothing to invite.
+  useEffect(() => {
+    if (!alertsOn) return;
+    const recheck = () => void permissionGranted().then(granted => onPermissionChange(!granted));
+    window.addEventListener("focus", recheck);
+    return () => window.removeEventListener("focus", recheck);
+  }, [alertsOn, onPermissionChange]);
+
+  // Committed on blur rather than per keystroke: clamping while the field is
+  // half-typed rewrites what the user is in the middle of entering.
+  const commitLead = () => {
+    // A cleared field is someone retyping, not a request for the shortest lead
+    // the app allows; Number("") would otherwise commit it as zero.
+    if (leadDraft.trim() === "") {
+      setLeadDraft(String(leadMins));
+      return;
+    }
+    const mins = clampLead(Number(leadDraft));
+    onLeadChange(mins);
+    setLeadDraft(String(mins));
+  };
+
+  const toggleFavorite = async (nodeId: string) => {
+    const adding = !favorites.includes(nodeId);
+    onToggleFavorite(nodeId);
+    if (adding) onPermissionChange(!(await ensurePermission()));
+  };
+
+  if (!schedule) {
+    return error
+      ? <div className="arb-scroll"><div className="timer-error">{error} <button onClick={fetchSchedule}>Retry</button></div></div>
+      : <div className="arb-scroll"><div className="timer-loading">Loading arbitration schedule…</div></div>;
+  }
+
+  const nowSec = now / 1000;
+  const live = schedule.entries.filter(e => e.end > nowSec);
+  // The hour running now is the only one anyone can act on, so it shows
+  // regardless of the filter; the filter is about what to plan around.
+  const current = live.find(e => e.start <= nowSec);
+  const upcoming = live.filter(e => e.start > nowSec);
+  const isFav = (e: ScheduleEntry) => favorites.includes(e.node_id);
+  // A starred node is exempt from the filter for the same reason the current
+  // hour is: hiding it strands it, since the star that would unstar it lives
+  // on the row itself.
+  const shown = upcoming.filter(e => isFav(e) || tierFilter.includes(tierKey(e.tier)));
+  const stale = schedule.source === "stale" || error;
+  const byTier = (e: ScheduleEntry) => alertTiers.includes(tierKey(e.tier));
+  const rowClass = (e: ScheduleEntry) =>
+    `${isFav(e) ? " arb-fav" : ""}${byTier(e) ? " arb-tier-alert" : ""}`;
+  const alertTitle = (e: ScheduleEntry) => (byTier(e) && !isFav(e) ? "Alerted by tier" : undefined);
+
+  const star = (e: ScheduleEntry) => (
+    <button
+      className={`timer-star ${isFav(e) ? "fav" : ""}`}
+      onClick={() => void toggleFavorite(e.node_id)}
+      title={isFav(e) ? "Unfavorite node" : "Favorite node"}
+    >★</button>
+  );
+  const detail = (e: ScheduleEntry) =>
+    [e.mission_type, e.faction].filter(Boolean).join(" · ");
+  const name = (e: ScheduleEntry) => (
+    <>
+      <TierBadge tier={e.tier} />
+      {e.node}{e.region && <span className="arb-region"> ({e.region})</span>}
+    </>
+  );
+
+  let lastDay = "";
+  return (
+    <div className="arb-scroll">
+      {stale && (
+        <div className="arb-stale" title={schedule.warning ?? error}>
+          Showing the last schedule that loaded; refreshing failed.
+          <button onClick={fetchSchedule}>Retry</button>
+        </div>
+      )}
+
+      <div className="arb-alerts">
+        <label>
+          Alert me
+          <input
+            type="number"
+            min={MIN_LEAD_MINS}
+            max={MAX_LEAD_MINS}
+            value={leadDraft}
+            onChange={e => setLeadDraft(e.target.value)}
+            onBlur={commitLead}
+            onKeyDown={e => { if (e.key === "Enter") e.currentTarget.blur(); }}
+          />
+          minutes before an alerting node starts
+        </label>
+        <TierSelect label="Alert for tiers" selected={alertTiers} onChange={onAlertTiersChange} />
+        {!alertsOn && <span>Star a node or pick a tier to be alerted.</span>}
+      </div>
+      {permissionDenied && (
+        <div className="arb-alerts-denied">FrameForge cannot send notifications. Check its permission in your system settings.</div>
+      )}
+
+      <div className="timer-group-label">Now</div>
+      {current ? (
+        <div className={`arb-current${rowClass(current)}`} title={alertTitle(current)}>
+          {star(current)}
+          <div className="arb-current-body">
+            <div className="arb-current-node">{name(current)}</div>
+            <div className="arb-detail">{detail(current)}</div>
+          </div>
+          <div className="arb-current-cd">
+            <div className="timer-cd">{fmtMs(current.end * 1000 - now)}</div>
+            <div className="timer-until">remaining</div>
+          </div>
+        </div>
+      ) : (
+        <div className="timer-empty">No arbitration in the schedule for this hour.</div>
+      )}
+
+      <div className="arb-filters arb-tier-filter">
+        <TierSelect label="Show tiers" selected={tierFilter} onChange={onTierFilterChange} />
+        <span className="arb-filter-sep" aria-hidden="true" />
+        <span className="arb-filter-window">
+          <span className="tier-select-label">Show</span>
+          <span className="arb-window-select">
+            <select
+              className="arb-window-select-input"
+              value={clampScheduleDays(scheduleDays)}
+              onChange={e => onScheduleDaysChange(Number(e.target.value))}
+            >
+              {SCHEDULE_DAY_OPTIONS.map(d => (
+                <option key={d} value={d}>{d} days</option>
+              ))}
+            </select>
+            <span className="arb-window-select-caret" aria-hidden="true">▾</span>
+          </span>
+        </span>
+        <span className="arb-muted arb-filter-count">{shown.length} of {upcoming.length} hours</span>
+      </div>
+
+      {upcoming.length === 0 && <div className="timer-empty">No upcoming arbitrations in the feed.</div>}
+      {upcoming.length > 0 && shown.length === 0 &&
+        <div className="timer-empty">No upcoming arbitrations in the tiers you are showing.</div>}
+      {shown.map(e => {
+        const day = dayLabel(e.start);
+        const header = day !== lastDay ? <div className="timer-group-label">{day}</div> : null;
+        lastDay = day;
+        return (
+          <div key={e.start}>
+            {header}
+            <div className={`timer-row${rowClass(e)}`} title={alertTitle(e)}>
+              {star(e)}
+              <span className="arb-time">{formatUnixTime(e.start, clockFormat, systemLocale)}</span>
+              <span className="timer-name">{name(e)}</span>
+              <span className="arb-detail">{detail(e)}</span>
+              <span className="timer-until">in {fmtMs(e.start * 1000 - now)}</span>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/arbitration/TierSelect.tsx
+++ b/src/arbitration/TierSelect.tsx
@@ -1,0 +1,97 @@
+import { useRef, useState } from "react";
+import { useClickOutside } from "../shared/useClickOutside";
+import { TIER_KEYS, TIER_LABELS, type TierKey } from "./arbitrationTiers";
+
+type Props = {
+  label: string;
+  selected: readonly TierKey[];
+  onChange: (next: TierKey[]) => void;
+};
+
+function summarize(selected: readonly TierKey[]): string {
+  if (selected.length === 0) return "None";
+  if (selected.length === TIER_KEYS.length) return "All";
+  return TIER_KEYS.filter((k) => selected.includes(k))
+    .map((k) => TIER_LABELS[k])
+    .join(", ");
+}
+
+/// Multi-select over the arbitration tiers, shared by the schedule's filter
+/// and its alert rule. A native `<select multiple>` would need a modifier key
+/// held to pick a second tier, which is not discoverable for the one control
+/// most users will touch here.
+export default function TierSelect({ label, selected, onChange }: Props) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useClickOutside(rootRef, () => setOpen(false), open);
+
+  const toggle = (key: TierKey) =>
+    onChange(
+      TIER_KEYS.filter((k) =>
+        k === key ? !selected.includes(k) : selected.includes(k),
+      ),
+    );
+
+  return (
+    <div className="tier-select" ref={rootRef}>
+      <span className="tier-select-label">{label}</span>
+      <button
+        type="button"
+        className={`tier-select-btn${open ? " open" : ""}`}
+        aria-expanded={open}
+        aria-label={label}
+        onClick={() => setOpen((o) => !o)}
+      >
+        {summarize(selected)}
+        <span className="tier-select-caret">▾</span>
+      </button>
+      {open && (
+        <div className="tier-select-menu">
+          {TIER_KEYS.map((k) => (
+            <label key={k} className="tier-select-row">
+              <input
+                type="checkbox"
+                checked={selected.includes(k)}
+                onChange={() => toggle(k)}
+              />
+              <TierBadge tier={k === "unrated" ? null : k} showUnrated />
+              <span>{TIER_LABELS[k]}</span>
+            </label>
+          ))}
+          <div className="tier-select-actions">
+            <button type="button" onClick={() => onChange([...TIER_KEYS])}>
+              All
+            </button>
+            <button type="button" onClick={() => onChange([])}>
+              None
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function TierBadge({
+  tier,
+  showUnrated = false,
+}: {
+  tier: TierKey | null;
+  showUnrated?: boolean;
+}) {
+  // An unrated node keeps the badge's width so the node names below each
+  // other still line up; only the dropdown spells the absence out.
+  if (tier === null || tier === "unrated") {
+    return (
+      <span className={`tier-badge tier-${showUnrated ? "unrated" : "none"}`}>
+        {showUnrated ? "–" : ""}
+      </span>
+    );
+  }
+  return (
+    <span className={`tier-badge tier-${tier}`} title={`Tier ${tier}`}>
+      {tier}
+    </span>
+  );
+}

--- a/src/arbitration/arbitrationAlerts.test.ts
+++ b/src/arbitration/arbitrationAlerts.test.ts
@@ -1,0 +1,218 @@
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  clampLead, dueAlerts, occurrenceKey, runAlertPass, DEFAULT_LEAD_MINS, EVAL_INTERVAL_MS,
+  MAX_LEAD_MINS, MIN_LEAD_MINS, MIN_REMAINING_SECS, type ScheduleEntry,
+} from "./arbitrationAlerts.ts";
+import type { Tier } from "./arbitrationTiers.ts";
+
+const HOUR = 3600;
+
+const entry = (start: number, node_id = "SolNode1", tier: Tier | null = null): ScheduleEntry => ({
+  start, end: start + HOUR, node_id,
+  node: "Tessera", region: "Void", mission_type: "Defense", faction: "Corpus", tier,
+});
+
+const due = (r: { due: ScheduleEntry[] }) => r.due.map(e => e.node_id);
+
+const persistAll = (r: { due: ScheduleEntry[]; kept: string[] }) => [...r.kept, ...r.due.map(occurrenceKey)];
+
+const raiseAll = async () => true;
+const raiseNone = async () => false;
+
+test("a favorited hour alerts once the lead window opens", () => {
+  const entries = [entry(10 * HOUR)];
+  assert.deepEqual(due(dueAlerts(entries, { favorites: ["SolNode1"] }, 10, [], 10 * HOUR - 601)), []);
+  assert.deepEqual(due(dueAlerts(entries, { favorites: ["SolNode1"] }, 10, [], 10 * HOUR - 600)), ["SolNode1"]);
+  assert.deepEqual(due(dueAlerts(entries, { favorites: ["SolNode1"] }, 10, [], 10 * HOUR - 1)), ["SolNode1"]);
+});
+
+test("an hour whose lead window was slept through still alerts", () => {
+  const entries = [entry(10 * HOUR)];
+  assert.deepEqual(due(dueAlerts(entries, { favorites: ["SolNode1"] }, 10, [], 10 * HOUR)), ["SolNode1"]);
+  assert.deepEqual(due(dueAlerts(entries, { favorites: ["SolNode1"] }, 10, [], 10 * HOUR + 30 * 60)), ["SolNode1"]);
+});
+
+test("an hour too far gone to join stays quiet", () => {
+  const entries = [entry(10 * HOUR)];
+  const lastUseful = 11 * HOUR - MIN_REMAINING_SECS;
+  assert.deepEqual(due(dueAlerts(entries, { favorites: ["SolNode1"] }, 10, [], lastUseful - 1)), ["SolNode1"]);
+  assert.deepEqual(due(dueAlerts(entries, { favorites: ["SolNode1"] }, 10, [], lastUseful)), []);
+  assert.deepEqual(due(dueAlerts(entries, { favorites: ["SolNode1"] }, 10, [], 11 * HOUR)), []);
+});
+
+test("an hour alerted before it started is not alerted again once it runs", () => {
+  const entries = [entry(10 * HOUR)];
+  const fired = persistAll(dueAlerts(entries, { favorites: ["SolNode1"] }, 10, [], 10 * HOUR - 600));
+  assert.deepEqual(due(dueAlerts(entries, { favorites: ["SolNode1"] }, 10, fired, 10 * HOUR + 60)), []);
+  assert.deepEqual(due(dueAlerts(entries, { favorites: ["SolNode1"] }, 10, fired, 10 * HOUR + 30 * 60)), []);
+});
+
+test("nothing alerts without a favorite", () => {
+  const entries = [entry(10 * HOUR), entry(11 * HOUR, "SolNode2")];
+  const result = dueAlerts(entries, { favorites: [] }, 60, [], 10 * HOUR - 60);
+  assert.deepEqual(result.due, []);
+  assert.deepEqual(result.kept, []);
+});
+
+test("an unfavorited node in the same window stays quiet", () => {
+  const entries = [entry(10 * HOUR, "SolNode1"), entry(10 * HOUR, "SolNode2")];
+  assert.deepEqual(due(dueAlerts(entries, { favorites: ["SolNode2"] }, 10, [], 10 * HOUR - 60)), ["SolNode2"]);
+});
+
+test("an occurrence already fired is not repeated", () => {
+  const entries = [entry(10 * HOUR)];
+  const first = dueAlerts(entries, { favorites: ["SolNode1"] }, 10, [], 10 * HOUR - 600);
+  assert.deepEqual(due(first), ["SolNode1"]);
+
+  let fired = persistAll(first);
+  for (let tick = 1; tick <= 5; tick++) {
+    const next = dueAlerts(entries, { favorites: ["SolNode1"] }, 10, fired, 10 * HOUR - 600 + tick * 60);
+    assert.deepEqual(next.due, []);
+    fired = persistAll(next);
+  }
+});
+
+test("fired state survives a restart", () => {
+  const entries = [entry(10 * HOUR)];
+  const fired = persistAll(dueAlerts(entries, { favorites: ["SolNode1"] }, 10, [], 10 * HOUR - 600));
+  assert.deepEqual(dueAlerts(entries, { favorites: ["SolNode1"] }, 10, [...fired], 10 * HOUR - 300).due, []);
+});
+
+test("the same node alerts again on its next occurrence", () => {
+  const entries = [entry(10 * HOUR), entry(40 * HOUR)];
+  const fired = persistAll(dueAlerts(entries, { favorites: ["SolNode1"] }, 10, [], 10 * HOUR - 60));
+  assert.deepEqual(due(dueAlerts(entries, { favorites: ["SolNode1"] }, 10, fired, 40 * HOUR - 60)), ["SolNode1"]);
+});
+
+test("keys outlive the start they name, then are pruned", () => {
+  const entries = [entry(40 * HOUR)];
+  const stale = [`${10 * HOUR}@SolNode1`, `${40 * HOUR}@SolNode1`];
+
+  // Still inside the hour it names, so it has to survive: the occurrence can
+  // yet alert as a catch-up, and a dropped key would let it alert twice.
+  assert.deepEqual(dueAlerts(entries, { favorites: ["SolNode1"] }, 10, stale, 10 * HOUR + 60).kept, stale);
+  assert.deepEqual(dueAlerts(entries, { favorites: ["SolNode1"] }, 10, stale, 20 * HOUR).kept, [`${40 * HOUR}@SolNode1`]);
+});
+
+test("a key that parses to no number is dropped rather than kept forever", () => {
+  const stale = ["Infinity@SolNode1", "garbage", "@SolNode1"];
+  assert.deepEqual(dueAlerts([], { favorites: ["SolNode1"] }, 10, stale, 20 * HOUR).kept, []);
+});
+
+test("favoriting mid-window alerts on the next tick", () => {
+  const entries = [entry(10 * HOUR)];
+  const quiet = dueAlerts(entries, { favorites: [] }, 10, [], 10 * HOUR - 300);
+  assert.deepEqual(due(dueAlerts(entries, { favorites: ["SolNode1"] }, 10, persistAll(quiet), 10 * HOUR - 240)), ["SolNode1"]);
+});
+
+test("a longer lead reaches an hour a shorter one does not", () => {
+  const entries = [entry(10 * HOUR)];
+  const now = 10 * HOUR - 30 * 60;
+  assert.deepEqual(due(dueAlerts(entries, { favorites: ["SolNode1"] }, 10, [], now)), []);
+  assert.deepEqual(due(dueAlerts(entries, { favorites: ["SolNode1"] }, 45, [], now)), ["SolNode1"]);
+});
+
+test("lead is clamped into range, so a zero or negative lead cannot fire late", () => {
+  assert.equal(clampLead(0), MIN_LEAD_MINS);
+  assert.equal(clampLead(-30), MIN_LEAD_MINS);
+  assert.equal(clampLead(9999), MAX_LEAD_MINS);
+  assert.equal(clampLead(NaN), DEFAULT_LEAD_MINS);
+  assert.equal(clampLead(10.4), 10);
+
+  const entries = [entry(10 * HOUR)];
+  assert.deepEqual(due(dueAlerts(entries, { favorites: ["SolNode1"] }, 0, [], 10 * HOUR - 120)), []);
+  assert.deepEqual(due(dueAlerts(entries, { favorites: ["SolNode1"] }, 0, [], 10 * HOUR - 60)), ["SolNode1"]);
+});
+
+test("the shortest lead is still offered on several consecutive ticks", () => {
+  const entries = [entry(10 * HOUR)];
+  const tickSecs = EVAL_INTERVAL_MS / 1000;
+  const windowSecs = MIN_LEAD_MINS * 60;
+
+  // One delayed timer must not be able to step over the narrowest window, so
+  // more than one tick has to land inside it.
+  let offered = 0;
+  for (let t = 0; t * tickSecs < windowSecs; t++) {
+    const now = 10 * HOUR - windowSecs + t * tickSecs;
+    assert.deepEqual(due(dueAlerts(entries, { favorites: ["SolNode1"] }, MIN_LEAD_MINS, [], now)), ["SolNode1"]);
+    offered++;
+  }
+  assert.ok(offered >= 2, `narrowest window fits only ${offered} evaluations`);
+});
+
+test("only occurrences inside the window join the fired state", () => {
+  const entries = [entry(10 * HOUR), entry(20 * HOUR)];
+  assert.deepEqual(persistAll(dueAlerts(entries, { favorites: ["SolNode1"] }, 10, [], 10 * HOUR - 60)),
+    [`${10 * HOUR}@SolNode1`]);
+});
+
+test("a raised alert joins the persisted state", async () => {
+  const entries = [entry(10 * HOUR)];
+  assert.deepEqual(await runAlertPass(entries, { favorites: ["SolNode1"] }, 10, [], 10 * HOUR - 600, raiseAll),
+    [`${10 * HOUR}@SolNode1`]);
+});
+
+test("an alert that could not be raised is not recorded, and comes back", async () => {
+  const entries = [entry(10 * HOUR)];
+  assert.equal(await runAlertPass(entries, { favorites: ["SolNode1"] }, 10, [], 10 * HOUR - 600, raiseNone), null);
+
+  const seen: string[] = [];
+  await runAlertPass(entries, { favorites: ["SolNode1"] }, 10, [], 10 * HOUR - 540, async e => {
+    seen.push(e.node_id);
+    return true;
+  });
+  assert.deepEqual(seen, ["SolNode1"]);
+});
+
+test("only the occurrences that were raised are recorded", async () => {
+  const entries = [entry(10 * HOUR, "SolNode1"), entry(10 * HOUR, "SolNode2")];
+  assert.deepEqual(
+    await runAlertPass(entries, { favorites: ["SolNode1", "SolNode2"] }, 10, [], 10 * HOUR - 600,
+      async e => e.node_id === "SolNode1"),
+    [`${10 * HOUR}@SolNode1`]);
+});
+
+test("a pass that changes nothing reports nothing to save", async () => {
+  const entries = [entry(10 * HOUR)];
+  const fired = [`${10 * HOUR}@SolNode1`];
+  assert.equal(await runAlertPass(entries, { favorites: ["SolNode1"] }, 10, fired, 10 * HOUR - 300, raiseAll), null);
+});
+
+test("a pass that only prunes still reports the pruned state", async () => {
+  assert.deepEqual(await runAlertPass([], { favorites: [] }, 10, [`${8 * HOUR}@SolNode1`], 10 * HOUR, raiseAll), []);
+});
+
+
+test("an hour alerts on its tier without the node being favorited", () => {
+  const entries = [entry(10 * HOUR, "SolNode1", "S")];
+  assert.deepEqual(due(dueAlerts(entries, { tiers: ["S"] }, 10, [], 10 * HOUR - 600)), ["SolNode1"]);
+  assert.deepEqual(due(dueAlerts(entries, { tiers: ["A"] }, 10, [], 10 * HOUR - 600)), []);
+});
+
+test("a rule matching both ways raises the hour once", () => {
+  const entries = [entry(10 * HOUR, "SolNode1", "S")];
+  const rule = { favorites: ["SolNode1"], tiers: ["S"] as const };
+  const first = dueAlerts(entries, rule, 10, [], 10 * HOUR - 600);
+  assert.deepEqual(due(first), ["SolNode1"]);
+  assert.deepEqual(due(dueAlerts(entries, rule, 10, persistAll(first), 10 * HOUR - 540)), []);
+});
+
+test("an unrated node is alertable as its own tier, not as every tier", () => {
+  const entries = [entry(10 * HOUR, "SolNode1", null)];
+  assert.deepEqual(due(dueAlerts(entries, { tiers: ["unrated"] }, 10, [], 10 * HOUR - 600)), ["SolNode1"]);
+  assert.deepEqual(due(dueAlerts(entries, { tiers: ["S", "A", "B", "C", "D"] }, 10, [], 10 * HOUR - 600)), []);
+});
+
+test("an empty rule alerts nothing at all", () => {
+  const entries = [entry(10 * HOUR, "SolNode1", "S")];
+  assert.deepEqual(due(dueAlerts(entries, {}, 10, [], 10 * HOUR - 600)), []);
+});
+
+test("a tier alert obeys the same lead and catch-up limits as a favorite", () => {
+  const entries = [entry(10 * HOUR, "SolNode1", "S")];
+  const rule = { tiers: ["S"] as const };
+  assert.deepEqual(due(dueAlerts(entries, rule, 10, [], 10 * HOUR - 601)), []);
+  assert.deepEqual(due(dueAlerts(entries, rule, 10, [], 11 * HOUR - MIN_REMAINING_SECS)), []);
+});

--- a/src/arbitration/arbitrationAlerts.ts
+++ b/src/arbitration/arbitrationAlerts.ts
@@ -1,0 +1,118 @@
+// Extension spelled out because the alert rules run under node's type
+// stripping in the tests, which resolves this import for real.
+import { tierKey, type Tier, type TierKey } from "./arbitrationTiers.ts";
+
+// Arbitration schedule as the backend serves it. All times are unix seconds.
+export type ScheduleEntry = {
+  start: number;
+  end: number;
+  node_id: string;
+  node: string;
+  region: string;
+  mission_type: string;
+  faction: string;
+  /// Null for a node the community rating does not cover.
+  tier: Tier | null;
+};
+
+export type Schedule = {
+  entries: ScheduleEntry[];
+  source: "fresh" | "refreshed" | "refreshing" | "stale" | "fallback";
+  warning: string | null;
+};
+
+// A zero lead would put the alert at the moment the hour starts, which is the
+// one instant it cannot help. The ceiling is one rotation, which keeps the
+// alert inside the hour immediately before the one it announces.
+export const MIN_LEAD_MINS = 1;
+export const MAX_LEAD_MINS = 60;
+export const DEFAULT_LEAD_MINS = 10;
+
+// The lead floor above has to span several of these: an alert window exactly
+// one tick wide is one delayed timer away from being stepped over.
+export const EVAL_INTERVAL_MS = 20_000;
+
+// An hour whose lead window was slept through still alerts, but only while
+// this much of it is left. Below that it announces a run nobody can reach in
+// time.
+export const MIN_REMAINING_SECS = 300;
+
+// One rotation. A fired key carries a start and no end, so pruning needs this
+// to work out when the key has aged out of ever matching again.
+const ROTATION_SECS = 3600;
+
+export function clampLead(mins: number): number {
+  if (!Number.isFinite(mins)) return DEFAULT_LEAD_MINS;
+  return Math.min(MAX_LEAD_MINS, Math.max(MIN_LEAD_MINS, Math.round(mins)));
+}
+
+export type AlertRule = {
+  favorites?: readonly string[];
+  tiers?: readonly TierKey[];
+};
+
+function matches(rule: AlertRule, entry: ScheduleEntry): boolean {
+  return (rule.favorites?.includes(entry.node_id) ?? false)
+    || (rule.tiers?.includes(tierKey(entry.tier)) ?? false);
+}
+
+export const occurrenceKey = (e: ScheduleEntry) => `${e.start}@${e.node_id}`;
+const keyStart = (key: string) => Number(key.split("@")[0]);
+
+// `fired` is the caller's persisted state and `kept` replaces it, which is what
+// prunes it: the state stays the size of the horizon rather than growing for as
+// long as the app is installed. Keys for `due` are deliberately not in `kept`:
+// the caller appends the ones it managed to raise, so an occurrence that could
+// not be delivered is retried rather than recorded.
+export function dueAlerts(
+  entries: readonly ScheduleEntry[],
+  rule: AlertRule,
+  leadMins: number,
+  fired: readonly string[],
+  nowSec: number,
+): { due: ScheduleEntry[]; kept: string[] } {
+  const leadSecs = clampLead(leadMins) * 60;
+  const alreadyFired = new Set(fired);
+
+  const due = entries.filter(e =>
+    matches(rule, e) &&
+    !alreadyFired.has(occurrenceKey(e)) &&
+    // Once the hour is running the alert is a catch-up for a timer suspended
+    // across the lead window, so the time left to join the run decides it
+    // instead of the lead.
+    (e.start > nowSec
+      ? e.start - leadSecs <= nowSec
+      : e.end - nowSec > MIN_REMAINING_SECS));
+
+  // A key has to outlive the start it names, because that hour stays alertable
+  // while it runs; pruning on start would re-alert a running occurrence every
+  // evaluation. A key that parses to no number at all goes immediately.
+  return {
+    due,
+    kept: fired.filter(k => {
+      const start = keyStart(k);
+      return Number.isFinite(start) && start + ROTATION_SECS > nowSec;
+    }),
+  };
+}
+
+// `raise` says whether the alert was handed over; an occurrence it could not
+// raise stays out of the result, so the next pass offers it again. Null means
+// nothing moved, which spares the caller a settings write.
+export async function runAlertPass(
+  entries: readonly ScheduleEntry[],
+  rule: AlertRule,
+  leadMins: number,
+  fired: readonly string[],
+  nowSec: number,
+  raise: (entry: ScheduleEntry) => Promise<boolean>,
+): Promise<string[] | null> {
+  const { due, kept } = dueAlerts(entries, rule, leadMins, fired, nowSec);
+
+  const raised: string[] = [];
+  for (const e of due) if (await raise(e)) raised.push(occurrenceKey(e));
+
+  const next = [...kept, ...raised];
+  const unchanged = next.length === fired.length && next.every((k, i) => k === fired[i]);
+  return unchanged ? null : next;
+}

--- a/src/arbitration/arbitrationAnalytics.test.ts
+++ b/src/arbitration/arbitrationAnalytics.test.ts
@@ -1,0 +1,95 @@
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { filterRuns, summarize, type RunRecord } from "./arbitrationAnalytics.ts";
+
+const DAY = 86_400_000;
+const NOW = Date.UTC(2026, 8, 4, 12);
+
+let seq = 0;
+const run = (over: Partial<RunRecord> = {}): RunRecord => ({
+  uid: `run-${seq++}`,
+  started_at: new Date(NOW - DAY).toISOString(),
+  node: "Mot (Void)",
+  tier: null,
+  mission_type: "survival",
+  end_reason: "mission_end",
+  duration_sec: 600,
+  rotations: 2,
+  waves: 0,
+  kills: 300,
+  drone_kills: 10,
+  vitus_mean: 20,
+  vitus_per_minute: 2,
+  ...over,
+});
+
+const daysAgo = (days: number) => new Date(NOW - days * DAY).toISOString();
+
+test("rates come from completed runs only; totals count every run", () => {
+  const s = summarize([
+    run({ duration_sec: 600, vitus_mean: 20, kills: 100 }),
+    run({ duration_sec: 1200, vitus_mean: 60, kills: 200 }),
+    run({ end_reason: "aborted", duration_sec: 6000, vitus_mean: 1000, kills: 50 }),
+    run({ end_reason: "new_mission", duration_sec: 60, vitus_mean: 0, kills: 7 }),
+  ]);
+  assert.equal(s.runs, 4);
+  assert.equal(s.incomplete, 2);
+  assert.equal(s.playtimeSec, 7860);
+  assert.equal(s.kills, 357);
+  assert.equal(s.vitus, 80);
+  assert.equal(s.perMinute, 80 / 30);
+  assert.deepEqual(s.rate, [2, 2]);
+});
+
+test("empty history has no rate, not a division by zero", () => {
+  const s = summarize([]);
+  assert.equal(s.runs, 0);
+  assert.equal(s.perMinute, null);
+  assert.deepEqual(s.rate, []);
+  assert.deepEqual(s.byNode, []);
+  assert.equal(summarize([run({ end_reason: "aborted" })]).perMinute, null);
+});
+
+test("rate series is chronological even when runs arrive newest first", () => {
+  const s = summarize([
+    run({ started_at: daysAgo(1), vitus_per_minute: 3 }),
+    run({ started_at: daysAgo(3), vitus_per_minute: 1 }),
+    run({ started_at: daysAgo(2), vitus_per_minute: 2 }),
+  ]);
+  assert.deepEqual(s.rate, [1, 2, 3]);
+});
+
+test("breakdowns group by node and by mission type, best rate first", () => {
+  const s = summarize([
+    run({ node: "Mot (Void)", mission_type: "survival", duration_sec: 600, vitus_mean: 10 }),
+    run({ node: "Mot (Void)", mission_type: "survival", end_reason: "aborted", vitus_mean: 999 }),
+    run({ node: "Stöfler (Lua)", mission_type: "defense", duration_sec: 600, vitus_mean: 30 }),
+    run({ node: "Casta (Ceres)", mission_type: "defense", end_reason: "unterminated" }),
+  ]);
+  assert.deepEqual(
+    s.byNode.map(b => [b.key, b.runs, b.completed, b.vitus, b.perMinute]),
+    [["Stöfler (Lua)", 1, 1, 30, 3], ["Mot (Void)", 2, 1, 10, 1], ["Casta (Ceres)", 1, 0, 0, null]],
+  );
+  assert.deepEqual(
+    s.byMissionType.map(b => [b.key, b.runs, b.perMinute]),
+    [["defense", 2, 3], ["survival", 2, 1]],
+  );
+});
+
+test("date range and mission type filters combine", () => {
+  const runs = [
+    run({ uid: "old-survival", started_at: daysAgo(40) }),
+    run({ uid: "new-survival", started_at: daysAgo(2) }),
+    run({ uid: "new-defense", started_at: daysAgo(2), mission_type: "defense" }),
+    run({ uid: "no-clock", started_at: null }),
+  ];
+  const ids = (days: number | "all", missionType: "all" | "survival" | "defense") =>
+    filterRuns(runs, { days, missionType }, NOW).map(r => r.uid);
+
+  assert.deepEqual(ids("all", "all"), ["old-survival", "new-survival", "new-defense", "no-clock"]);
+  assert.deepEqual(ids(30, "all"), ["new-survival", "new-defense"]);
+  assert.deepEqual(ids(30, "survival"), ["new-survival"]);
+  assert.deepEqual(ids("all", "defense"), ["new-defense"]);
+  assert.deepEqual(ids(7, "defense"), ["new-defense"]);
+});

--- a/src/arbitration/arbitrationAnalytics.ts
+++ b/src/arbitration/arbitrationAnalytics.ts
@@ -1,0 +1,120 @@
+import type { Tier } from "./arbitrationTiers.ts";
+
+export type MissionType = "defense" | "interception" | "disruption" | "survival" | "other";
+export type EndReason = "mission_end" | "aborted" | "new_mission" | "unterminated";
+
+export interface RunRecord {
+  uid: string;
+  /// Null for an unrated node, and for a run recorded without the star chart
+  /// node it happened on.
+  tier: Tier | null;
+  /// RFC-3339 UTC; null when the log had no boot-time header.
+  started_at: string | null;
+  node: string;
+  mission_type: MissionType;
+  end_reason: EndReason;
+  duration_sec: number;
+  rotations: number;
+  waves: number;
+  kills: number;
+  drone_kills: number;
+  vitus_mean: number;
+  vitus_per_minute: number;
+}
+
+export const MISSION_TYPES: MissionType[] = ["defense", "interception", "disruption", "survival", "other"];
+
+/// Only a run the mission itself ended counts toward rates. An abort, a host
+/// migration into a new mission, or a log that ended mid-run all cut the
+/// combat window short, and a partial window says nothing about a full run's
+/// rate.
+export const completed = (run: RunRecord) => run.end_reason === "mission_end";
+
+export interface Filters {
+  days: number | "all";
+  missionType: MissionType | "all";
+}
+
+/// A run without a wall clock is outside every date range but "all", as in
+/// the database query that stored it.
+export function filterRuns(runs: RunRecord[], filters: Filters, now = Date.now()): RunRecord[] {
+  const cutoff = filters.days === "all" ? null : new Date(now - filters.days * 86_400_000).toISOString();
+  return runs.filter(run =>
+    (filters.missionType === "all" || run.mission_type === filters.missionType)
+    && (cutoff === null || (run.started_at !== null && run.started_at >= cutoff)),
+  );
+}
+
+export interface Breakdown {
+  key: string;
+  runs: number;
+  completed: number;
+  vitus: number;
+  /// Vitus per minute over the combined combat time of completed runs,
+  /// so a long run weighs more than a short one; null with no completed run.
+  perMinute: number | null;
+}
+
+export interface Summary {
+  runs: number;
+  /// Every run the mission itself did not end: aborted, left for another
+  /// mission, or cut off by the end of the log.
+  incomplete: number;
+  playtimeSec: number;
+  kills: number;
+  vitus: number;
+  perMinute: number | null;
+  rate: number[];
+  byNode: Breakdown[];
+  byMissionType: Breakdown[];
+}
+
+function breakdown(key: string, runs: RunRecord[]): Breakdown {
+  const done = runs.filter(completed);
+  const vitus = done.reduce((s, r) => s + r.vitus_mean, 0);
+  const minutes = done.reduce((s, r) => s + r.duration_sec, 0) / 60;
+  return {
+    key,
+    runs: runs.length,
+    completed: done.length,
+    vitus,
+    perMinute: minutes > 0 ? vitus / minutes : null,
+  };
+}
+
+function groupBy(runs: RunRecord[], key: (r: RunRecord) => string): Breakdown[] {
+  const groups = new Map<string, RunRecord[]>();
+  for (const run of runs) {
+    const k = key(run);
+    const group = groups.get(k);
+    if (group) group.push(run);
+    else groups.set(k, [run]);
+  }
+  return [...groups]
+    .map(([k, rs]) => breakdown(k, rs))
+    .sort((a, b) => (b.perMinute ?? -1) - (a.perMinute ?? -1) || b.runs - a.runs);
+}
+
+// Runs without a wall clock go last, as the stored list orders them.
+const byStart = (a: RunRecord, b: RunRecord) => {
+  if (a.started_at === null || b.started_at === null) return Number(a.started_at === null) - Number(b.started_at === null);
+  return a.started_at < b.started_at ? -1 : a.started_at > b.started_at ? 1 : 0;
+};
+
+export function summarize(runs: RunRecord[]): Summary {
+  const all = breakdown("all", runs);
+  return {
+    runs: runs.length,
+    incomplete: runs.length - all.completed,
+    playtimeSec: runs.reduce((s, r) => s + r.duration_sec, 0),
+    kills: runs.reduce((s, r) => s + r.kills, 0),
+    vitus: all.vitus,
+    perMinute: all.perMinute,
+    rate: runs
+      .filter(completed)
+      .sort(byStart)
+      .map(r => r.vitus_per_minute),
+    byNode: groupBy(runs, r => r.node),
+    byMissionType: groupBy(runs, r => r.mission_type),
+  };
+}

--- a/src/arbitration/arbitrationSchedule.test.ts
+++ b/src/arbitration/arbitrationSchedule.test.ts
@@ -1,0 +1,22 @@
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { clampScheduleDays, DEFAULT_SCHEDULE_DAYS, SCHEDULE_DAY_OPTIONS } from "./arbitrationSchedule.ts";
+
+test("the window defaults to a week and the options reach 60 days", () => {
+  assert.equal(DEFAULT_SCHEDULE_DAYS, 7);
+  assert.deepEqual([...SCHEDULE_DAY_OPTIONS], [3, 7, 14, 30, 60]);
+});
+
+test("a stored selection outside the 1-60 day range clamps to its edge", () => {
+  assert.equal(clampScheduleDays(0), 1);
+  assert.equal(clampScheduleDays(-5), 1);
+  assert.equal(clampScheduleDays(61), 60);
+  assert.equal(clampScheduleDays(9999), 60);
+  assert.equal(clampScheduleDays(14), 14);
+});
+
+test("a non-number selection falls back to the default", () => {
+  assert.equal(clampScheduleDays(Number.NaN), DEFAULT_SCHEDULE_DAYS);
+  assert.equal(clampScheduleDays(Number.POSITIVE_INFINITY), DEFAULT_SCHEDULE_DAYS);
+});

--- a/src/arbitration/arbitrationSchedule.ts
+++ b/src/arbitration/arbitrationSchedule.ts
@@ -1,0 +1,115 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import type { Schedule } from "./arbitrationAlerts";
+
+// One poll per window, shared by the browser and the alert loop. The backend
+// command re-reads and re-parses the whole multi-year feed on every call, so a
+// timer per consumer is not free the way a cache hit sounds like it should be.
+//
+// Hourly, because that is how often the rotation changes; the entries already
+// reach ahead, so a schedule fetched fifty minutes ago still holds every hour
+// anyone is about to be alerted about.
+const POLL_MS = 60 * 60 * 1000;
+
+// Until one fetch has landed there is nothing to alert from at all, and an
+// hour's wait for the next attempt is long enough to walk past an occurrence
+// entirely. Backs off so a feed that is down all afternoon is not hammered.
+const RETRY_MS = [15_000, 60_000, 300_000];
+
+export const DEFAULT_SCHEDULE_DAYS = 7;
+export const SCHEDULE_DAY_OPTIONS = [3, 7, 14, 30, 60] as const;
+const MIN_SCHEDULE_DAYS = 1;
+const MAX_SCHEDULE_DAYS = 60;
+
+/// A stored selection is any number, not just a preset; it must land inside
+/// the range the backend honors rather than being rejected outright.
+export function clampScheduleDays(days: number) {
+  if (!Number.isFinite(days)) return DEFAULT_SCHEDULE_DAYS;
+  return Math.min(MAX_SCHEDULE_DAYS, Math.max(MIN_SCHEDULE_DAYS, Math.round(days)));
+}
+
+type Snapshot = { schedule: Schedule | null; error: string };
+
+let current: Snapshot = { schedule: null, error: "" };
+let fetchedForDays = DEFAULT_SCHEDULE_DAYS;
+let inFlight: Promise<void> | null = null;
+let inFlightDays = DEFAULT_SCHEDULE_DAYS;
+let timer: ReturnType<typeof setInterval> | null = null;
+let retry: ReturnType<typeof setTimeout> | null = null;
+let failures = 0;
+const subscribers = new Set<(s: Snapshot) => void>();
+
+function publish(next: Snapshot) {
+  current = next;
+  for (const notify of subscribers) notify(next);
+}
+
+function clearRetry() {
+  if (retry) { clearTimeout(retry); retry = null; }
+}
+
+function fetchOnce(days: number): Promise<void> {
+  days = clampScheduleDays(days);
+  if (inFlight) {
+    // A request for a horizon the running fetch is not building must not be
+    // lost to it; the refresh follows once the running fetch settles.
+    if (days === inFlightDays) return inFlight;
+    return inFlight.then(() => fetchOnce(days));
+  }
+  inFlightDays = days;
+  inFlight = invoke<Schedule>("fetch_arbitration_schedule", { horizonDays: days })
+    .then(s => { failures = 0; clearRetry(); fetchedForDays = days; publish({ schedule: s, error: "" }); })
+    // The last good schedule is published alongside the error rather than
+    // cleared: its entries stay valid for days, so the alert loop keeps
+    // working through a failed refresh and the browser can show what it has.
+    .catch(e => { publish({ ...current, error: String(e) }); scheduleRetry(); })
+    .finally(() => { inFlight = null; });
+  return inFlight;
+}
+
+// Only while nothing usable is cached. Once a schedule is in hand the hourly
+// poll is soon enough, because those entries already cover every hour anyone
+// is about to be alerted about.
+function scheduleRetry() {
+  if (current.schedule || retry || subscribers.size === 0) return;
+  retry = setTimeout(() => {
+    retry = null;
+    void fetchOnce(fetchedForDays);
+  }, RETRY_MS[Math.min(failures++, RETRY_MS.length - 1)]);
+}
+
+// `enabled` is false for a consumer that wants the schedule only if someone
+// else is already paying for it: the alert loop must not start an hourly fetch
+// for a user who has never starred a node. `horizonDays` is how far ahead this
+// consumer wants the entries to reach; the browser passes its choice, and the
+// alert loop passes nothing — it has no window preference, so it must not pull
+// the shared snapshot off the window the user picked.
+export function useArbitrationSchedule(enabled: boolean, horizonDays?: number): Snapshot & { refresh: () => void } {
+  const [snapshot, setSnapshot] = useState(current);
+  const days = clampScheduleDays(horizonDays ?? DEFAULT_SCHEDULE_DAYS);
+  const passive = horizonDays === undefined;
+
+  useEffect(() => {
+    if (!enabled) return;
+    subscribers.add(setSnapshot);
+    if (subscribers.size === 1) {
+      fetchOnce(days);
+      timer = setInterval(() => fetchOnce(fetchedForDays), POLL_MS);
+    } else {
+      setSnapshot(current);
+      // Entries arrive windowed whole from the backend, so a request for a
+      // horizon other than the snapshot's needs its own fetch in either
+      // direction: narrower is not a client-side slice.
+      if (!passive && (current.schedule === null || fetchedForDays !== days)) fetchOnce(days);
+    }
+    return () => {
+      subscribers.delete(setSnapshot);
+      if (subscribers.size > 0) return;
+      if (timer) { clearInterval(timer); timer = null; }
+      clearRetry();
+      failures = 0;
+    };
+  }, [enabled, days]);
+
+  return { ...snapshot, refresh: () => fetchOnce(days) };
+}

--- a/src/arbitration/arbitrationTiers.test.ts
+++ b/src/arbitration/arbitrationTiers.test.ts
@@ -1,0 +1,25 @@
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { sanitizeTierKeys, tierKey, TIER_KEYS } from "./arbitrationTiers.ts";
+
+test("an unrated node filters as its own key", () => {
+  assert.equal(tierKey(null), "unrated");
+  assert.equal(tierKey("S"), "S");
+});
+
+test("a stored selection keeps only keys this version knows, in display order", () => {
+  assert.deepEqual(sanitizeTierKeys(["unrated", "B", "S", "Z", 7]), [
+    "S",
+    "B",
+    "unrated",
+  ]);
+  assert.deepEqual(sanitizeTierKeys([]), []);
+  assert.deepEqual(sanitizeTierKeys([...TIER_KEYS]), [...TIER_KEYS]);
+});
+
+test("a selection that is not a list at all leaves the default alone", () => {
+  assert.equal(sanitizeTierKeys(undefined), null);
+  assert.equal(sanitizeTierKeys("S"), null);
+  assert.equal(sanitizeTierKeys(null), null);
+});

--- a/src/arbitration/arbitrationTiers.ts
+++ b/src/arbitration/arbitrationTiers.ts
@@ -1,0 +1,38 @@
+// The community's S-to-D rating of how well a node farms Vitus Essence. The
+// table itself lives in the backend, next to the schedule it annotates; this
+// is the vocabulary the browser needs to show and filter by it.
+
+export type Tier = "S" | "A" | "B" | "C" | "D";
+
+/// A node the rating does not cover is Unrated, which is a value the filter
+/// and the alert rule can be set to like any other.
+export type TierKey = Tier | "unrated";
+
+export const TIER_KEYS: readonly TierKey[] = [
+  "S",
+  "A",
+  "B",
+  "C",
+  "D",
+  "unrated",
+];
+
+export const TIER_LABELS: Record<TierKey, string> = {
+  S: "S",
+  A: "A",
+  B: "B",
+  C: "C",
+  D: "D",
+  unrated: "Unrated",
+};
+
+export const tierKey = (tier: Tier | null): TierKey => tier ?? "unrated";
+
+/// Settings are a file the user can edit and an older version can have
+/// written, so a stored selection is filtered down to keys this version
+/// knows rather than trusted. Null for anything that is not a list at all,
+/// which leaves the caller's default in place.
+export function sanitizeTierKeys(value: unknown): TierKey[] | null {
+  if (!Array.isArray(value)) return null;
+  return TIER_KEYS.filter((k) => value.includes(k));
+}

--- a/src/header/CacheStatusChip.tsx
+++ b/src/header/CacheStatusChip.tsx
@@ -21,6 +21,7 @@ function age(ts: number | null): string {
 }
 
 const DISPLAY: Record<string, string> = {
+  "arbitrations-v1.json": "Arbitrations",
   worldstate: "Worldstate",
   "bulk-prices": "Bulk Prices",
   catalogue: "Catalogue",

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -22,13 +22,29 @@ export function ensurePermission(): Promise<boolean> {
   return pending;
 }
 
+// Reports permission without asking for it, for callers that need to know at a
+// moment when raising the dialog would be wrong.
+export async function permissionGranted(): Promise<boolean> {
+  try {
+    return await isPermissionGranted();
+  } catch (e) {
+    console.error("notification permission check failed", e);
+    return false;
+  }
+}
+
 // Never prompts and never throws: a missing notification daemon or a denied
 // permission must not break the caller's poll loop.
-export async function notify(title: string, body: string): Promise<void> {
+//
+// The result says the notification was handed over, not that anyone saw it:
+// sendNotification returns void, so the platform never reports delivery.
+export async function notify(title: string, body: string): Promise<boolean> {
   try {
-    if (!(await isPermissionGranted())) return;
+    if (!(await isPermissionGranted())) return false;
     sendNotification({ title, body });
+    return true;
   } catch (e) {
     console.error("notification failed", e);
+    return false;
   }
 }

--- a/src/lib/useOverlayWindow.ts
+++ b/src/lib/useOverlayWindow.ts
@@ -1,0 +1,66 @@
+import { useCallback, useEffect, useRef } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { getCurrentWindow, primaryMonitor, LogicalPosition, LogicalSize } from "@tauri-apps/api/window";
+import { overlayScale } from "./uiScale";
+
+export type OverlayAnchor = "top-right" | "top-center";
+
+const TOP_MARGIN = 20;
+const RIGHT_MARGIN = 100;
+
+/**
+ * Fits a transparent overlay window to its content and parks it at `anchor`
+ * on the primary monitor. The backend only shows the window; it cannot place
+ * it, because the overlay scale that decides the rendered size is a frontend
+ * setting.
+ *
+ * Returns a callback ref for the overlay's root element. It has to be a
+ * callback ref: the root does not exist until a payload arrives, so a
+ * mount-time effect would have nothing to observe.
+ */
+export function useOverlayWindow(width: number, anchor: OverlayAnchor) {
+  const roRef   = useRef<ResizeObserver | null>(null);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  // contentRect reports the pre-zoom layout size; the drawn size is × scale.
+  const place = useCallback(async (layoutHeight: number) => {
+    if (layoutHeight <= 0) return;
+    const s = overlayScale();
+    let w = width * s;
+    let h = layoutHeight * s;
+    let x = 0;
+    try {
+      const m = await primaryMonitor();
+      if (m) {
+        const f = m.scaleFactor || 1;
+        const monW = m.size.width / f;
+        const monH = m.size.height / f;
+        w = Math.min(w, monW);
+        h = Math.min(h, monH);
+        x = anchor === "top-right" ? monW - w - RIGHT_MARGIN : (monW - w) / 2;
+      }
+      const win = getCurrentWindow();
+      await win.setSize(new LogicalSize(Math.round(w), Math.round(h)));
+      await win.setPosition(new LogicalPosition(Math.round(Math.max(0, x)), TOP_MARGIN));
+    } catch {}
+  }, [width, anchor]);
+
+  const root = useCallback((el: HTMLDivElement | null) => {
+    if (roRef.current) { roRef.current.disconnect(); roRef.current = null; }
+    rootRef.current = el;
+    if (!el) return;
+    const ro = new ResizeObserver(entries => place(Math.ceil(entries[0].contentRect.height)));
+    ro.observe(el);
+    roRef.current = ro;
+  }, [place]);
+
+  useEffect(() => {
+    const un = listen("settings-updated", () => {
+      const el = rootRef.current;
+      if (el) place(Math.ceil(el.getBoundingClientRect().height / overlayScale()));
+    });
+    return () => { un.then(f => f()); };
+  }, [place]);
+
+  return root;
+}

--- a/src/shared/Report.css
+++ b/src/shared/Report.css
@@ -1,0 +1,182 @@
+/* Pieces the report-style views share: the stat card and its tiles, the
+   small filter button group, the inline delete confirmation, the sparkline
+   box, the empty-state explainer and the sub-tab strip. */
+
+/* ── Sub-tabs ── */
+
+.arb .sub-tabs {
+  display: flex;
+  gap: 2px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.arb .sub-tabs button {
+  background: none;
+  border: 1px solid rgba(48,54,61,.6);
+  color: var(--muted);
+  font-size: 12px;
+  padding: 3px 14px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background .1s, color .1s, border-color .1s;
+}
+.arb .sub-tabs button:hover { background: rgba(255,255,255,.06); color: var(--text); }
+.arb .sub-tabs button.active { background: rgba(56,139,253,.15); border-color: var(--accent); color: var(--accent); }
+
+/* ── Card ── */
+
+.arb .report-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  cursor: default;
+  transition: border-color 0.1s, opacity 0.1s;
+}
+
+.arb .report-tf-btns {
+  display: flex;
+}
+.arb .report-tf-btn {
+  background: none;
+  border: 1px solid rgba(48,54,61,.5);
+  border-right-width: 0;
+  color: var(--muted);
+  font-size: 10px;
+  padding: 2px 6px;
+  cursor: pointer;
+  transition: background .1s, color .1s, border-color .1s;
+  line-height: 1.4;
+}
+
+.arb .report-tf-btn:first-child { border-radius: 3px 0 0 3px; }
+.arb .report-tf-btn:last-child { border-right-width: 1px; border-radius: 0 3px 3px 0; margin-right: 4px; }
+
+.arb .report-tf-btn:hover { background: rgba(255,255,255,.06); color: var(--text); }
+.arb .report-tf-btn.active {
+  background: rgba(56,139,253,.15);
+  border-color: var(--accent);
+  border-right-width: 1px;
+  color: var(--accent);
+}
+
+.arb .report-tf-btn.active + .report-tf-btn { border-left-color: rgba(48,54,61,.5); }
+.arb .report-remove-btn {
+  background: none;
+  border: none;
+  color: var(--muted);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 2px;
+  transition: color .1s;
+}
+
+.arb .report-remove-btn:hover { color: var(--red); }
+.arb .report-confirm-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.arb .report-confirm-msg {
+  font-size: 11px;
+  color: var(--red);
+  white-space: nowrap;
+}
+
+.arb .report-confirm-yes {
+  background: rgba(248,81,73,.2);
+  border: 1px solid var(--red);
+  border-radius: 3px;
+  color: var(--red);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  cursor: pointer;
+  transition: background .1s;
+}
+
+.arb .report-confirm-yes:hover { background: rgba(248,81,73,.35); }
+.arb .report-confirm-no {
+  background: rgba(255,255,255,.06);
+  border: 1px solid rgba(48,54,61,.6);
+  border-radius: 3px;
+  color: var(--muted);
+  font-size: 11px;
+  padding: 2px 8px;
+  cursor: pointer;
+  transition: background .1s;
+}
+
+.arb .report-confirm-no:hover { background: rgba(255,255,255,.12); color: var(--text); }
+/* ── Chart ── */
+
+.arb .report-chart-svg {
+  width: 100%;
+  height: 60px;
+  display: block;
+  border-radius: 4px;
+  background: rgba(0,0,0,.15);
+}
+
+.arb .report-chart-empty {
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  color: var(--muted);
+  font-style: italic;
+  background: rgba(0,0,0,.1);
+  border-radius: 4px;
+}
+
+/* ── Stats row ── */
+
+.arb .report-card-stats {
+  display: flex;
+  gap: 16px;
+}
+
+.arb .report-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.arb .report-stat-label {
+  font-size: 10px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: .04em;
+}
+
+.arb .report-stat-value {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+.arb .report-pos { color: var(--green); }
+.arb .report-neg { color: var(--red); }
+.arb .report-empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 40px;
+  text-align: center;
+}
+
+.arb .report-empty-icon { font-size: 48px; }
+.arb .report-empty-title { font-size: 16px; font-weight: 600; color: var(--text); }
+.arb .report-empty-desc { font-size: 13px; color: var(--muted); line-height: 1.6; }

--- a/src/shared/Sparkline.tsx
+++ b/src/shared/Sparkline.tsx
@@ -1,0 +1,49 @@
+import "./Report.css";
+
+export default function Sparkline({ values, empty }: { values: number[]; empty: string }) {
+  const W = 300, H = 60;
+  const pt = 6, pb = 6, pl = 2, pr = 2;
+  const cW = W - pl - pr;
+  const cH = H - pt - pb;
+
+  if (values.length === 0) {
+    return <div className="report-chart-empty">{empty}</div>;
+  }
+
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+
+  const xi = (i: number) =>
+    pl + (values.length === 1 ? cW / 2 : (i / (values.length - 1)) * cW);
+  const yi = (v: number) => pt + (1 - (v - min) / range) * cH;
+
+  if (values.length === 1) {
+    return (
+      <svg viewBox={`0 0 ${W} ${H}`} className="report-chart-svg" preserveAspectRatio="none">
+        <line
+          x1={pl} y1={H / 2} x2={pl + cW} y2={H / 2}
+          stroke="var(--accent)" strokeWidth="1" strokeOpacity="0.4" strokeDasharray="4 3"
+        />
+        <circle cx={xi(0)} cy={H / 2} r="3" fill="var(--accent)" />
+      </svg>
+    );
+  }
+
+  const linePts = values.map((v, i) => `${xi(i).toFixed(1)},${yi(v).toFixed(1)}`).join(" ");
+  const fillPts = `${pl},${pt + cH} ${linePts} ${pl + cW},${pt + cH}`;
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} className="report-chart-svg" preserveAspectRatio="none">
+      <polygon points={fillPts} fill="var(--accent)" fillOpacity="0.12" />
+      <polyline
+        points={linePts}
+        fill="none"
+        stroke="var(--accent)"
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/src/shared/useClickOutside.ts
+++ b/src/shared/useClickOutside.ts
@@ -1,0 +1,17 @@
+import { useEffect, useRef, type RefObject } from "react";
+
+export function useClickOutside(ref: RefObject<HTMLElement | null>, onClose: () => void, active = true) {
+  const close = useRef(onClose);
+  close.current = onClose;
+  useEffect(() => {
+    if (!active) return;
+    const onDown = (e: MouseEvent) => { if (!ref.current?.contains(e.target as Node)) close.current(); };
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") close.current(); };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [ref, active]);
+}

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,3 +1,4 @@
+import type { TierKey } from "../arbitration/arbitrationTiers";
 export type ClockFormat = "auto" | "12h" | "24h";
 export type RelicOverlayPriority = "completion" | "plat" | "ducat" | "setPlat";
 export type RelicPickPriority = "unowned" | "ducat" | "platinum";
@@ -15,6 +16,8 @@ export interface FissureWatch {
 }
 
 export interface SettingsSnapshot {
+  arbitrationFavorites: string[]; arbitrationLeadMins: number; arbitrationOverlayEnabled: boolean;
+  arbitrationTierFilter: TierKey[]; arbitrationAlertTiers: TierKey[]; arbitrationScheduleDays: number;
   overlayEnabled: boolean; overlayPriority: RelicOverlayPriority; textScale: number; colorblindMode: boolean;
   clockFormat: ClockFormat; companionApiEnabled: boolean; memoryScannerEnabled: boolean;
   blobLogEnabled: boolean; apiLogEnabled: boolean; autoDiagEnabled: boolean; tracked: string[];


### PR DESCRIPTION
Adds arbitration schedules with node favorites, tier filters, and optional
notifications. Alerts run while other modules are open, catch up after sleep,
and persist successful handoffs to avoid repeating an occurrence after restart.
The schedule uses the existing cache and refresh loop, including stale fallback,
with a seven-day default and a 1–60-day horizon.

Records arbitration runs from EE.log, backfills history without replaying old
trade prompts or overlays, and adds history deletion and analytics. A
transactional schema v5 migration preserves existing v4 records. Deleted runs
stay deleted after replay, and failed writes remain queued across log replacement.
An optional post-run summary closes after 12 seconds and defaults to off.

The port preserves the existing Windows backend layout, filesystem notifications,
dependencies, release configuration, and other overlays. Vitus values retain the
existing estimates and parser limits. Stats export/import is deferred.
Original parser/model attribution is included in THIRD_PARTY_NOTICES.md.